### PR TITLE
Clean up class names

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,65 @@
+---
+Checks:          '-*,readability-identifier-naming'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file 
+User:            zigen
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             readability-identifier-naming.AbstractClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.StructCase
+#    value:           CamelCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.TypeAliasCase
+    value:           CamelCase
+#  - key:             readability-identifier-naming.ConstantCase
+#    value:           CamelCase
+#  - key:             readability-identifier-naming.ConstantPrefix
+#    value:           'k'
+#  - key:             readability-identifier-naming.ConstantParameterCase
+#    value:           lower_case
+#  - key:             readability-identifier-naming.ConstantParameterPrefix
+#    value:           ''
+#  - key:             readability-identifier-naming.TypedefCase
+#    value:           CamelCase
+#  - key:             readability-identifier-naming.VariableCase
+#    value:           lower_case
+#  - key:             readability-identifier-naming.ParameterCase
+#    value:           lower_case
+#  - key:             readability-identifier-naming.FunctionCase
+#    value:           camelBack
+...
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env docker build --build-arg VERSION=5.6 -t omnetpp/omnetpp-gui:u18.04-5.6 .
 FROM omnetpp/omnetpp-base:u18.04 as base
 RUN apt-get update -y && apt install -y --no-install-recommends qt5-default libqt5opengl5-dev \
-    libgtk-3-0 libwebkitgtk-3.0-0 default-jre osgearth libeigen3-dev cmake g++ gdb clang-format
+    libgtk-3-0 libwebkitgtk-3.0-0 default-jre osgearth libeigen3-dev cmake g++ gdb clang-format clang-tidy
 
 # first stage - build OMNeT++ with GUI
 FROM base as builder

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ format:
 
 ci:
 	@clang-format $(SRCS) $(HEADERS) -output-replacements-xml | grep -c "<replacement " -q ; if [ $$? -ne 1 ]; then echo "error: run make format and then push it again"; exit 1; fi
-	#@clang-tidy -warnings-as-errors="*" -header-filter="./quisp/(rules|modules)/.*.h" $(SRCS) -- $(COPTS:-I.=-I./quisp)
+	@clang-tidy -warnings-as-errors="*" -header-filter="./quisp/(rules|modules)/.*.h" $(SRCS) -- $(COPTS:-I.=-I./quisp)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-SRCS=./quisp/modules/*.cc ./quisp/modules/*.h ./quisp/rules/*.cc ./quisp/rules/*.h
+include ./quisp/Makefile
+
+SRCS=./quisp/modules/*.cc ./quisp/rules/*.cc 
+HEADERS=./quisp/modules/*.h ./quisp/rules/*.h
+
+tidy:
+	clang-tidy -header-filter="./quisp/(rules|modules)/.*.h" $(SRCS) -- $(COPTS:-I.=-I./quisp)
 
 format:
-	clang-format -i $(SRCS)
+	clang-format -i $(SRCS) $(HEADERS)
 
 ci:
-	@clang-format $(SRCS) -output-replacements-xml | grep -c "<replacement " -q ; if [ $$? -ne 1 ]; then echo "error: run make format and then push it again"; exit 1; fi
+	@clang-format $(SRCS) $(HEADERS) -output-replacements-xml | grep -c "<replacement " -q ; if [ $$? -ne 1 ]; then echo "error: run make format and then push it again"; exit 1; fi
+	#@clang-tidy -warnings-as-errors="*" -header-filter="./quisp/(rules|modules)/.*.h" $(SRCS) -- $(COPTS:-I.=-I./quisp)

--- a/quisp/modules/BellStateAnalyzer.cc
+++ b/quisp/modules/BellStateAnalyzer.cc
@@ -48,7 +48,7 @@ class BellStateAnalyzer : public cSimpleModule {
   int left_photon_origin_qubit_address;
   bool left_photon_Xerr;
   bool left_photon_Zerr;
-  stationaryQubit *left_statQubit_ptr;
+  StationaryQubit *left_statQubit_ptr;
   simtime_t right_arrived_at;
   int right_photon_origin_node_address;
   int right_photon_origin_qnic_address;
@@ -58,7 +58,7 @@ class BellStateAnalyzer : public cSimpleModule {
   bool right_photon_Zerr;
   bool right_photon_lost;
   bool left_photon_lost;
-  stationaryQubit *right_statQubit_ptr;
+  StationaryQubit *right_statQubit_ptr;
   int count_X = 0, count_Y = 0, count_Z = 0, count_I = 0, count_L = 0, count_total = 0;  // for debug
   // bool handshake = false;
   bool this_trial_done = false;
@@ -152,7 +152,7 @@ void BellStateAnalyzer::handleMessage(cMessage *msg) {
     left_photon_origin_qnic_address = photon->getQNICEntangledWith();
     left_photon_origin_qubit_address = photon->getStationaryQubitEntangledWith();
     left_photon_origin_qnic_type = photon->getQNICtypeEntangledWith();
-    left_statQubit_ptr = check_and_cast<stationaryQubit *>(photon->getEntangled_with());
+    left_statQubit_ptr = check_and_cast<StationaryQubit *>(photon->getEntangled_with());
     left_photon_Xerr = photon->getPauliXerr();
     left_photon_Zerr = photon->getPauliZerr();
     left_photon_lost = photon->getPhotonLost();
@@ -174,7 +174,7 @@ void BellStateAnalyzer::handleMessage(cMessage *msg) {
     right_photon_origin_qubit_address = photon->getStationaryQubitEntangledWith();
     right_photon_origin_qnic_type = photon->getQNICtypeEntangledWith();
     // right_statQubit_ptr = photon->getEntangled_with();
-    right_statQubit_ptr = check_and_cast<stationaryQubit *>(photon->getEntangled_with());
+    right_statQubit_ptr = check_and_cast<StationaryQubit *>(photon->getEntangled_with());
     right_photon_Xerr = photon->getPauliXerr();
     right_photon_Zerr = photon->getPauliZerr();
     right_photon_lost = photon->getPhotonLost();

--- a/quisp/modules/EntangledPhotonPairSource.h
+++ b/quisp/modules/EntangledPhotonPairSource.h
@@ -18,7 +18,7 @@ using namespace quisp::messages;
 namespace quisp {
 namespace modules {
 
-typedef struct _entangledPhotons {
+typedef struct {
   PhotonicQubit* qubitOne;
   PhotonicQubit* qubitTwo;
 } entangledPhotons;

--- a/quisp/modules/HardwareMonitor.cc
+++ b/quisp/modules/HardwareMonitor.cc
@@ -724,7 +724,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Clause* resource_clause = new EnoughResourceClause(partner_address, 3);
           Purification_condition->addClause(resource_clause);
           Purification->setCondition(Purification_condition);
-          Action* purify_action = new DoublePurifyAction_inv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
+          Action* purify_action = new DoublePurifyActionInv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
           Purification->setAction(purify_action);
           rule_index++;
           tomography_RuleSet->addRule(Purification);
@@ -777,7 +777,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Action* purify_action = new DoubleSelectionAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
           Purification->setAction(purify_action);
         } else {
-          Action* purify_action = new DoubleSelectionAction_inv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
+          Action* purify_action = new DoubleSelectionActionInv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
           Purification->setAction(purify_action);
         }
         rule_index++;
@@ -806,7 +806,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Action* purify_action = new DoubleSelectionDualAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2, 3, 4);
           Purification->setAction(purify_action);
         } else {
-          Action* purify_action = new DoubleSelectionDualAction_inv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2, 3, 4);
+          Action* purify_action = new DoubleSelectionDualActionInv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2, 3, 4);
           Purification->setAction(purify_action);
         }
         rule_index++;
@@ -835,7 +835,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Action* purify_action = new DoubleSelectionDualActionSecond(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2, 3);
           Purification->setAction(purify_action);
         } else {
-          Action* purify_action = new DoubleSelectionDualActionSecond_inv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2, 3);
+          Action* purify_action = new DoubleSelectionDualActionSecondInv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2, 3);
           Purification->setAction(purify_action);
         }
         rule_index++;
@@ -863,7 +863,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Action* purify_action = new DoubleSelectionAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
           Purification->setAction(purify_action);
         } else {
-          Action* purify_action = new DoubleSelectionAction_inv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
+          Action* purify_action = new DoubleSelectionActionInv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
           Purification->setAction(purify_action);
         }
         rule_index++;

--- a/quisp/modules/HardwareMonitor.h
+++ b/quisp/modules/HardwareMonitor.h
@@ -20,7 +20,7 @@ using namespace omnetpp;
 namespace quisp {
 namespace modules {
 
-typedef struct _neighborInfo {
+typedef struct {
   bool isQNode;
   cModuleType *type;
   int address;  // May be QNode, SPDC, HOM
@@ -30,7 +30,7 @@ typedef struct _neighborInfo {
 
 typedef QNIC_id entangledWith;
 
-typedef struct _stationaryQubitInfo {
+typedef struct {
   int qnic_index;
   int qubit_index;
   bool isBusy;  // Reserved or free to use
@@ -38,7 +38,7 @@ typedef struct _stationaryQubitInfo {
   entangledWith entangled_inf;
 } stationaryQubitInfo;
 
-typedef struct _Interface_inf {
+typedef struct {
   // QubitAddr(int node_addr, int qnic_index, int qubit_index):node_address(node_addr),qnic_index(qnic_index),qubit_index(qubit_index){}
   QNIC qnic;
   double initial_fidelity = -1; /*Oka's protocol?*/
@@ -49,13 +49,13 @@ typedef struct _Interface_inf {
   QNIC neighbor_qnic;
 } Interface_inf;
 
