### PR TITLE
Refactor connection manager part 1

### DIFF
--- a/quisp/modules/ConnectionManager.cc
+++ b/quisp/modules/ConnectionManager.cc
@@ -5,14 +5,8 @@
  *
  *  \brief ConnectionManager
  */
-#include <classical_messages_m.h>
-#include <modules/QNIC.h>
-#include <omnetpp.h>
-#include <rules/RuleSet.h>
-#include <vector>
-#include "HardwareMonitor.h"
-#include "RoutingDaemon.h"
-#include "RuleEngine.h"
+
+#include "ConnectionManager.h"
 
 using namespace omnetpp;
 using namespace quisp::messages;
@@ -21,90 +15,10 @@ using namespace quisp::rules;
 namespace quisp {
 namespace modules {
 
-typedef struct swapping_rule_table {  // This is a little bit redundunt
-  int left_partner;
-  QNIC_type lqnic_type;
-  int lqnic_index;
-  int lqnic_address;
-  int lres;
-  int right_partner;
-  QNIC_type rqnic_type;
-  int rqnic_index;
-  int rqnic_address;
-  int rres;
-  int self_left_qnic_index;
-  QNIC_type self_left_qnic_type;
-  int self_right_qnic_index;
-  QNIC_type self_right_qnic_type;
-} swap_table;
-
-/** \class ConnectionManager ConnectionManager.cc
- *  \todo Documentation of the class header.
- *
- *  \brief ConnectionManager
- *
- * The ConnectionManager is one of the five key modules in the
- * software for a quantum repeater/router (qrsa).  It is responsible for
- * managing the connections: initiating ConnectionSetupRequests,
- * behaving as responder for a ConnectionSetupRequest (which involves
- * actually creating the RuleSets), and handling the requests and
- * responses as the move along the path at setup time.
- *
- * It communicates with the RuleEngine, which is responsible for
- * actually executing the Rules as it is notified of events, but
- * the ConnectionManager has _nothing_ to do with the actual
- * processing of the quantum states as they evolve.
- *
- * You will see member functions for the roles as initiator, responder,
- * and intermediate node.  The main tasks are to respond to ConnectionSetupRequest,
- * ConnectionSetupResponse, RejectConnectionSetupRequest, and ConnectionTeardown messages.
- *
- * It is also responsible for the end-to-end reservation of resources,
- * as dictated by the multiplexing (muxing) discpline in use.
- */
-class ConnectionManager : public cSimpleModule {
- private:
-  int myAddress;
-  int num_of_qnics;
-  std::map<int, bool> qnic_res_table;
-  RoutingDaemon *routingdaemon;
-  HardwareMonitor *hardwaremonitor;
-
- protected:
-  virtual void initialize() override;
-
-  virtual void handleMessage(cMessage *msg) override;
-  virtual void responder_alloc_req_handler(ConnectionSetupRequest *pk);
-  virtual void intermediate_alloc_req_handler(ConnectionSetupRequest *pk);
-
-  virtual void initiator_alloc_res_handler(ConnectionSetupResponse *pk);
-  virtual void intermediate_alloc_res_handler(ConnectionSetupResponse *pk);
-
-  virtual void responder_reject_req_handler(RejectConnectionSetupRequest *pk);
-  virtual void intermediate_reject_req_handler(RejectConnectionSetupRequest *pk);
-
-  // virtual RuleSet* generateRuleSet_EntanglementSwapping(unsigned int RuleSet_id,int owner, int left_node, QNIC_type lqnic_type, int lqnic_index, int lres, int right_node,
-  // QNIC_type rqnic_type, int rqnic_index, int rres);
-  virtual RuleSet *generateRuleSet_Tomography(unsigned long RuleSet_id, int owner, int partner, int num_measure, QNIC_type qnic_type, int qnic_index, int num_resources);
-  virtual RuleSet *generateRuleSet_EntanglementSwapping(unsigned long RuleSet_id, int owner, swap_table conf);
-  virtual swap_table EntanglementSwappingConfig(int swapper_address, std::vector<int> path, std::map<int, std::vector<int>> swapping_partners, std::vector<QNIC_pair_info> qnics,
-                                                int num_resources);
-
-  virtual void reserve_qnic(int qnic_address);
-  virtual void release_qnic(int qnic_address);
-  virtual bool isQnic_busy(int qnic_address);
-
-  virtual unsigned long createUniqueId();
-};
-
-Define_Module(ConnectionManager);
-
 void ConnectionManager::initialize() {
-  EV << "ConnectionManager booted\n";
-  cModule *rd = getParentModule()->getSubmodule("rd");
-  routingdaemon = check_and_cast<RoutingDaemon *>(rd);
-  cModule *hm = getParentModule()->getSubmodule("hm");
-  hardwaremonitor = check_and_cast<HardwareMonitor *>(hm);
+  EV_DEBUG << "ConnectionManager booted\n";
+  routingdaemon = check_and_cast<RoutingDaemon *>(getParentModule()->getSubmodule("rd"));
+  hardwaremonitor = check_and_cast<HardwareMonitor *>(getParentModule()->getSubmodule("hm"));
   myAddress = par("address");
   num_of_qnics = par("total_number_of_qnics");
 

--- a/quisp/modules/ConnectionManager.cc
+++ b/quisp/modules/ConnectionManager.cc
@@ -16,9 +16,8 @@ namespace quisp {
 namespace modules {
 
 void ConnectionManager::initialize() {
-  EV_DEBUG << "ConnectionManager booted\n";
-  routingdaemon = check_and_cast<RoutingDaemon *>(getParentModule()->getSubmodule("rd"));
-  hardwaremonitor = check_and_cast<HardwareMonitor *>(getParentModule()->getSubmodule("hm"));
+  routing_daemon = check_and_cast<RoutingDaemon *>(getParentModule()->getSubmodule("rd"));
+  hardware_monitor = check_and_cast<HardwareMonitor *>(getParentModule()->getSubmodule("hm"));
   myAddress = par("address");
   num_of_qnics = par("total_number_of_qnics");
 
@@ -29,8 +28,7 @@ void ConnectionManager::initialize() {
 }
 
 /**
- * The catch-all handler for messages received.  Needs to confirm the packet
- * type and call the appropriate lower-level handler.
+ * The catch-all handler for messages received.  Needs to confirm the packet type and call the appropriate lower-level handler.
  * \param msg pointer to the cMessage itself
  */
 void ConnectionManager::handleMessage(cMessage *msg) {
@@ -46,9 +44,9 @@ void ConnectionManager::handleMessage(cMessage *msg) {
       return;
     }
 
-    int local_qnic_address_to_actual_dst = routingdaemon->return_QNIC_address_to_destAddr(actual_dst);
-    connection_setup_inf dst_inf = hardwaremonitor->return_setupInf(local_qnic_address_to_actual_dst);
-    bool is_qnic_available = isQnic_busy(dst_inf.qnic.address);
+    int local_qnic_address_to_actual_dst = routing_daemon->return_QNIC_address_to_destAddr(actual_dst);
+    connection_setup_inf dst_inf = hardware_monitor->return_setupInf(local_qnic_address_to_actual_dst);
+    bool is_qnic_available = isQnicBusy(dst_inf.qnic.address);
     bool requested_by_myself = actual_src == myAddress;
 
     if (requested_by_myself) {
@@ -83,11 +81,11 @@ void ConnectionManager::handleMessage(cMessage *msg) {
 
     if (initiator_addr == myAddress || responder_addr == myAddress) {
       // this node is not a swapper
-      initiator_alloc_res_handler(pk);
+      storeRuleSetForApplication(pk);
     } else {
       // this node is a swapper (intermediate node)
       // currently, destinations are separated. (Not accumulated.)
-      intermediate_alloc_res_handler(pk);
+      storeRuleSet(pk);
     }
     delete msg;
     return;
@@ -105,23 +103,32 @@ void ConnectionManager::handleMessage(cMessage *msg) {
   }
 }
 
-// might just be 2*l
-static int compute_path_division_size(int l /**< number of links (path length, number of nodes -1) */) {
+/**
+ * \param number of links (path length, number of nodes -1
+ **/
+int ConnectionManager::computePathDivisionSize(int l) {
   if (l > 1) {
     int hl = (l >> 1);
-    return compute_path_division_size(hl) + compute_path_division_size(l - hl) + 1;
+    return computePathDivisionSize(hl) + computePathDivisionSize(l - hl) + 1;
   }
   return l;
 }
 
-/** Treat subpath [i:...] of length l */
-static int fill_path_division(std::vector<int> path /**< Nodes on the connection setup path */, int i /**< Left of the subpath to consider */, int l /**< Length of the subpath */,
-                              int *link_left /**< Left part of the list of "links" */, int *link_right /**< Right part */,
-                              int *swapper /**< Swappers to create those links (might be -1 for real links) */, int fill_start /** [0:fill_start[ is already filled */) {
+/**
+ * Treat subpath [i:...] of length l
+ * \param path Nodes on the connection setup path
+ * \param i Left of the subpath to consider
+ * \param l Length of the subpath
+ * \param link_left Left part of the list of "links"
+ * \param link_right Right part
+ * \param swapper Swappers to create those links (might be -1 for real links)
+ * \param fill_start [0:fill_start[ is already filled
+ **/
+int ConnectionManager::fillPathDivision(std::vector<int> path, int i, int l, int *link_left, int *link_right, int *swapper, int fill_start) {
   if (l > 1) {
     int hl = (l >> 1);
-    fill_start = fill_path_division(path, i, hl, link_left, link_right, swapper, fill_start);
-    fill_start = fill_path_division(path, i + hl, l - hl, link_left, link_right, swapper, fill_start);
+    fill_start = fillPathDivision(path, i, hl, link_left, link_right, swapper, fill_start);
+    fill_start = fillPathDivision(path, i + hl, l - hl, link_left, link_right, swapper, fill_start);
     swapper[fill_start] = path.at(i + hl);
   }
   if (l > 0) {
@@ -134,7 +141,7 @@ static int fill_path_division(std::vector<int> path /**< Nodes on the connection
 }
 
 /**
- *  This function is called to handle the ConnectionSetupResponse at the initiator.
+ *  This function is called to handle the ConnectionSetupResponse at the intermediate node.
  * \param pk pointer to the ConnectionSetupRequest packet itself
  * \returns nothing
  *
@@ -144,12 +151,12 @@ static int fill_path_division(std::vector<int> path /**< Nodes on the connection
  *
  * \todo Where should timeouts and error handling happen?
  **/
-void ConnectionManager::intermediate_alloc_res_handler(ConnectionSetupResponse *pk) {
-  // here return ack?
+void ConnectionManager::storeRuleSet(ConnectionSetupResponse *pk) {
   InternalRuleSetForwarding *pk_internal = new InternalRuleSetForwarding;
   pk_internal->setDestAddr(pk->getDestAddr());
   pk_internal->setSrcAddr(pk->getDestAddr());
-  pk_internal->setKind(4);  // if here is setKind(1), packet is gonna go to App automatically.
+
+  pk_internal->setKind(4);
 
   pk_internal->setRuleSet_id(pk->getRuleSet_id());
   pk_internal->setRuleSet(pk->getRuleSet());
@@ -157,22 +164,18 @@ void ConnectionManager::intermediate_alloc_res_handler(ConnectionSetupResponse *
 }
 
 /**
- *  This function is called to handle the ConnectionSetupResponse at an "intermediate"
- *  node, one that is neither the initiator nor the responder.
+ *  This function is called to handle the ConnectionSetupResponse at an end node
  * \param pk pointer to the ConnectionSetupRequest packet itself
  * \returns nothing
  *
- * The only job here is to unpack the RuleSets, feed them to the RuleEngine, and
- * start the connection running.
+ * The only job here is to unpack the RuleSets, feed them to the RuleEngine,
+ * and start the connection running.
  **/
-void ConnectionManager::initiator_alloc_res_handler(ConnectionSetupResponse *pk) {
-  // forward swapping rule
-  // FIXME HACK This might not be better.
+void ConnectionManager::storeRuleSetForApplication(ConnectionSetupResponse *pk) {
   InternalRuleSetForwarding_Application *pk_internal = new InternalRuleSetForwarding_Application;
   pk_internal->setDestAddr(pk->getDestAddr());
   pk_internal->setSrcAddr(pk->getDestAddr());  // Should be original Src here?
-  pk_internal->setKind(4);  // if here is setKind(1), packet is gonna go to App automatically.
-
+  pk_internal->setKind(4);
   pk_internal->setRuleSet_id(pk->getRuleSet_id());
   pk_internal->setRuleSet(pk->getRuleSet());
   pk_internal->setApplication_type(pk->getApplication_type());
@@ -189,7 +192,7 @@ void ConnectionManager::initiator_alloc_res_handler(ConnectionSetupResponse *pk)
  * The procedure:
  * \verbatim
  * 1. figure out swapping order & partners by calling EntanglementSwappingConfig
- * 2. generate all the RuleSets by calling generateRuleSet_EntanglementSwapping
+ * 2. generate all the RuleSets by calling generateEntanglementSwappingRuleSet
  * 3. return ConnectionSetupResponse to each node in this connection.
  * \endverbatim
  * \todo Always room to make this better.  Ideally should be
@@ -199,13 +202,13 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
   // Taking qnic information of responder node.
   int actual_dst = pk->getActual_destAddr();
   int actual_src = pk->getActual_srcAddr();  // initiator address (to get input qnic)
-  int local_qnic_address_to_actual_dst = routingdaemon->return_QNIC_address_to_destAddr(actual_dst);  // This must be -1
-  int local_qnic_address_to_actual_src = routingdaemon->return_QNIC_address_to_destAddr(actual_src);  // TODO: premise only oneconnection allowed btw, two nodes.
-  connection_setup_inf dst_inf = hardwaremonitor->return_setupInf(local_qnic_address_to_actual_dst);
-  connection_setup_inf src_inf = hardwaremonitor->return_setupInf(local_qnic_address_to_actual_src);
+  int local_qnic_address_to_actual_dst = routing_daemon->return_QNIC_address_to_destAddr(actual_dst);  // This must be -1
+  int local_qnic_address_to_actual_src = routing_daemon->return_QNIC_address_to_destAddr(actual_src);  // TODO: premise only oneconnection allowed btw, two nodes.
+  connection_setup_inf dst_inf = hardware_monitor->return_setupInf(local_qnic_address_to_actual_dst);
+  connection_setup_inf src_inf = hardware_monitor->return_setupInf(local_qnic_address_to_actual_src);
   QNIC_id_pair pair_info = {.fst = src_inf.qnic, .snd = dst_inf.qnic};
-  bool isReserved_src = isQnic_busy(src_inf.qnic.address);
-  bool isReserved_dst = isQnic_busy(dst_inf.qnic.address);
+  bool isReserved_src = isQnicBusy(src_inf.qnic.address);
+  bool isReserved_dst = isQnicBusy(dst_inf.qnic.address);
   if (!isReserved_src && !isReserved_dst) {
     // the number of steps
     int hop_count = pk->getStack_of_QNodeIndexesArraySize();
@@ -218,10 +221,10 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
       path.push_back(pk->getStack_of_QNodeIndexes(i));
     }
     path.push_back(myAddress);
-    int divisions = compute_path_division_size(hop_count);
+    int divisions = computePathDivisionSize(hop_count);
     int *link_left = new int[divisions], *link_right = new int[divisions], *swapper = new int[divisions];
-    // fill_path_division should yield *exactly* the anticipated number of divisions.
-    if (fill_path_division(path, 0, hop_count, link_left, link_right, swapper, 0) < divisions) {
+    // fillPathDivision should yield *exactly* the anticipated number of divisions.
+    if (fillPathDivision(path, 0, hop_count, link_left, link_right, swapper, 0) < divisions) {
       error("Something went wrong in path division computation.");
     }
     std::map<int, std::vector<int>> swapping_partners;
@@ -235,14 +238,14 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
       }
     }
     /* TODO: Remember you have link costs <3
-    for(int i = 0; i<hop_count; i++){
-        //The link cost is just a dummy variable (constant 1 for now and how it is set in a bad way (read from the channel but from only 1 channels from Src->BSA and ignoring
-    BSA->Dest).
-        //If you need to test with different costs, try changing the value.
-        //But we need to implement actual link-tomography for this eventually.
-        EV<<"\nThis is one of the stacked link costs....."<<pk->getStack_of_linkCosts(i)<<"\n";
-    }
-    */
+     for(int i = 0; i<hop_count; i++){
+     //The link cost is just a dummy variable (constant 1 for now and how it is set in a bad way (read from the channel but from only 1 channels from Src->BSA and ignoring
+     BSA->Dest).
+     //If you need to test with different costs, try changing the value.
+     //But we need to implement actual link-tomography for this eventually.
+     EV<<"\nThis is one of the stacked link costs....."<<pk->getStack_of_linkCosts(i)<<"\n";
+     }
+     */
     // getting swappers index as vector(This might be redundant FIXME)
     std::vector<int> swappers = {};
     for (int i = 0; i < divisions; i++) {
@@ -289,7 +292,7 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
         // here we have to check the order of entanglement swapping
         swap_table swap_config;  // swapping configurations for path[i]
         swap_config = EntanglementSwappingConfig(path.at(i), path, swapping_partners, qnics, num_resource);
-        RuleSet *swapping_rule = generateRuleSet_EntanglementSwapping(createUniqueId(), path.at(i), swap_config);
+        RuleSet *swapping_rule = generateEntanglementSwappingRuleSet(createUniqueId(), path.at(i), swap_config);
         ConnectionSetupResponse *pkr = new ConnectionSetupResponse;
         pkr->setDestAddr(path.at(i));
         pkr->setSrcAddr(myAddress);
@@ -303,10 +306,10 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
         int num_measure = pk->getNum_measure();
         RuleSet *tomography_ruleset = nullptr;
         if (i == 0) {  // if this is initiater
-          tomography_ruleset = generateRuleSet_Tomography(createUniqueId(), path.at(i), path.at(path.size() - 1), num_measure, qnics.at(qnics.size() - 1).fst.type,
-                                                          qnics.at(qnics.size() - 1).fst.index, num_resource);
+          tomography_ruleset = generateTomographyRuleSet(createUniqueId(), path.at(i), path.at(path.size() - 1), num_measure, qnics.at(qnics.size() - 1).fst.type,
+                                                         qnics.at(qnics.size() - 1).fst.index, num_resource);
         } else {  // if this is responder
-          tomography_ruleset = generateRuleSet_Tomography(createUniqueId(), path.at(i), path.at(0), num_measure, qnics.at(0).snd.type, qnics.at(0).snd.index, num_resource);
+          tomography_ruleset = generateTomographyRuleSet(createUniqueId(), path.at(i), path.at(0), num_measure, qnics.at(0).snd.type, qnics.at(0).snd.index, num_resource);
         }
         if (tomography_ruleset != nullptr) {
           ConnectionSetupResponse *pkr = new ConnectionSetupResponse;
@@ -327,10 +330,10 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
       }
     }
     if (actual_dst != myAddress) {
-      reserve_qnic(src_inf.qnic.address);
-      reserve_qnic(dst_inf.qnic.address);
+      reserveQnic(src_inf.qnic.address);
+      reserveQnic(dst_inf.qnic.address);
     } else {
-      reserve_qnic(src_inf.qnic.address);
+      reserveQnic(src_inf.qnic.address);
     }
   } else {
     RejectConnectionSetupRequest *pkt = new RejectConnectionSetupRequest;
@@ -493,11 +496,6 @@ swap_table ConnectionManager::EntanglementSwappingConfig(int swapper_address, st
   return swap_setting;
 }
 
-// RuleSet **ConnectionManager::generate_RuleSet( int *stack_of_QNodeIndexes,
-//                                           int *stack_of_linkCosts,
-//                                           QNIC_pair_info *stack_of_QNICs){
-// }
-
 /**
  *  This function is called to handle the ConnectionSetupRequest at an "intermediate"
  *  node, one that is neither the initiator nor the responder.
@@ -507,10 +505,10 @@ swap_table ConnectionManager::EntanglementSwappingConfig(int swapper_address, st
 void ConnectionManager::intermediate_alloc_req_handler(ConnectionSetupRequest *pk) {
   int actual_dst = pk->getActual_destAddr();  // responder address
   int actual_src = pk->getActual_srcAddr();  // initiator address (to get input qnic)
-  int local_qnic_address_to_actual_dst = routingdaemon->return_QNIC_address_to_destAddr(actual_dst);
+  int local_qnic_address_to_actual_dst = routing_daemon->return_QNIC_address_to_destAddr(actual_dst);
 
   // TODO: premise only oneconnection allowed btw, two nodes.
-  int local_qnic_address_to_actual_src = routingdaemon->return_QNIC_address_to_destAddr(actual_src);
+  int local_qnic_address_to_actual_src = routing_daemon->return_QNIC_address_to_destAddr(actual_src);
 
   // TODO here need to check
   if (local_qnic_address_to_actual_dst == -1) {  // is not found
@@ -521,17 +519,17 @@ void ConnectionManager::intermediate_alloc_req_handler(ConnectionSetupRequest *p
     // Use the QNIC address to find the next hop QNode,
     // by asking the Hardware Monitor (neighbor table).
     EV << "Source : " << pk->getSrcAddr() << " qnic_for_actual_dst : " << local_qnic_address_to_actual_dst << "\n";
-    connection_setup_inf dst_inf = hardwaremonitor->return_setupInf(local_qnic_address_to_actual_dst);
+    connection_setup_inf dst_inf = hardware_monitor->return_setupInf(local_qnic_address_to_actual_dst);
     EV << "DST_INF " << dst_inf.qnic.type << "," << dst_inf.qnic.index << "\n";
-    connection_setup_inf src_inf = hardwaremonitor->return_setupInf(local_qnic_address_to_actual_src);
+    connection_setup_inf src_inf = hardware_monitor->return_setupInf(local_qnic_address_to_actual_src);
     EV << "SRC_INF " << src_inf.qnic.type << "," << src_inf.qnic.index << "\n";
     // if(reservation){
     //   EV<<"reserved!"<<myAddress<<":"<<local_qnic_address_to_actual_dst<<"\n";
     // }else{
     //   EV<<"not reserved!"<<myAddress<<":"<<local_qnic_address_to_actual_dst<<"\n";
     // }
-    bool isReserved_src = isQnic_busy(src_inf.qnic.address);
-    bool isReserved_dst = isQnic_busy(dst_inf.qnic.address);
+    bool isReserved_src = isQnicBusy(src_inf.qnic.address);
+    bool isReserved_dst = isQnicBusy(dst_inf.qnic.address);
     if (!isReserved_src && !isReserved_dst) {
       int num_accumulated_nodes = pk->getStack_of_QNodeIndexesArraySize();
       int num_accumulated_costs = pk->getStack_of_linkCostsArraySize();
@@ -549,8 +547,8 @@ void ConnectionManager::intermediate_alloc_req_handler(ConnectionSetupRequest *p
       pk->setStack_of_QNICs(num_accumulated_pair_info, pair_info);
       pair_info = pk->getStack_of_QNICs(num_accumulated_pair_info);
       if (actual_src != myAddress) {
-        reserve_qnic(src_inf.qnic.address);
-        reserve_qnic(dst_inf.qnic.address);
+        reserveQnic(src_inf.qnic.address);
+        reserveQnic(dst_inf.qnic.address);
       }
       send(pk, "RouterPort$o");
     } else {  // TODO after connection expired, this goes to false
@@ -566,7 +564,7 @@ void ConnectionManager::intermediate_alloc_req_handler(ConnectionSetupRequest *p
   }
 }
 // This is not good way. This property should be held in qnic property.
-void ConnectionManager::reserve_qnic(int qnic_address) {
+void ConnectionManager::reserveQnic(int qnic_address) {
   auto it = qnic_res_table.find(qnic_address);
   if (it != qnic_res_table.end() && !it->second) {
     it->second = true;
@@ -576,7 +574,7 @@ void ConnectionManager::reserve_qnic(int qnic_address) {
   }
 }
 
-void ConnectionManager::release_qnic(int qnic_address) {
+void ConnectionManager::releaseQnic(int qnic_address) {
   auto it = qnic_res_table.find(qnic_address);
   if (it != qnic_res_table.end() && it->second) {
     it->second = false;
@@ -585,7 +583,7 @@ void ConnectionManager::release_qnic(int qnic_address) {
   }
 }
 
-bool ConnectionManager::isQnic_busy(int qnic_address) {
+bool ConnectionManager::isQnicBusy(int qnic_address) {
   bool isReserved = false;
   auto it = qnic_res_table.find(qnic_address);
   if (it != qnic_res_table.end()) {
@@ -621,17 +619,21 @@ void ConnectionManager::intermediate_reject_req_handler(RejectConnectionSetupReq
   int actual_dst = pk->getActual_destAddr();  // responder address
   int actual_src = pk->getActual_srcAddr();  // initiator address (to get input qnic)
   // Currently, sending path and returning path are same, but for future, this might not good way
-  int local_qnic_address_to_actual_dst = routingdaemon->return_QNIC_address_to_destAddr(actual_dst);
-  int local_qnic_address_to_actual_src = routingdaemon->return_QNIC_address_to_destAddr(actual_src);
-  connection_setup_inf dst_inf = hardwaremonitor->return_setupInf(local_qnic_address_to_actual_dst);
-  connection_setup_inf src_inf = hardwaremonitor->return_setupInf(local_qnic_address_to_actual_src);
+  int local_qnic_address_to_actual_dst = routing_daemon->return_QNIC_address_to_destAddr(actual_dst);
+  int local_qnic_address_to_actual_src = routing_daemon->return_QNIC_address_to_destAddr(actual_src);
+  connection_setup_inf dst_inf = hardware_monitor->return_setupInf(local_qnic_address_to_actual_dst);
+  connection_setup_inf src_inf = hardware_monitor->return_setupInf(local_qnic_address_to_actual_src);
   if (myAddress != actual_dst && myAddress != actual_src) {
-    release_qnic(dst_inf.qnic.address);
-    release_qnic(src_inf.qnic.address);
-  } else if (myAddress == actual_dst) {
-    release_qnic(src_inf.qnic.address);
-  } else if (myAddress == actual_src) {
-    release_qnic(dst_inf.qnic.address);
+    releaseQnic(dst_inf.qnic.address);
+    releaseQnic(src_inf.qnic.address);
+    return;
+  }
+
+  if (myAddress == actual_dst) {
+    releaseQnic(src_inf.qnic.address);
+  }
+  if (myAddress == actual_src) {
+    releaseQnic(dst_inf.qnic.address);
   }
 }
 
@@ -650,7 +652,7 @@ void ConnectionManager::intermediate_reject_req_handler(RejectConnectionSetupReq
  * \todo Room for endless intelligence and improvements here.  Ideally should be
  * a _configurable choice_, or even a _policy_ implementation.
  **/
-RuleSet *ConnectionManager::generateRuleSet_EntanglementSwapping(unsigned long RuleSet_id, int owner, swap_table conf) {
+RuleSet *ConnectionManager::generateEntanglementSwappingRuleSet(unsigned long RuleSet_id, int owner, swap_table conf) {
   int rule_index = 0;
   std::vector<int> partners = {conf.left_partner, conf.right_partner};
   RuleSet *EntanglementSwapping = new RuleSet(RuleSet_id, owner, partners);
@@ -672,8 +674,8 @@ RuleSet *ConnectionManager::generateRuleSet_EntanglementSwapping(unsigned long R
   return EntanglementSwapping;
 }
 
-RuleSet *ConnectionManager::generateRuleSet_Tomography(unsigned long RuleSet_id, int owner, int partner, int num_of_measure, QNIC_type qnic_type, int qnic_index,
-                                                       int num_resources) {
+RuleSet *ConnectionManager::generateTomographyRuleSet(unsigned long RuleSet_id, int owner, int partner, int num_of_measure, QNIC_type qnic_type, int qnic_index,
+                                                      int num_resources) {
   // tomography ruleset
   int rule_index = 0;
   RuleSet *tomography = new RuleSet(RuleSet_id, owner, partner);

--- a/quisp/modules/ConnectionManager.h
+++ b/quisp/modules/ConnectionManager.h
@@ -70,33 +70,33 @@ class ConnectionManager : public cSimpleModule {
   int myAddress;
   int num_of_qnics;
   std::map<int, bool> qnic_res_table;
-  RoutingDaemon *routingdaemon;
-  HardwareMonitor *hardwaremonitor;
+  RoutingDaemon *routing_daemon;
+  HardwareMonitor *hardware_monitor;
 
   virtual void initialize() override;
-
   virtual void handleMessage(cMessage *msg) override;
+
   void responder_alloc_req_handler(ConnectionSetupRequest *pk);
   void intermediate_alloc_req_handler(ConnectionSetupRequest *pk);
 
-  void initiator_alloc_res_handler(ConnectionSetupResponse *pk);
-  void intermediate_alloc_res_handler(ConnectionSetupResponse *pk);
+  void storeRuleSetForApplication(ConnectionSetupResponse *pk);
+  void storeRuleSet(ConnectionSetupResponse *pk);
 
   void responder_reject_req_handler(RejectConnectionSetupRequest *pk);
   void intermediate_reject_req_handler(RejectConnectionSetupRequest *pk);
 
-  // virtual RuleSet* generateRuleSet_EntanglementSwapping(unsigned int RuleSet_id,int owner, int left_node, QNIC_type lqnic_type, int lqnic_index, int lres, int right_node,
-  // QNIC_type rqnic_type, int rqnic_index, int rres);
-  RuleSet *generateRuleSet_Tomography(unsigned long RuleSet_id, int owner, int partner, int num_measure, QNIC_type qnic_type, int qnic_index, int num_resources);
-  RuleSet *generateRuleSet_EntanglementSwapping(unsigned long RuleSet_id, int owner, swap_table conf);
+  RuleSet *generateTomographyRuleSet(unsigned long RuleSet_id, int owner, int partner, int num_measure, QNIC_type qnic_type, int qnic_index, int num_resources);
+  RuleSet *generateEntanglementSwappingRuleSet(unsigned long RuleSet_id, int owner, swap_table conf);
   swap_table EntanglementSwappingConfig(int swapper_address, std::vector<int> path, std::map<int, std::vector<int>> swapping_partners, std::vector<QNIC_pair_info> qnics,
                                         int num_resources);
 
-  void reserve_qnic(int qnic_address);
-  void release_qnic(int qnic_address);
-  bool isQnic_busy(int qnic_address);
+  void reserveQnic(int qnic_address);
+  void releaseQnic(int qnic_address);
+  bool isQnicBusy(int qnic_address);
 
   unsigned long createUniqueId();
+  static int computePathDivisionSize(int l);
+  static int fillPathDivision(std::vector<int> path, int i, int l, int *link_left, int *link_right, int *swapper, int fill_start);
 };
 
 Define_Module(ConnectionManager);

--- a/quisp/modules/ConnectionManager.h
+++ b/quisp/modules/ConnectionManager.h
@@ -1,0 +1,105 @@
+/*
+ * ConnectionManager.h
+ *
+ *  Created on: Sep 14, 2020
+ *      Author: zigen
+ */
+
+#ifndef MODULES_CONNECTIONMANAGER_H_
+#define MODULES_CONNECTIONMANAGER_H_
+
+#include <classical_messages_m.h>
+#include <modules/QNIC.h>
+#include <omnetpp.h>
+#include <rules/RuleSet.h>
+#include <vector>
+#include "HardwareMonitor.h"
+#include "RoutingDaemon.h"
+#include "RuleEngine.h"
+
+using namespace omnetpp;
+using namespace quisp::messages;
+using namespace quisp::rules;
+
+namespace quisp {
+namespace modules {
+
+typedef struct swapping_rule_table {  // This is a little bit redundant
+  int left_partner;
+  QNIC_type lqnic_type;
+  int lqnic_index;
+  int lqnic_address;
+  int lres;
+  int right_partner;
+  QNIC_type rqnic_type;
+  int rqnic_index;
+  int rqnic_address;
+  int rres;
+  int self_left_qnic_index;
+  QNIC_type self_left_qnic_type;
+  int self_right_qnic_index;
+  QNIC_type self_right_qnic_type;
+} swap_table;
+
+/** \class ConnectionManager ConnectionManager.cc
+ *  \todo Documentation of the class header.
+ *
+ *  \brief ConnectionManager
+ *
+ * The ConnectionManager is one of the five key modules in the
+ * software for a quantum repeater/router (qrsa).  It is responsible for
+ * managing the connections: initiating ConnectionSetupRequests,
+ * behaving as responder for a ConnectionSetupRequest (which involves
+ * actually creating the RuleSets), and handling the requests and
+ * responses as the move along the path at setup time.
+ *
+ * It communicates with the RuleEngine, which is responsible for
+ * actually executing the Rules as it is notified of events, but
+ * the ConnectionManager has _nothing_ to do with the actual
+ * processing of the quantum states as they evolve.
+ *
+ * You will see member functions for the roles as initiator, responder,
+ * and intermediate node.  The main tasks are to respond to ConnectionSetupRequest,
+ * ConnectionSetupResponse, RejectConnectionSetupRequest, and ConnectionTeardown messages.
+ *
+ * It is also responsible for the end-to-end reservation of resources,
+ * as dictated by the multiplexing (muxing) discpline in use.
+ */
+class ConnectionManager : public cSimpleModule {
+ private:
+  int myAddress;
+  int num_of_qnics;
+  std::map<int, bool> qnic_res_table;
+  RoutingDaemon *routingdaemon;
+  HardwareMonitor *hardwaremonitor;
+
+  virtual void initialize() override;
+
+  virtual void handleMessage(cMessage *msg) override;
+  void responder_alloc_req_handler(ConnectionSetupRequest *pk);
+  void intermediate_alloc_req_handler(ConnectionSetupRequest *pk);
+
+  void initiator_alloc_res_handler(ConnectionSetupResponse *pk);
+  void intermediate_alloc_res_handler(ConnectionSetupResponse *pk);
+
+  void responder_reject_req_handler(RejectConnectionSetupRequest *pk);
+  void intermediate_reject_req_handler(RejectConnectionSetupRequest *pk);
+
+  // virtual RuleSet* generateRuleSet_EntanglementSwapping(unsigned int RuleSet_id,int owner, int left_node, QNIC_type lqnic_type, int lqnic_index, int lres, int right_node,
+  // QNIC_type rqnic_type, int rqnic_index, int rres);
+  RuleSet *generateRuleSet_Tomography(unsigned long RuleSet_id, int owner, int partner, int num_measure, QNIC_type qnic_type, int qnic_index, int num_resources);
+  RuleSet *generateRuleSet_EntanglementSwapping(unsigned long RuleSet_id, int owner, swap_table conf);
+  swap_table EntanglementSwappingConfig(int swapper_address, std::vector<int> path, std::map<int, std::vector<int>> swapping_partners, std::vector<QNIC_pair_info> qnics,
+                                        int num_resources);
+
+  void reserve_qnic(int qnic_address);
+  void release_qnic(int qnic_address);
+  bool isQnic_busy(int qnic_address);
+
+  unsigned long createUniqueId();
+};
+
+Define_Module(ConnectionManager);
+}  // namespace modules
+}  // namespace quisp
+#endif /* MODULES_CONNECTIONMANAGER_H_ */


### PR DESCRIPTION
This PR refactors ConnectionManager
* separate header file
* rename local vars lower_case
* rename methods camelCase (camelBack)
* refactor handleMessage
* fix wrong comments

I'll refactor each low-level handler in the next PR because these are too complicated to put it in this PR.