### PR TITLE
debug on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env docker build --build-arg VERSION=5.6 -t omnetpp/omnetpp-gui:u18.04-5.6 .
 FROM omnetpp/omnetpp-base:u18.04 as base
 RUN apt-get update -y && apt install -y --no-install-recommends qt5-default libqt5opengl5-dev \
-            libgtk-3-0 libwebkitgtk-3.0-0 default-jre osgearth libeigen3-dev cmake g++
+    libgtk-3-0 libwebkitgtk-3.0-0 default-jre osgearth libeigen3-dev cmake g++ gdb
 
 # first stage - build OMNeT++ with GUI
 FROM base as builder
@@ -15,9 +15,10 @@ RUN mv omnetpp-$VERSION omnetpp
 WORKDIR /root/omnetpp
 ENV PATH /root/omnetpp/bin:$PATH
 # remove unused files and build
-RUN ./configure WITH_OSG=no　&& \
+RUN ./configure WITH_OSG=no && \
+    make -j $(nproc) MODE=debug base && \
     make -j $(nproc) MODE=release base && \
-    rm -r doc out test samples misc config.log config.status
+    rm -r doc out test samples config.log config.status
 
 # second stage - copy only the final binaries (to get rid of the 'out' folder and reduce the image size)
 FROM base


### PR DESCRIPTION
# summary
This PR allows us to debug with OMNET++ IDE on docker as the following screenshot.
<img width="1620" alt="Screen Shot 2020-08-26 at 2 11 35" src="https://user-images.githubusercontent.com/3610296/91248355-6b9cd000-e78f-11ea-92a1-d68c00130c3b.png">

# motivation
I'm running quisp on macOS Catalina, and I couldn't debug with OMNET++ IDE (I signed gdb executable, but it doesn't work).
So when I want to check the actual value of variables, I used `EV` and [`WATCH` macro](https://doc.omnetpp.org/omnetpp/manual/#sec:sim-lib:watches-and-snapshots). 
But `EV` makes log output messy, so I desire to debug with OMNET++ IDE on docker.