-typedef struct _For_connection_setup {
+typedef struct {
   QNIC_id qnic;
   int neighbor_address;
   int quantum_link_cost;
 } connection_setup_inf;
 
-typedef struct _tomogrphy_outcome {
+typedef struct {
   char my_basis;
   bool my_output_is_plus;
   char my_GOD_clean;
@@ -64,7 +64,7 @@ typedef struct _tomogrphy_outcome {
   char partner_GOD_clean;
 } tomography_outcome;
 
-typedef struct _output_count {
+typedef struct {
   int total_count;
   int plus_plus;
   int plus_minus;
@@ -72,7 +72,7 @@ typedef struct _output_count {
   int minus_minus;
 } output_count;
 
-typedef struct _link_cost {
+typedef struct {
   simtime_t tomography_time;
   int tomography_measurements;
   double Bellpair_per_sec;

--- a/quisp/modules/HoM_Controller.h
+++ b/quisp/modules/HoM_Controller.h
@@ -4,7 +4,7 @@
  *  \authors cldurand,takaakimatsuo
  *  \date 2018/04/01
  *
- *  \brief HoM_Controller
+ *  \brief HoMController
  */
 #ifndef QUISP_MODULES_HOM_CONTROLLER_H_
 #define QUISP_MODULES_HOM_CONTROLLER_H_
@@ -20,14 +20,14 @@ using namespace quisp::messages;
 namespace quisp {
 namespace modules {
 
-/** \class HoM_Controller HoM_Controller.h
+/** \class HoMController HoM_Controller.h
  *  \todo Documentation of the class header.
  *  \note How about if two nodes have imbalanced buffers?
  *        Maybe use unused qnic (which is ought to be used for another path)?
  *
- *  \brief HoM_Controller
+ *  \brief HoMController
  */
-class HoM_Controller : public cSimpleModule {
+class HoMController : public cSimpleModule {
  private:
   int address;
   int photon_detection_per_sec;
@@ -91,7 +91,7 @@ class HoM_Controller : public cSimpleModule {
   // virtual void  finish();
  public:
   virtual void setMax_buffer(int buffer);
-  HoM_Controller();
+  HoMController();
 };
 
 }  // namespace modules

--- a/quisp/modules/QNIC.h
+++ b/quisp/modules/QNIC.h
@@ -13,7 +13,7 @@ using namespace omnetpp;
 namespace quisp {
 namespace modules {
 
-typedef enum _QNIC_type : int {
+typedef enum : int {
   QNIC_E, /**< Emitter QNIC          */
   QNIC_R, /**< Receiver QNIC         */
   QNIC_RP, /**< Passive Receiver QNIC */
@@ -26,25 +26,26 @@ static const char* QNIC_names[QNIC_N] = {
     [QNIC_RP] = "qnic_rp",
 };
 
-typedef struct _QNIC_id {
+typedef struct {
   QNIC_type type;
   int index;
   int address;
   bool isReserved;
 } QNIC_id;
 
-typedef struct _QNIC_id_pair {
+typedef struct {
   QNIC_id fst;
   QNIC_id snd;
 } QNIC_id_pair;
 
-typedef struct _QNIC : _QNIC_id {
+typedef struct : QNIC_id {
   cModule* pointer;  // Pointer to that particular QNIC.
   int address;
 } QNIC;
 
 // Table to check the qnic is reserved or not.
 typedef std::map<int, std::map<int, bool>> QNIC_reservation_table;
+
 }  // namespace modules
 }  // namespace quisp
 

--- a/quisp/modules/QUBIT.h
+++ b/quisp/modules/QUBIT.h
@@ -43,7 +43,7 @@ struct QubitState {
 
 /*For resource management*/
 // typedef std::multimap<int, QubitAddr> EntangledPairs;//entangled Node address -> list of qubits from new to old
-typedef std::multimap<int, stationaryQubit*> EntangledPairs;  // entangled Node address -> pointer to that local qubit
+typedef std::multimap<int, StationaryQubit*> EntangledPairs;  // entangled Node address -> pointer to that local qubit
 typedef EntangledPairs* qnicResources;  // For each qnic. If the number of "qnic" is 3, then the size is 3.
 /*For resource management over.*/
 

--- a/quisp/modules/RealTimeController.cc
+++ b/quisp/modules/RealTimeController.cc
@@ -30,7 +30,7 @@ void RealTimeController::EmitPhoton(int qnic_index, int qubit_index, QNIC_type q
     cModule *qubit = nullptr;
     if (qnic_type >= QNIC_N) error("Only 3 qnic types are currently recognized....");  // avoid segfaults <3
     qubit = qnode->getSubmodule(QNIC_names[qnic_type], qnic_index)->getSubmodule("statQubit", qubit_index);
-    stationaryQubit *q = check_and_cast<stationaryQubit *>(qubit);
+    StationaryQubit *q = check_and_cast<StationaryQubit *>(qubit);
     q->emitPhoton(pulse);
   } catch (std::exception &e) {
     error("Some error occurred in RealTimeController. Here!. Maybe the qnic/statQubit couldnt be found. Have you changed the namings?");
@@ -61,7 +61,7 @@ void RealTimeController::ReInitialize_StationaryQubit(int qnic_index, int qubit_
     cModule *qubit = nullptr;
     if (qnic_type >= QNIC_N) error("Only 3 qnic types are currently recognized....");  // avoid segfaults <3
     qubit = qnode->getSubmodule(QNIC_names[qnic_type], qnic_index)->getSubmodule("statQubit", qubit_index);
-    stationaryQubit *q = check_and_cast<stationaryQubit *>(qubit);
+    StationaryQubit *q = check_and_cast<StationaryQubit *>(qubit);
     q->setFree(consumed);
   } catch (std::exception &e) {
     error("Some error occured in RealTimeController. Maybe the qnic/statQubit couldnt be found. Have you changed the namings?");

--- a/quisp/modules/RuleEngine.cc
+++ b/quisp/modules/RuleEngine.cc
@@ -212,7 +212,7 @@ void RuleEngine::handleMessage(cMessage *msg) {
     purification_id.index = pkt->getAction_index();
     pr.id = purification_id;
     pr.outcome = pkt->getOutput_is_plus();
-    // stationaryQubit *q = check_and_cast<stationaryQubit *>(pkt->getEntangled_with());
+    // StationaryQubit *q = check_and_cast<StationaryQubit *>(pkt->getEntangled_with());
     // std::cout<<"Purification result is from node["<<pkt->getSrcAddr()<<"] rid="<< pkt->getRuleset_id()<<"Must be qnic["<<my_qnic_index<<" type="<<my_qnic_type<<"\n";
     // std::cout<<"Locked one is "<<pkt->getEntangled_with()<<"in node["<<q->node_address<<"] \n";
     storeCheck_Purification_Agreement(pr);
@@ -228,7 +228,7 @@ void RuleEngine::handleMessage(cMessage *msg) {
     pr.id = purification_id;
     pr.Xpurification_outcome = pkt->getXOutput_is_plus();
     pr.Zpurification_outcome = pkt->getZOutput_is_plus();
-    // stationaryQubit *q = check_and_cast<stationaryQubit *>(pkt->getEntangled_with());
+    // StationaryQubit *q = check_and_cast<StationaryQubit *>(pkt->getEntangled_with());
     // std::cout<<"Purification result is from node["<<pkt->getSrcAddr()<<"] rid="<< pkt->getRuleset_id()<<"Must be qnic["<<my_qnic_index<<" type="<<my_qnic_type<<"\n";
     // std::cout<<"Locked one is "<<pkt->getEntangled_with()<<"in node["<<q->node_address<<"] \n";
     storeCheck_DoublePurification_Agreement(pr);
@@ -246,7 +246,7 @@ void RuleEngine::handleMessage(cMessage *msg) {
     pr.Zpurification_outcome = pkt->getZOutput_is_plus();
     pr.DS_Xpurification_outcome = pkt->getDS_XOutput_is_plus();
     pr.DS_Zpurification_outcome = pkt->getDS_ZOutput_is_plus();
-    // stationaryQubit *q = check_and_cast<stationaryQubit *>(pkt->getEntangled_with());
+    // StationaryQubit *q = check_and_cast<StationaryQubit *>(pkt->getEntangled_with());
     // std::cout<<"Purification result is from node["<<pkt->getSrcAddr()<<"] rid="<< pkt->getRuleset_id()<<"Must be qnic["<<my_qnic_index<<" type="<<my_qnic_type<<"\n";
     // std::cout<<"Locked one is "<<pkt->getEntangled_with()<<"in node["<<q->node_address<<"] \n";
     storeCheck_QuatroPurification_Agreement(pr);
@@ -581,7 +581,7 @@ void RuleEngine::Unlock_resource_and_upgrade_stage(unsigned long ruleset_id, int
                 // Correct resource found! Need to unlock and stage up the resource to the next rule.
                 qubit->second->Unlock();
                 // std::cout<<"[Upgrade Unlock] "<<qubit->second<<" in node["<<qubit->second->node_address<<"]\n";
-                stationaryQubit *q = qubit->second;
+                StationaryQubit *q = qubit->second;
                 (*rule)->resources.erase(qubit);  // Erase this from resource list
                 rule++;
                 if (rule == end) {
@@ -941,7 +941,7 @@ void RuleEngine::updateResources_EntanglementSwapping(swapping_result swapr) {
   // we need to free swapper resources consumed for entanglement swapping.
 
   // qubit with address Addr was shot in nth time. This list is ordered from old to new.
-  stationaryQubit *qubit = check_and_cast<stationaryQubit *>(getQNode()->getSubmodule(QNIC_names[qnic_type], qnic_index)->getSubmodule("statQubit", qubit_index));
+  StationaryQubit *qubit = check_and_cast<StationaryQubit *>(getQNode()->getSubmodule(QNIC_names[qnic_type], qnic_index)->getSubmodule("statQubit", qubit_index));
   // if(parentAddress == 27 && qubit->entangled_partner->node_address == 15){
   //     EV<<parentAddress<<" is entangled with "<<qubit->entangled_partner->node_address<<" !!\n";
   //     error("Did it! Currently, no application implemeted. So, after resource consumed, simulation will end.");
@@ -1027,7 +1027,7 @@ void RuleEngine::freeFailedQubits_and_AddAsResource(int destAddr, int internal_q
       // Keep the entangled qubits
       // std::cout<<i<<"th shot has succeeded.....that was qubit["<<it->second.qubit_index<<"] in qnic["<<it->second.qnic_index<<"] node addr["<<it->first<<"] \n";
       // Add this as an available resource
-      stationaryQubit *qubit = check_and_cast<stationaryQubit *>(getQNode()->getSubmodule(QNIC_names[qnic_type], qnic_index)->getSubmodule("statQubit", it->second.qubit_index));
+      StationaryQubit *qubit = check_and_cast<StationaryQubit *>(getQNode()->getSubmodule(QNIC_names[qnic_type], qnic_index)->getSubmodule("statQubit", it->second.qubit_index));
       if (qubit->entangled_partner != nullptr) {
         if (qubit->entangled_partner->entangled_partner == nullptr) {
           // std::cout<<qubit<<" in node["<<qubit->node_address<<"] <-> "<<qubit->entangled_partner<<" in node["<<qubit->entangled_partner->node_address<<"]\n";
@@ -1342,7 +1342,7 @@ void RuleEngine::traverseThroughAllProcesses2() {
   }  // For loop
 }
 
-void RuleEngine::freeConsumedResource(int qnic_index /*Not the address!!!*/, stationaryQubit *qubit, QNIC_type qnic_type) {
+void RuleEngine::freeConsumedResource(int qnic_index /*Not the address!!!*/, StationaryQubit *qubit, QNIC_type qnic_type) {
   realtime_controller->ReInitialize_StationaryQubit(qnic_index, qubit->par("stationaryQubit_address"), qnic_type, true);
   Busy_OR_Free_QubitState_table[qnic_type] = setQubitFree_inQnic(Busy_OR_Free_QubitState_table[qnic_type], qnic_index, qubit->par("stationaryQubit_address"));
 

--- a/quisp/modules/RuleEngine.h
+++ b/quisp/modules/RuleEngine.h
@@ -36,7 +36,7 @@ using namespace rules;
  *  \brief RuleEngine
  */
 
-typedef struct _process_identifier {
+typedef struct {
   unsigned long ruleset_id;
   int rule_id;
   int index;
@@ -79,7 +79,7 @@ struct swapping_result {
 };
 
 // Process = RuleSet
-typedef struct _process {
+typedef struct {
   int ownner_addr;
   // int process_ID;
   RuleSet* Rs;
@@ -121,7 +121,7 @@ class RuleEngine : public cSimpleModule {
   qnicResources* allResources;  // Size will be defined in initialization. If 3 qnic types, then size is 3. Type defined in QUBIT.h
   /*
    * DEFINED in QNIC.h
-   * typedef std::multimap<int, stationaryQubit*> EntangledPairs;//entangled Node address -> pointer to that local qubit
+   * typedef std::multimap<int, StationaryQubit*> EntangledPairs;//entangled Node address -> pointer to that local qubit
    * typedef EntangledPairs* qnicResources;//For each qnic. If the number of "qnic" is 3, then the size is 3.
    * For resource management over.
    * */
@@ -133,7 +133,7 @@ class RuleEngine : public cSimpleModule {
   // int assigned = 0;
   // typedef std::map<std::string, quisp::rules::RuleSet> processes;//process_id -> Rule set
   virtual void freeResource(int qnic_index, int qubit_index, QNIC_type qnic_type);
-  virtual void freeConsumedResource(int qnic_index, stationaryQubit* qubit, QNIC_type qnic_type);
+  virtual void freeConsumedResource(int qnic_index, StationaryQubit* qubit, QNIC_type qnic_type);
   virtual void dynamic_ResourceAllocation(int qnic_type, int qnic_index);
   virtual void ResourceAllocation(int qnic_type, int qnic_index);
   virtual void JustATest() {

--- a/quisp/modules/stationaryQubit.cc
+++ b/quisp/modules/stationaryQubit.cc
@@ -1,8 +1,8 @@
-/** \file stationaryQubit.cc
+/** \file StationaryQubit.cc
  *  \authors cldurand,takaakimatsuo
  *  \date 2018/03/14
  *
- *  \brief stationaryQubit
+ *  \brief StationaryQubit
  */
 #include "stationaryQubit.h"
 #include <PhotonicQubit_m.h>
@@ -16,15 +16,15 @@
 namespace quisp {
 namespace modules {
 
-Define_Module(stationaryQubit);
+Define_Module(StationaryQubit);
 
 /**
- * \brief Initialize stationaryQubit
+ * \brief Initialize StationaryQubit
  *
  * Omnet called method to initialize objects.
  *
  */
-void stationaryQubit::initialize() {
+void StationaryQubit::initialize() {
   double rand = dblrand();
 
   /*Photon emission time error rates*/
@@ -155,7 +155,7 @@ memory_err.completely_mixed_rate = memory_err.error_rate * (memory_completely_mi
   /* e^(t/T1) energy relaxation, e^(t/T2) phase relaxation. Want to use only 1/10 of T1 and T2 in general.*/
 }
 
-void stationaryQubit::finish() {
+void StationaryQubit::finish() {
   // std::cout<<"emitted "<<numemitted<<"¥n";
 }
 
@@ -164,7 +164,7 @@ void stationaryQubit::finish() {
  *
  * \param msg is the message
  */
-void stationaryQubit::handleMessage(cMessage *msg) {
+void StationaryQubit::handleMessage(cMessage *msg) {
   bubble("Got a photon!!");
   setBusy();
   // numemitted++;
@@ -179,7 +179,7 @@ void stationaryQubit::handleMessage(cMessage *msg) {
   }
 }
 
-gate_error_model stationaryQubit::SetSingleQubitGateErrorCeilings(std::string gate_name) {
+gate_error_model StationaryQubit::SetSingleQubitGateErrorCeilings(std::string gate_name) {
   gate_error_model gate;
   std::string error_rate_par_name = std::string(gate_name) + std::string("_error_rate");
   std::string Xerror_ratio_par_name = std::string(gate_name) + std::string("_X_error_ratio");
@@ -205,7 +205,7 @@ gate_error_model stationaryQubit::SetSingleQubitGateErrorCeilings(std::string ga
   return gate;
 }
 
-two_qubit_gate_error_model stationaryQubit::SetTwoQubitGateErrorCeilings(std::string gate_name) {
+two_qubit_gate_error_model StationaryQubit::SetTwoQubitGateErrorCeilings(std::string gate_name) {
   two_qubit_gate_error_model gate;
   std::string error_rate_par_name = std::string(gate_name) + std::string("_error_rate");
 
@@ -280,7 +280,7 @@ two_qubit_gate_error_model stationaryQubit::SetTwoQubitGateErrorCeilings(std::st
 }
 
 /*
-void stationaryQubit::setEmissionPauliError(){
+void StationaryQubit::setEmissionPauliError(){
     if(par("GOD_Xerror") || par("GOD_Zerror")){
         //std::cout<<"node["<<node_address<<"] qnic["<<qnic_address<<"] Emitting from "<<this<<"X="<<par("GOD_Xerror").str()<<"Z="<<par("GOD_Zerror").str()<<"\n";
         error("There shouldn't be an error existing before photon emission. This error may have not been reinitialized since last use. Better check!");
@@ -313,7 +313,7 @@ void stationaryQubit::setEmissionPauliError(){
 }
 */
 
-bool stationaryQubit::measure_X() {
+bool StationaryQubit::measure_X() {
   // Need to add noise here later
   apply_single_qubit_gate_error(Measurement_error, this);
   return !par("GOD_Zerror");
@@ -322,7 +322,7 @@ bool stationaryQubit::measure_X() {
 /**
  *  Returns true if the measurement outcome was correct
  */
-bool stationaryQubit::measure_Y() {
+bool StationaryQubit::measure_Y() {
   // Need to add noise here later
   apply_single_qubit_gate_error(Measurement_error, this);
   bool error = true;
@@ -336,14 +336,14 @@ bool stationaryQubit::measure_Y() {
   // return !(par("GOD_Zerror") || par("GOD_Xerror"));
 }
 
-bool stationaryQubit::measure_Z() {
+bool StationaryQubit::measure_Z() {
   // Need to add noise here later
   apply_single_qubit_gate_error(Measurement_error, this);
   return !par("GOD_Xerror");
 }
 
 // Convert X to Z, and Z to X error. Therefore, Y error stays as Y.
-void stationaryQubit::Hadamard_gate() {
+void StationaryQubit::Hadamard_gate() {
   // Need to add noise here later
   apply_single_qubit_gate_error(Hgate_error, this);
   bool z = par("GOD_Zerror");
@@ -351,19 +351,19 @@ void stationaryQubit::Hadamard_gate() {
   par("GOD_Xerror") = z;
 }
 
-void stationaryQubit::Z_gate() {
+void StationaryQubit::Z_gate() {
   // Need to add noise here later
   apply_single_qubit_gate_error(Zgate_error, this);
   par("GOD_Zerror") = !par("GOD_Zerror");
 }
 
-void stationaryQubit::X_gate() {
+void StationaryQubit::X_gate() {
   // Need to add noise here later
   apply_single_qubit_gate_error(Xgate_error, this);
   par("GOD_Xerror") = !par("GOD_Xerror");
 }
 
-void stationaryQubit::CNOT_gate(stationaryQubit *control_qubit) {
+void StationaryQubit::CNOT_gate(StationaryQubit *control_qubit) {
   // Need to add noise here later
   apply_two_qubit_gate_error(CNOTgate_error, this, control_qubit);
   // std::cout<<"this X err = "<<this->par("GOD_Xerror").boolValue()<<"\n";
@@ -380,7 +380,7 @@ void stationaryQubit::CNOT_gate(stationaryQubit *control_qubit) {
 }
 
 // This is invoked whenever a photon is emitted out from this particular qubit.
-void stationaryQubit::setBusy() {
+void StationaryQubit::setBusy() {
   isBusy = true;
   emitted_time = simTime();
   updated_time = simTime();  // Should be no error at this time.
@@ -395,7 +395,7 @@ void stationaryQubit::setBusy() {
 
 // Re-initialization of this stationary qubit
 // This is called at the beginning of the simulation (in initialization() above), and whenever it is reinitialized via the RealTimeController.
-void stationaryQubit::setFree(bool consumed) {
+void StationaryQubit::setFree(bool consumed) {
   num_purified = 0;
   locked = false;
   locked_ruleset_id = -1;
@@ -441,13 +441,13 @@ void stationaryQubit::setFree(bool consumed) {
   }
 }
 
-bool stationaryQubit::checkBusy() {
+bool StationaryQubit::checkBusy() {
   Enter_Method("checkBusy()");
   return isBusy;
 }
 
 /*To avoid disturbing this qubit.*/
-void stationaryQubit::Lock(unsigned long rs_id, int rule_id, int action_id) {
+void StationaryQubit::Lock(unsigned long rs_id, int rule_id, int action_id) {
   if (rs_id == -1 || rule_id == -1 || action_id == -1) {
     error("ruleset_id || rule_id || action_id == -1");
   }
@@ -463,7 +463,7 @@ void stationaryQubit::Lock(unsigned long rs_id, int rule_id, int action_id) {
   }
 }
 
-void stationaryQubit::Unlock() {
+void StationaryQubit::Unlock() {
   locked = false;
   locked_ruleset_id = -1;  // Used to identify what this qubit is locked for.
   locked_rule_id = -1;
@@ -475,9 +475,9 @@ void stationaryQubit::Unlock() {
   }
 }
 
-bool stationaryQubit::isLocked() { return locked; }
+bool StationaryQubit::isLocked() { return locked; }
 
-void stationaryQubit::Allocate() {
+void StationaryQubit::Allocate() {
   allocated = true;
   if (hasGUI()) {
     bubble("Allocated!");
@@ -485,15 +485,15 @@ void stationaryQubit::Allocate() {
   }
 }
 
-void stationaryQubit::Deallocate() { allocated = false; }
+void StationaryQubit::Deallocate() { allocated = false; }
 
-bool stationaryQubit::isAllocated() { return allocated; }
+bool StationaryQubit::isAllocated() { return allocated; }
 
 /**
  * \brief Generate photon entangled with the memory
  * \warning Shouldn't we destroy a possibly existing photon object before? <- No, I dont think so...
  */
-PhotonicQubit *stationaryQubit::generateEntangledPhoton() {
+PhotonicQubit *StationaryQubit::generateEntangledPhoton() {
   Enter_Method("generateEntangledPhoton()");
   photon = new PhotonicQubit("Photon");
   // To simulate the actual physical entangled partner, not what the system thinks!!! we need this.
@@ -504,7 +504,7 @@ PhotonicQubit *stationaryQubit::generateEntangledPhoton() {
   // qnic_address != qnic_index. qnic_index is not unique because there are 3 types.
   photon->setQNICEntangledWith(qnic_address);
 
-  // stationaryQubit_address = stationaryQubit's index
+  // stationaryQubit_address = StationaryQubit's index
   photon->setStationaryQubitEntangledWith(stationaryQubit_address);
   photon->setQNICtypeEntangledWith(qnic_type);
   photon->setEntangled_with(this);
@@ -518,7 +518,7 @@ PhotonicQubit *stationaryQubit::generateEntangledPhoton() {
  *
  * The stationary qubit shouldn't be already busy.
  */
-void stationaryQubit::emitPhoton(int pulse) {
+void StationaryQubit::emitPhoton(int pulse) {
   Enter_Method("emitPhoton()");
   if (checkBusy()) {
     error("Requested a photon emission to a busy qubit... this should not happen!");
@@ -534,7 +534,7 @@ void stationaryQubit::emitPhoton(int pulse) {
 }
 
 // This gets direcltly invoked when darkcount happened in BellStateAnalyzer.cc.
-void stationaryQubit::setCompletelyMixedDensityMatrix() {
+void StationaryQubit::setCompletelyMixedDensityMatrix() {
   this->Density_Matrix_Collapsed << (double)1 / (double)2, 0, 0, (double)1 / (double)2;
   // std::cout<<"Dm completely mixed "<<this->Density_Matrix_Collapsed<<"\n";
   this->completely_mixed = true;
@@ -558,7 +558,7 @@ void stationaryQubit::setCompletelyMixedDensityMatrix() {
 }
 
 // This gets invoked in memory error simulation or by BellStateAnalyzer if photonLoss + darkcount.
-void stationaryQubit::setExcitedDensityMatrix() {
+void StationaryQubit::setExcitedDensityMatrix() {
   Density_Matrix_Collapsed << 1, 0, 0, 0;  // Overwrite density matrix
   completely_mixed = false;
   excited_or_relaxed = true;  // It is excited
@@ -586,7 +586,7 @@ void stationaryQubit::setExcitedDensityMatrix() {
   }  // else it is already not entangled. e.g. excited -> relaxed.
 }
 
-void stationaryQubit::setRelaxedDensityMatrix() {
+void StationaryQubit::setRelaxedDensityMatrix() {
   Density_Matrix_Collapsed << 0, 0, 0, 1;
   completely_mixed = false;
   excited_or_relaxed = true;
@@ -611,7 +611,7 @@ void stationaryQubit::setRelaxedDensityMatrix() {
   }  // else it is already not entangled. e.g. excited -> relaxed.
 }
 
-void stationaryQubit::setEntangledPartnerInfo(stationaryQubit *partner) {
+void StationaryQubit::setEntangledPartnerInfo(StationaryQubit *partner) {
   // When BSA succeeds, this method gets invoked to store entangled partner information.
   // This will also be sent classically to the partner node afterwards.
   entangled_partner = partner;
@@ -623,7 +623,7 @@ void stationaryQubit::setEntangledPartnerInfo(stationaryQubit *partner) {
 }
 
 /*Add another X error. If an X error already exists, then they cancel out*/
-void stationaryQubit::addXerror() {
+void StationaryQubit::addXerror() {
   // error("Huh...?");
   bool Xerr = this->par("GOD_Xerror");
   // Switches true to false or false to true
@@ -632,7 +632,7 @@ void stationaryQubit::addXerror() {
 }
 
 /*Add another Z error. If an Z error already exists, then they cancel out*/
-void stationaryQubit::addZerror() {
+void StationaryQubit::addZerror() {
   bool Zerr = this->par("GOD_Zerror");
   // Switches true to false or false to true
   this->par("GOD_Zerror") = !Zerr;
@@ -640,7 +640,7 @@ void stationaryQubit::addZerror() {
 }
 
 // Only tracks error propagation. If two booleans (Alice and Bob) agree (truetrue or falsefalse), keep the purified ebit.
-bool stationaryQubit::Xpurify(stationaryQubit *resource_qubit /*Controlled*/) {
+bool StationaryQubit::Xpurify(StationaryQubit *resource_qubit /*Controlled*/) {
   // std::cout<<"X puri\n";
   // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
   apply_memory_error(this);
@@ -650,7 +650,7 @@ bool stationaryQubit::Xpurify(stationaryQubit *resource_qubit /*Controlled*/) {
   return meas;
 }
 
-bool stationaryQubit::Zpurify(stationaryQubit *resource_qubit /*Target*/) {
+bool StationaryQubit::Zpurify(StationaryQubit *resource_qubit /*Target*/) {
   // std::cout<<"Z puri\n";
   apply_memory_error(this);  // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
   apply_memory_error(resource_qubit);
@@ -661,7 +661,7 @@ bool stationaryQubit::Zpurify(stationaryQubit *resource_qubit /*Target*/) {
 }
 
 // Single qubit memory error based on Markov-Chain
-void stationaryQubit::apply_memory_error(stationaryQubit *qubit) {
+void StationaryQubit::apply_memory_error(StationaryQubit *qubit) {
   if (qubit->entangled_partner == nullptr && qubit->Density_Matrix_Collapsed(0, 0).real() == -111 && !qubit->no_density_matrix_nullptr_entangled_partner_ok)
     error("This must not happen in apply memory error");
 
@@ -867,7 +867,7 @@ void stationaryQubit::apply_memory_error(stationaryQubit *qubit) {
   qubit->par("last_updated_at") = simTime().dbl();  // For GUI
 }
 
-Matrix2cd stationaryQubit::getErrorMatrix(stationaryQubit *qubit) {
+Matrix2cd StationaryQubit::getErrorMatrix(StationaryQubit *qubit) {
   Matrix2cd err;
 
   if (qubit->par("GOD_CMerror") || qubit->par("GOD_REerror") || qubit->par("GOD_REerror")) {
@@ -902,7 +902,7 @@ Matrix2cd stationaryQubit::getErrorMatrix(stationaryQubit *qubit) {
 
 // returns the density matrix of the Bell pair with error. This assumes that this is entangled with another stationary qubit.
 // Measurement output will be based on this matrix, as long as it is still entnagled.
-quantum_state stationaryQubit::getQuantumState() {
+quantum_state StationaryQubit::getQuantumState() {
   if (this->excited_or_relaxed || this->entangled_partner->excited_or_relaxed) {
     error("Wrong");
   }
@@ -936,7 +936,7 @@ quantum_state stationaryQubit::getQuantumState() {
   return q;
 }
 
-void stationaryQubit::apply_single_qubit_gate_error(gate_error_model gate, stationaryQubit *qubit) {
+void StationaryQubit::apply_single_qubit_gate_error(gate_error_model gate, StationaryQubit *qubit) {
   if (gate.pauli_error_rate == 0) {
     return;
   }
@@ -961,7 +961,7 @@ void stationaryQubit::apply_single_qubit_gate_error(gate_error_model gate, stati
   }
 }
 
-void stationaryQubit::apply_two_qubit_gate_error(two_qubit_gate_error_model gate, stationaryQubit *first_qubit, stationaryQubit *second_qubit) {
+void StationaryQubit::apply_two_qubit_gate_error(two_qubit_gate_error_model gate, StationaryQubit *first_qubit, StationaryQubit *second_qubit) {
   if (gate.pauli_error_rate == 0) {
     return;
   }
@@ -1016,7 +1016,7 @@ void stationaryQubit::apply_two_qubit_gate_error(two_qubit_gate_error_model gate
   }
 }
 
-measurement_outcome stationaryQubit::measure_density_independent() {
+measurement_outcome StationaryQubit::measure_density_independent() {
   // std::cout<<"\n\n\n\n\n\n\n\nMEASURING!!!\n";
 
   // if(this->getIndex() == 71 && this->node_address == 3)
@@ -1206,7 +1206,7 @@ measurement_outcome stationaryQubit::measure_density_independent() {
   return o;
 }
 
-measurement_operator stationaryQubit::Random_Measurement_Basis_Selection() {
+measurement_operator StationaryQubit::Random_Measurement_Basis_Selection() {
   measurement_operator this_measurement;
   double dbl = dblrand();  // Random double value for random basis selection.
   EV << "Random dbl = " << dbl << "! \n ";
@@ -1240,7 +1240,7 @@ measurement_operator stationaryQubit::Random_Measurement_Basis_Selection() {
 // When do we perform measurements? I think we can just ignore the success/fail of entanglement attempt, and measure it beforehand anyway. Waiting cause error.
 // How do we know when to measure though?
 // Return value: 1 if output is +, 0 if output is -.
-/*std::bitset<1> stationaryQubit::measure_density(char basis_this_qubit){
+/*std::bitset<1> StationaryQubit::measure_density(char basis_this_qubit){
     if(entangled_partner == nullptr){
         error("Measuring a qubit that is not entangled with another qubit. Not allowed!");
     }

--- a/quisp/modules/stationaryQubit.h
+++ b/quisp/modules/stationaryQubit.h
@@ -1,11 +1,11 @@
-/** \file stationaryQubit.h
+/** \file StationaryQubit.h
  *  \authors cldurand,takaakimatsuo
  *  \date 2018/03/14
  *
- *  \brief stationaryQubit
+ *  \brief StationaryQubit
  */
-#ifndef QUISP_MODULES_STATIONARYQUBIT_H_
-#define QUISP_MODULES_STATIONARYQUBIT_H_
+#ifndef QUISP_MODULES_StationaryQubit_H_
+#define QUISP_MODULES_StationaryQubit_H_
 
 #include <PhotonicQubit_m.h>
 
@@ -20,14 +20,14 @@ namespace modules {
 #define STATIONARYQUBIT_PULSE_END 0x02
 #define STATIONARYQUBIT_PULSE_BOUND (STATIONARYQUBIT_PULSE_BEGIN | STATIONARYQUBIT_PULSE_END)
 
-/** \class stationaryQubit stationaryQubit.h
+/** \class StationaryQubit StationaryQubit.h
  *
- *  \brief stationaryQubit
+ *  \brief StationaryQubit
  */
 
 typedef std::complex<double> Complex;
 
-typedef struct _emission_error_model {
+typedef struct {
   double pauli_error_rate;  // Overall error rate
   double Z_error_rate;
   double X_error_rate;
@@ -41,7 +41,7 @@ typedef struct _emission_error_model {
   double Loss_error_ceil;
 } emission_error_model;
 
-typedef struct _gate_error_model {
+typedef struct {
   double pauli_error_rate;  // Overall error rate
   double Z_error_rate;
   double X_error_rate;
@@ -53,7 +53,7 @@ typedef struct _gate_error_model {
   double Y_error_ceil;
 } gate_error_model;
 
-typedef struct _two_qubit_gate_error_model {
+typedef struct {
   double pauli_error_rate;  // Overall error rate
   double IZ_error_rate;
   double ZI_error_rate;
@@ -77,7 +77,7 @@ typedef struct _two_qubit_gate_error_model {
   double XX_error_ceil;
 } two_qubit_gate_error_model;
 
-typedef struct _memory_error_model {
+typedef struct {
   double error_rate;  // Overall error rate
   double Z_error_rate;
   double X_error_rate;
@@ -88,26 +88,26 @@ typedef struct _memory_error_model {
 } memory_error_model;
 
 // Matrices of single qubit errors. Used when conducting tomography.
-typedef struct _single_qubit_errors {
+typedef struct {
   Matrix2cd X;  // double 2*2 matrix
   Matrix2cd Y;  // complex double 2*2 matrix
   Matrix2cd Z;
   Matrix2cd I;
 } single_qubit_error;
 
-typedef struct _quantum_state {
+typedef struct {
   Matrix4cd state_in_density_matrix;
   Vector4cd state_in_ket;
 } quantum_state;
 
-typedef struct _measurement_output {
+typedef struct {
   double probability_plus_plus;  // P(+,+)
   double probability_minus_plus;  // P(+,-)
   double probability_plus_minus;  // P(-,+)
   double probability_minus_minus;  // P(-,-)
 } measurement_output_probabilities;
 
-typedef struct _measurement_operator {
+typedef struct {
   Matrix2cd plus;
   Matrix2cd minus;
   Vector2cd plus_ket;
@@ -116,20 +116,20 @@ typedef struct _measurement_operator {
 } measurement_operator;
 
 // Single qubit
-typedef struct _measurement_operators {
+typedef struct {
   measurement_operator X_basis;
   measurement_operator Y_basis;
   measurement_operator Z_basis;
   Matrix2cd identity;
 } measurement_operators;
 
-typedef struct _measurement_outcome {
+typedef struct {
   char basis;
   bool outcome_is_plus;
   char GOD_clean;
 } measurement_outcome;
 
-class stationaryQubit : public cSimpleModule {
+class StationaryQubit : public cSimpleModule {
  public:
   /** @name Errors
    *  @{
@@ -154,9 +154,9 @@ class stationaryQubit : public cSimpleModule {
   int QNICEntangledWith;
   int QNICtypeEntangledWith;
   /** Index of Qubit in qNIC. */
-  int stationaryQubitEntangledWith;
+  int StationaryQubitEntangledWith;
   /** Pointer to the entangled qubit*/
-  stationaryQubit *entangled_partner = nullptr;
+  StationaryQubit *entangled_partner = nullptr;
   /** Photon emitted at*/
   simtime_t emitted_time = -1;
   /** Stationary qubit last updated at*/
@@ -266,15 +266,15 @@ class stationaryQubit : public cSimpleModule {
   virtual measurement_outcome measure_density_independent(); /*Separate dm calculation*/
 
   /*Applies memory error to the given qubit*/
-  virtual void apply_memory_error(stationaryQubit *qubit);
+  virtual void apply_memory_error(StationaryQubit *qubit);
 
-  virtual void apply_single_qubit_gate_error(gate_error_model gate, stationaryQubit *qubit);
-  virtual void apply_two_qubit_gate_error(two_qubit_gate_error_model gate, stationaryQubit *first_qubit, stationaryQubit *second_qubit);
+  virtual void apply_single_qubit_gate_error(gate_error_model gate, StationaryQubit *qubit);
+  virtual void apply_two_qubit_gate_error(two_qubit_gate_error_model gate, StationaryQubit *first_qubit, StationaryQubit *second_qubit);
   /**
    * \brief Two qubit CNOT gate.
    * \param Need to specify the control qubit as an argument.
    */
-  virtual void CNOT_gate(stationaryQubit *control_qubit);
+  virtual void CNOT_gate(StationaryQubit *control_qubit);
   /**
    * \brief Single qubit Hadamard gate
    * \param X error transforms to Z, and vise-versa.
@@ -284,11 +284,11 @@ class stationaryQubit : public cSimpleModule {
   virtual void Z_gate();
 
   virtual void X_gate();
-  virtual bool Xpurify(stationaryQubit *resource_qubit);
-  virtual bool Zpurify(stationaryQubit *resource_qubit);
+  virtual bool Xpurify(StationaryQubit *resource_qubit);
+  virtual bool Zpurify(StationaryQubit *resource_qubit);
 
   /*GOD parameters*/
-  virtual void setEntangledPartnerInfo(stationaryQubit *partner);
+  virtual void setEntangledPartnerInfo(StationaryQubit *partner);
   virtual void setCompletelyMixedDensityMatrix();
   virtual void setRelaxedDensityMatrix();
   virtual void setExcitedDensityMatrix();
@@ -326,7 +326,7 @@ class stationaryQubit : public cSimpleModule {
   virtual void setBusy();
   // virtual void setErrorCeilings();
   // virtual void setEmissionPauliError();
-  virtual Matrix2cd getErrorMatrix(stationaryQubit *qubit);  // returns the matrix that represents the errors on the Bell pair. (e.g. XY, XZ and ZI...)
+  virtual Matrix2cd getErrorMatrix(StationaryQubit *qubit);  // returns the matrix that represents the errors on the Bell pair. (e.g. XY, XZ and ZI...)
   virtual quantum_state getQuantumState();  // returns the dm of the physical Bell pair. Used for tomography.
   virtual measurement_operator Random_Measurement_Basis_Selection();
   virtual gate_error_model SetSingleQubitGateErrorCeilings(std::string gate_name);
@@ -337,4 +337,4 @@ class stationaryQubit : public cSimpleModule {
 }  // namespace modules
 }  // namespace quisp
 
-#endif /* QUISP_MODULES_STATIONARYQUBIT_H_ */
+#endif /* QUISP_MODULES_StationaryQubit_H_ */

--- a/quisp/networks/HoM.ned
+++ b/quisp/networks/HoM.ned
@@ -24,10 +24,10 @@ simple BellStateAnalyzer
         output toHoMController_port;
 }
 
-simple HoM_Controller
+simple HoMController
 {
     parameters:
-        //@class(quisp::modules::HoM_Controller);
+        //@class(quisp::modules::HoMController);
         int address;
         volatile double Speed_of_light_in_fiber @unit(km);//per sec
         int photon_detection_per_sec = default(10000);
@@ -69,7 +69,7 @@ module interHoM {
         inout quantum_port[] @loose;
         output toRouter @loose;
      submodules:
-        Controller: HoM_Controller {
+        Controller: HoMController {
             parameters:
                 address = address;
                 @display("p=103.55499,121.435");
@@ -147,7 +147,7 @@ module HoM
                 address = 0;
                 @display("p=281.61,55.874996");
         }
-        Controller: HoM_Controller {
+        Controller: HoMController {
             parameters:
                 address = address;
                 photon_detection_per_sec = hom_photon_detection_per_sec;

--- a/quisp/networks/qnic.ned
+++ b/quisp/networks/qnic.ned
@@ -1,6 +1,6 @@
 package networks;
 
-simple stationaryQubit
+simple StationaryQubit
 {
     parameters:
         // performance analysis
@@ -175,7 +175,7 @@ module QNIC
         //inout dummyRoutingDaemonLink @loose;
 
     submodules:
-        statQubit[numBuffer]: stationaryQubit {
+        statQubit[numBuffer]: StationaryQubit {
             stationaryQubit_address = index;
             node_address = parent_node_address;
             qnic_address = self_qnic_address;

--- a/quisp/rules/Action.cc
+++ b/quisp/rules/Action.cc
@@ -17,9 +17,9 @@ namespace rules {
 int Action::checkNumResource() { return (*rule_resources).size(); }
 
 // required_index: 0 is the top one, 1 is the 2nd top one, and so on.
-stationaryQubit *Action::getResource_fromTop(int required_index) {
+StationaryQubit *Action::getResource_fromTop(int required_index) {
   int resource_index = 0;
-  stationaryQubit *pt = nullptr;
+  StationaryQubit *pt = nullptr;
 
   for (auto it = (*rule_resources).begin(); it != (*rule_resources).end(); ++it) {
     if (it->second->isLocked()) {
@@ -34,10 +34,10 @@ stationaryQubit *Action::getResource_fromTop(int required_index) {
   return pt;
 }
 
-stationaryQubit *Action::getResource_fromTop_with_partner(int required_index, int partner) {
+StationaryQubit *Action::getResource_fromTop_with_partner(int required_index, int partner) {
   // here
   int resource_index = 0;
-  stationaryQubit *pt = nullptr;
+  StationaryQubit *pt = nullptr;
   // EV<<"===========================================\n";
   // for (auto it=(*rule_resources).begin(); it!=(*rule_resources).end(); ++it) {
   //     EV<<"hey!"<<it->first<<"\n";
@@ -57,7 +57,7 @@ stationaryQubit *Action::getResource_fromTop_with_partner(int required_index, in
   return pt;
 }
 
-void Action::removeResource_fromRule(stationaryQubit *qubit) {
+void Action::removeResource_fromRule(StationaryQubit *qubit) {
   for (auto it = (*rule_resources).begin(), next_it = (*rule_resources).begin(); it != (*rule_resources).end(); it = next_it) {
     next_it = it;
     ++next_it;
@@ -72,8 +72,8 @@ void Action::removeResource_fromRule(stationaryQubit *qubit) {
 cPacket *SwappingAction::run(cModule *re) {
   float success_probability = 1.0;
 
-  stationaryQubit *left_qubit = nullptr;
-  stationaryQubit *right_qubit = nullptr;
+  StationaryQubit *left_qubit = nullptr;
+  StationaryQubit *right_qubit = nullptr;
 
   left_qubit = getResource_fromTop_with_partner(left_resource, left_partner);
   right_qubit = getResource_fromTop_with_partner(right_resource, right_partner);
@@ -90,8 +90,8 @@ cPacket *SwappingAction::run(cModule *re) {
   }
 
   // actual swapping operations
-  stationaryQubit *right_partner_qubit = right_qubit->entangled_partner;
-  stationaryQubit *left_partner_qubit = left_qubit->entangled_partner;
+  StationaryQubit *right_partner_qubit = right_qubit->entangled_partner;
+  StationaryQubit *left_partner_qubit = left_qubit->entangled_partner;
   // just swapping pointer.
   // swapper have no way to know this swapping is success or not.
   // bell measurement
@@ -178,8 +178,8 @@ cPacket *SwappingAction::run(cModule *re) {
 
 // Either Z or X purification.
 cPacket *PurifyAction::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit = nullptr;
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit = getResource_fromTop(trash_resource);
@@ -232,8 +232,8 @@ cPacket *PurifyAction::run(cModule *re) {
 
 // Double error purification
 cPacket *DoublePurifyAction::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -297,9 +297,9 @@ cPacket *DoublePurifyAction::run(cModule *re) {
 }
 
 // Inveerted double error purification.
-cPacket *DoublePurifyAction_inv::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+cPacket *DoublePurifyActionInv::run(cModule *re) {
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -363,8 +363,8 @@ cPacket *DoublePurifyAction_inv::run(cModule *re) {
 
 // Double selection single error (X error) purification.
 cPacket *DoubleSelectionAction::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -428,9 +428,9 @@ cPacket *DoubleSelectionAction::run(cModule *re) {
 }
 
 // Double selection single error (Z error) purification
-cPacket *DoubleSelectionAction_inv::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+cPacket *DoubleSelectionActionInv::run(cModule *re) {
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -494,7 +494,7 @@ cPacket *DoubleSelectionAction_inv::run(cModule *re) {
 }
 
 cPacket *RandomMeasureAction::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
+  StationaryQubit *qubit = nullptr;
 
   qubit = getResource_fromTop(resource);
 
@@ -531,8 +531,8 @@ cPacket *RandomMeasureAction::run(cModule *re) {
 
 // X purification, Z purification to trash_qubit_X Bell pair.
 cPacket *DoubleSelectionDualAction::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -624,9 +624,9 @@ cPacket *DoubleSelectionDualAction::run(cModule *re) {
 }
 
 // Double selection double error (ZX error) purification
-cPacket *DoubleSelectionDualAction_inv::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
+cPacket *DoubleSelectionDualActionInv::run(cModule *re) {
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -712,8 +712,8 @@ cPacket *DoubleSelectionDualAction_inv::run(cModule *re) {
 
 // X purification, Z purification to trash_qubit_X Bell pair.
 cPacket *DoubleSelectionDualActionSecond::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_X = nullptr;
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -787,9 +787,9 @@ cPacket *DoubleSelectionDualActionSecond::run(cModule *re) {
 }
 
 // Double selection double error (ZX error) purification
-cPacket *DoubleSelectionDualActionSecond_inv::run(cModule *re) {
-  stationaryQubit *qubit = nullptr;
-  stationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z = nullptr;
+cPacket *DoubleSelectionDualActionSecondInv::run(cModule *re) {
+  StationaryQubit *qubit = nullptr;
+  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);

--- a/quisp/rules/Action.h
+++ b/quisp/rules/Action.h
@@ -25,17 +25,17 @@ namespace rules {
 
 class Action {
  public:
-  std::multimap<int, stationaryQubit*>* rule_resources;
+  std::multimap<int, StationaryQubit*>* rule_resources;
   unsigned long ruleset_id;
   int rule_id;  // Used to make the lock_id unique, together with purification_count.
   // int resource_index = 0;// for check the index of resource.
   // virtual cPacket* run(cModule *re, qnicResources *resources) = 0;
   virtual cPacket* run(cModule* re) = 0;
-  virtual stationaryQubit* getResource_fromTop(int required_index);
-  virtual stationaryQubit* getResource_fromTop_with_partner(int required_index, int partner);
+  virtual StationaryQubit* getResource_fromTop(int required_index);
+  virtual StationaryQubit* getResource_fromTop_with_partner(int required_index, int partner);
   virtual int checkNumResource();
-  virtual void removeResource_fromRule(stationaryQubit* qubit);
-  // virtual stationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id);
+  virtual void removeResource_fromRule(StationaryQubit* qubit);
+  // virtual StationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id);
 };
 typedef std::unique_ptr<Action> pAction;
 
@@ -96,7 +96,7 @@ class PurifyAction : public Action {
   int qnic_id;
   int resource; /**< Identifies qubit */
   int trash_resource;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
@@ -143,7 +143,7 @@ class DoublePurifyAction : public Action {
   int resource; /**< Identifies qubit */
   int trash_resource_Z;
   int trash_resource_X;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
@@ -166,7 +166,7 @@ class DoublePurifyAction : public Action {
   cPacket* run(cModule* re) override;
 };
 
-class DoublePurifyAction_inv : public Action {
+class DoublePurifyActionInv : public Action {
  protected:
   int partner; /**< Identifies entanglement partner. */
   QNIC_type qnic_type;
@@ -174,13 +174,13 @@ class DoublePurifyAction_inv : public Action {
   int resource; /**< Identifies qubit */
   int trash_resource_Z;
   int trash_resource_X;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
   int action_index = 0;  // To track how many times this particular action has been invoked.
  public:
-  DoublePurifyAction_inv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z) {
+  DoublePurifyActionInv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z) {
     partner = part;
     qnic_type = qt;
     qnic_id = qi;
@@ -191,7 +191,7 @@ class DoublePurifyAction_inv : public Action {
     ruleset_id = RuleSet_id;
     // action_index++;
   };
-  DoublePurifyAction_inv(){
+  DoublePurifyActionInv(){
 
   };
   cPacket* run(cModule* re) override;
@@ -206,7 +206,7 @@ class DoubleSelectionAction : public Action {
   int resource; /**< Identifies qubit */
   int trash_resource_Z;
   int trash_resource_X;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
@@ -230,7 +230,7 @@ class DoubleSelectionAction : public Action {
 };
 
 // https://arxiv.org/abs/0811.2639
-class DoubleSelectionAction_inv : public Action {
+class DoubleSelectionActionInv : public Action {
  protected:
   int partner; /**< Identifies entanglement partner. */
   QNIC_type qnic_type;
@@ -238,13 +238,13 @@ class DoubleSelectionAction_inv : public Action {
   int resource; /**< Identifies qubit */
   int trash_resource_Z;
   int trash_resource_X;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
   int action_index = 0;  // To track how many times this particular action has been invoked.
  public:
-  DoubleSelectionAction_inv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z) {
+  DoubleSelectionActionInv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z) {
     partner = part;
     qnic_type = qt;
     qnic_id = qi;
@@ -255,7 +255,7 @@ class DoubleSelectionAction_inv : public Action {
     ruleset_id = RuleSet_id;
     // action_index++;
   };
-  DoubleSelectionAction_inv(){
+  DoubleSelectionActionInv(){
 
   };
   cPacket* run(cModule* re) override;
@@ -272,7 +272,7 @@ class DoubleSelectionDualAction : public Action {
   int trash_resource_X;
   int doubleselection_trash_resource_Z;
   int doubleselection_trash_resource_X;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
@@ -298,7 +298,7 @@ class DoubleSelectionDualAction : public Action {
 };
 
 // https://arxiv.org/abs/0811.2639
-class DoubleSelectionDualAction_inv : public Action {
+class DoubleSelectionDualActionInv : public Action {
  protected:
   int partner; /**< Identifies entanglement partner. */
   QNIC_type qnic_type;
@@ -308,13 +308,13 @@ class DoubleSelectionDualAction_inv : public Action {
   int trash_resource_X;
   int doubleselection_trash_resource_Z;
   int doubleselection_trash_resource_X;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
   int action_index = 0;  // To track how many times this particular action has been invoked.
  public:
-  DoubleSelectionDualAction_inv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z, int ds_X, int ds_Z) {
+  DoubleSelectionDualActionInv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z, int ds_X, int ds_Z) {
     partner = part;
     qnic_type = qt;
     qnic_id = qi;
@@ -327,14 +327,14 @@ class DoubleSelectionDualAction_inv : public Action {
     ruleset_id = RuleSet_id;
     // action_index++;
   };
-  DoubleSelectionDualAction_inv(){
+  DoubleSelectionDualActionInv(){
 
   };
   cPacket* run(cModule* re) override;
 };
 
 // https://arxiv.org/abs/0811.2639
-class DoubleSelectionDualActionSecond_inv : public Action {
+class DoubleSelectionDualActionSecondInv : public Action {
  protected:
   int partner; /**< Identifies entanglement partner. */
   QNIC_type qnic_type;
@@ -343,13 +343,13 @@ class DoubleSelectionDualActionSecond_inv : public Action {
   int trash_resource_Z;
   int trash_resource_X;
   int doubleselection_trash_resource_Z;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;
   int action_index = 0;  // To track how many times this particular action has been invoked.
  public:
-  DoubleSelectionDualActionSecond_inv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z, int ds_Z) {
+  DoubleSelectionDualActionSecondInv(unsigned long RuleSet_id, int rule_index, int part, QNIC_type qt, int qi, int res, int tres_X, int tres_Z, int ds_Z) {
     partner = part;
     qnic_type = qt;
     qnic_id = qi;
@@ -361,7 +361,7 @@ class DoubleSelectionDualActionSecond_inv : public Action {
     ruleset_id = RuleSet_id;
     // action_index++;
   };
-  DoubleSelectionDualActionSecond_inv(){
+  DoubleSelectionDualActionSecondInv(){
 
   };
   cPacket* run(cModule* re) override;
@@ -377,7 +377,7 @@ class DoubleSelectionDualActionSecond : public Action {
   int trash_resource_Z;
   int trash_resource_X;
   int doubleselection_trash_resource_X;
-  int mutable purification_count;  // Used for locked_id in stationaryQubit. You unlock the qubit when purification is successful.
+  int mutable purification_count;  // Used for locked_id in StationaryQubit. You unlock the qubit when purification is successful.
   bool X;
   bool Z;
   int num_purify;

--- a/quisp/rules/Clause.cc
+++ b/quisp/rules/Clause.cc
@@ -21,8 +21,8 @@ bool FidelityClause::check(qnicResources* resources) const {
     return false;
 }*/
 
-bool FidelityClause::check(std::multimap<int, stationaryQubit*> resource) const {
-  stationaryQubit* qubit = nullptr;
+bool FidelityClause::check(std::multimap<int, StationaryQubit*> resource) const {
+  StationaryQubit* qubit = nullptr;
   /*checkQnic();//This is not doing anything...
   if(qubit = getQubit(resources, qnic_type, qnic_id, partner, resource)){
       return (qubit->getFidelity() >= threshold);
@@ -30,12 +30,12 @@ bool FidelityClause::check(std::multimap<int, stationaryQubit*> resource) const 
   return false;*/
 }
 
-bool EnoughResourceClause::check(std::multimap<int, stationaryQubit*> resource) const {
+bool EnoughResourceClause::check(std::multimap<int, StationaryQubit*> resource) const {
   // std::cout<<"!!In enough clause \n";
   bool enough = false;
   int num_free = 0;
 
-  for (std::multimap<int, stationaryQubit*>::iterator it = resource.begin(); it != resource.end(); ++it) {
+  for (std::multimap<int, StationaryQubit*>::iterator it = resource.begin(); it != resource.end(); ++it) {
     if (it->first == partner) {
       if (!it->second->isLocked()) {  // here must have loop
         num_free++;
@@ -49,12 +49,12 @@ bool EnoughResourceClause::check(std::multimap<int, stationaryQubit*> resource) 
   return enough;
 }
 
-bool EnoughResourceClauseLeft::check(std::multimap<int, stationaryQubit*> resource) const {
+bool EnoughResourceClauseLeft::check(std::multimap<int, StationaryQubit*> resource) const {
   // std::cout<<"!!In enough clause \n";
   bool enough = false;
   int num_free = 0;
 
-  for (std::multimap<int, stationaryQubit*>::iterator it = resource.begin(); it != resource.end(); ++it) {
+  for (std::multimap<int, StationaryQubit*>::iterator it = resource.begin(); it != resource.end(); ++it) {
     if (it->first == partner_left) {
       if (!it->second->isLocked()) {  // here must have loop
         num_free++;
@@ -73,12 +73,12 @@ bool EnoughResourceClauseLeft::check(std::multimap<int, stationaryQubit*> resour
   return enough;
 }
 
-bool EnoughResourceClauseRight::check(std::multimap<int, stationaryQubit*> resource) const {
+bool EnoughResourceClauseRight::check(std::multimap<int, StationaryQubit*> resource) const {
   // std::cout<<"!!In enough clause \n";
   bool enough = false;
   int num_free = 0;
 
-  for (std::multimap<int, stationaryQubit*>::iterator it = resource.begin(); it != resource.end(); ++it) {
+  for (std::multimap<int, StationaryQubit*>::iterator it = resource.begin(); it != resource.end(); ++it) {
     if (it->first == partner_right) {
       if (!it->second->isLocked()) {  // here must have loop
         num_free++;
@@ -111,7 +111,7 @@ bool MeasureCountClause::check(qnicResources* resources) const {
     }
 }*/
 
-bool MeasureCountClause::check(std::multimap<int, stationaryQubit*> resources) const {
+bool MeasureCountClause::check(std::multimap<int, StationaryQubit*> resources) const {
   // std::cout<<"MeasureCountClause invoked!!!! \n";
   if (current_count < max_count) {
     current_count++;  // Increment measured counter.
@@ -123,7 +123,7 @@ bool MeasureCountClause::check(std::multimap<int, stationaryQubit*> resources) c
   }
 }
 
-bool MeasureCountClause::checkTerminate(std::multimap<int, stationaryQubit*> resources) const {
+bool MeasureCountClause::checkTerminate(std::multimap<int, StationaryQubit*> resources) const {
   EV << "Tomography termination clause invoked.\n";
   bool done = false;
   if (current_count >= max_count) {
@@ -157,8 +157,8 @@ bool PurificationCountClause::check(qnicResources* resources) const {
     }
 }*/
 
-bool PurificationCountClause::check(std::multimap<int, stationaryQubit*> resource) const {
-  stationaryQubit* qubit = nullptr;
+bool PurificationCountClause::check(std::multimap<int, StationaryQubit*> resource) const {
+  StationaryQubit* qubit = nullptr;
   // checkQnic();//This is not doing anything...
 
   /*

--- a/quisp/rules/Clause.h
+++ b/quisp/rules/Clause.h
@@ -54,10 +54,10 @@ class Clause {
       // if (qnic_id < 0) omnetpp::error("Negative qnic index.");
   };
   // virtual bool check(qnicResources *resources) const = 0;
-  virtual bool check(std::multimap<int, stationaryQubit*>) const = 0;
+  virtual bool check(std::multimap<int, StationaryQubit*>) const = 0;
   // virtual bool checkTerminate(qnicResources *resources) const = 0;
-  virtual bool checkTerminate(std::multimap<int, stationaryQubit*>) const = 0;
-  // virtual stationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) const = 0;
+  virtual bool checkTerminate(std::multimap<int, StationaryQubit*>) const = 0;
+  // virtual StationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) const = 0;
 };
 
 typedef std::unique_ptr<Clause> pClause;
@@ -71,8 +71,8 @@ class FidelityClause : public Clause {
   FidelityClause(int part, QNIC_type qt, int qi, int res, double fidelity) : Clause(part, qt, qi, res) { threshold = fidelity; };
   // bool check(qnicResources *resources) const override;
   // bool checkTerminate(qnicResources *resources) const override {return 0;} ;
-  bool check(std::multimap<int, stationaryQubit*>) const override;
-  bool checkTerminate(std::multimap<int, stationaryQubit*>) const override { return false; };
+  bool check(std::multimap<int, StationaryQubit*>) const override;
+  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override { return false; };
 };
 
 class EnoughResourceClause : public Clause {
@@ -85,8 +85,8 @@ class EnoughResourceClause : public Clause {
     num_resource_required = num_res;
     partner = part;
   };
-  bool check(std::multimap<int, stationaryQubit*>) const override;
-  bool checkTerminate(std::multimap<int, stationaryQubit*>) const override { return false; };
+  bool check(std::multimap<int, StationaryQubit*>) const override;
+  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override { return false; };
 };
 
 /**EnoughResourceClauseLeft is for checking if node have enough resource to left node.
@@ -103,8 +103,8 @@ class EnoughResourceClauseLeft : public Clause {
     partner_left = part_left;
   }
 
-  bool check(std::multimap<int, stationaryQubit*>) const override;
-  bool checkTerminate(std::multimap<int, stationaryQubit*>) const override { return false; };
+  bool check(std::multimap<int, StationaryQubit*>) const override;
+  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override { return false; };
 };
 
 class EnoughResourceClauseRight : public Clause {
@@ -118,8 +118,8 @@ class EnoughResourceClauseRight : public Clause {
     partner_right = part_right;
   }
 
-  bool check(std::multimap<int, stationaryQubit*>) const override;
-  bool checkTerminate(std::multimap<int, stationaryQubit*>) const override { return false; };
+  bool check(std::multimap<int, StationaryQubit*>) const override;
+  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override { return false; };
 };
 
 class NoClause : public Clause {
@@ -130,8 +130,8 @@ class NoClause : public Clause {
         };
   // bool check(qnicResources *resources) const override {return true;};
   // bool checkTerminate(qnicResources *resources) const override {return false;} ;
-  bool check(std::multimap<int, stationaryQubit*>) const override { return true; };
-  bool checkTerminate(std::multimap<int, stationaryQubit*>) const override { return false; };
+  bool check(std::multimap<int, StationaryQubit*>) const override { return true; };
+  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override { return false; };
 };
 
 class MeasureCountClause : public Clause {
@@ -148,8 +148,8 @@ class MeasureCountClause : public Clause {
   };
   // bool check(qnicResources *resources) const override;
   // bool checkTerminate(qnicResources *resources) const override;
-  bool check(std::multimap<int, stationaryQubit*>) const override;
-  bool checkTerminate(std::multimap<int, stationaryQubit*>) const override;
+  bool check(std::multimap<int, StationaryQubit*>) const override;
+  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override;
   // void increment(){current_count++;};
 };
 
@@ -165,7 +165,7 @@ class PurificationCountClause : public Clause {
 
   // bool check(qnicResources *resources) const override;
   // bool checkTerminate(qnicResources *resources) const override;
-  bool check(std::multimap<int, stationaryQubit*>) const override;
+  bool check(std::multimap<int, StationaryQubit*>) const override;
   // void increment(){current_count++;};
 };
 

--- a/quisp/rules/Condition.cc
+++ b/quisp/rules/Condition.cc
@@ -25,7 +25,7 @@ bool Condition::check(qnicResources *resources) const {
 }
 */
 
-bool Condition::check(std::multimap<int, stationaryQubit*> resources) const {
+bool Condition::check(std::multimap<int, StationaryQubit*> resources) const {
   EV << "In condition...\n";
   bool satisfying = true;
   for (auto clause = cbegin(), end = cend(); clause != end; clause++) {
@@ -50,7 +50,7 @@ bool Condition::checkTerminate(qnicResources *resources) const {
     return satisfying;
 }*/
 
-bool Condition::checkTerminate(std::multimap<int, stationaryQubit*> resources) const {
+bool Condition::checkTerminate(std::multimap<int, StationaryQubit*> resources) const {
   bool satisfying = false;
   for (auto clause = cbegin(), end = cend(); clause != end; clause++) {
     if ((*clause)->checkTerminate(resources)) {

--- a/quisp/rules/Condition.h
+++ b/quisp/rules/Condition.h
@@ -23,9 +23,9 @@ class Condition : std::list<pClause> {
   void addClause(Clause* c) { push_back(pClause(c)); };
   void addClause(pClause& c) { push_back(pClause(std::move(c))); };
   // bool check(qnicResources * resources) const;
-  bool check(std::multimap<int, stationaryQubit*> resources) const;
+  bool check(std::multimap<int, StationaryQubit*> resources) const;
   // bool checkTerminate(qnicResources * resources) const;
-  bool checkTerminate(std::multimap<int, stationaryQubit*> resources) const;
+  bool checkTerminate(std::multimap<int, StationaryQubit*> resources) const;
 };
 typedef std::unique_ptr<Condition> pCondition;
 

--- a/quisp/rules/Rule.cc
+++ b/quisp/rules/Rule.cc
@@ -14,7 +14,7 @@
 namespace quisp {
 namespace rules {
 
-void Rule::addResource(int address_entangled_with, stationaryQubit *qubit) {
+void Rule::addResource(int address_entangled_with, StationaryQubit *qubit) {
   // int index = number_of_resources_allocated_in_total;
   // this index must be entangled partner (this must be updated)
   resources.insert(std::make_pair(address_entangled_with, qubit));  // Assign resource to the 1st Rule.

--- a/quisp/rules/Rule.h
+++ b/quisp/rules/Rule.h
@@ -27,7 +27,7 @@ class Rule {
   int rule_index;
   pCondition condition;
   pAction action;
-  std::multimap<int, stationaryQubit *> resources;
+  std::multimap<int, StationaryQubit *> resources;
   int mutable number_of_resources_allocated_in_total = 0;
   // std::unique_ptr<Rule> next_rule;
   Rule(){};
@@ -36,10 +36,10 @@ class Rule {
     rule_index = r_index;
   };
 
-  void addResource(int address_entangled_with, stationaryQubit *qubit);
+  void addResource(int address_entangled_with, StationaryQubit *qubit);
   void setCondition(Condition *c);
   void setAction(Action *a);
-  void eraseResource(stationaryQubit *qubit){
+  void eraseResource(StationaryQubit *qubit){
       /*bool erased = false;
       for (auto it =  rc.cbegin(), next_it =  rc.cbegin(); it !=  rc.cend(); it = next_it){
           next_it = it; ++next_it;

--- a/quisp/rules/tools.h
+++ b/quisp/rules/tools.h
@@ -34,14 +34,14 @@ static stationaryQubit* getPurifiedQubit_fromTop(qnicResources* resources, QNIC_
     return NULL;
 }*/
 
-static stationaryQubit* getUnLockedQubit_fromTop(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) {
+static StationaryQubit* getUnLockedQubit_fromTop(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) {
   std::pair<EntangledPairs::iterator, EntangledPairs::iterator> ret = resources[qtype][qid].equal_range(partner);  // Find all resource in qytpe/qid entangled with partner.
   int real_res_id = 0;
   for (EntangledPairs::iterator it = ret.first; it != ret.second; ++it) {
     // std::cout << real_res_id << '\n';
     if (!it->second->isLocked()) {
       if (real_res_id == res_id) {
-        stationaryQubit* pt = it->second;
+        StationaryQubit* pt = it->second;
         return pt;
       } else {
         real_res_id++;
@@ -53,7 +53,7 @@ static stationaryQubit* getUnLockedQubit_fromTop(qnicResources* resources, QNIC_
 
 /** \func static stationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id)*/
 
-static stationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) {
+static StationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) {
   // assume that qnic type is ok
   std::pair<EntangledPairs::iterator, EntangledPairs::iterator> ret = resources[qtype][qid].equal_range(partner);  // Find all resource in qytpe/qid entangled with partner.
   // stationaryQubit *use_this_qubit;
@@ -62,7 +62,7 @@ static stationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int 
   for (EntangledPairs::iterator it = ret.first; it != ret.second; ++it, ++real_res_id) {
     // std::cout << real_res_id << '\n';
     if (real_res_id == res_id) {
-      stationaryQubit* pt = it->second;
+      StationaryQubit* pt = it->second;
       // RuleEngine re;
       // re.freeResource(qid, it->second->par("stationaryQubit_address"), qtype);
       // re.JustATest();
@@ -77,18 +77,18 @@ static stationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int 
   return nullptr;
 }
 
-static stationaryQubit* getQubitPurified(qnicResources* resources, QNIC_type qtype, int qid, int partner, int num_purified_must) {
+static StationaryQubit* getQubitPurified(qnicResources* resources, QNIC_type qtype, int qid, int partner, int num_purified_must) {
   std::pair<EntangledPairs::iterator, EntangledPairs::iterator> ret = resources[qtype][qid].equal_range(partner);  // Find all resource in qytpe/qid entangled with partner.
   for (EntangledPairs::iterator it = ret.first; it != ret.second; ++it) {
     if (it->second->num_purified == num_purified_must && !it->second->isLocked()) {
-      stationaryQubit* pt = it->second;
+      StationaryQubit* pt = it->second;
       return pt;
     }
   }
   return nullptr;
 }
 
-static stationaryQubit* getQubit(cModule* re, qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) {
+static StationaryQubit* getQubit(cModule* re, qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id) {
   // assume that qnic type is ok
   std::pair<EntangledPairs::iterator, EntangledPairs::iterator> ret = resources[qtype][qid].equal_range(partner);  // Find all resource in qytpe/qid entangled with partner.
   // stationaryQubit *use_this_qubit;
@@ -97,7 +97,7 @@ static stationaryQubit* getQubit(cModule* re, qnicResources* resources, QNIC_typ
   for (EntangledPairs::iterator it = ret.first; it != ret.second; ++it, ++real_res_id) {
     // std::cout << real_res_id << '\n';
     if (real_res_id == res_id) {
-      stationaryQubit* pt = it->second;
+      StationaryQubit* pt = it->second;
       // rule_engine->JustATest();
       return pt;
 


### PR DESCRIPTION
# TL;DR
* introduce clang-tidy and [its config](https://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html)
* use CamelCase [class names](https://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html#cmdoption-arg-classcase)
* remove unused struct names
