### PR TITLE
add packet name for debugging

### DIFF
--- a/quisp/modules/Application.cc
+++ b/quisp/modules/Application.cc
@@ -25,7 +25,7 @@ Application::Application() {}
 void Application::initialize() {
   // Since we only need this module in EndNode, delete it otherwise.
   if (!gate("toRouter")->isConnected()) {
-    deleteThisModule *msg = new deleteThisModule;
+    deleteThisModule *msg = new deleteThisModule("DeleteThisModule");
     scheduleAt(simTime(), msg);
     return;
   }
@@ -76,7 +76,7 @@ void Application::initialize() {
 }
 
 ConnectionSetupRequest *Application::createConnectionSetupRequest(int dest_addr, int num_of_required_resources) {
-  ConnectionSetupRequest *pk = new ConnectionSetupRequest();
+  ConnectionSetupRequest *pk = new ConnectionSetupRequest("ConnSetupRequest");
   pk->setActual_srcAddr(my_address);
   pk->setActual_destAddr(dest_addr);
   pk->setDestAddr(my_address);

--- a/quisp/modules/BellStateAnalyzer.cc
+++ b/quisp/modules/BellStateAnalyzer.cc
@@ -311,12 +311,12 @@ void BellStateAnalyzer::sendBSAresult(bool result, bool sendresults) {
   // true positive and true negative is no problem.
   // std::cout<<"send?="<<sendresults<<"___________________________________\n";
   if (!sendresults) {
-    BSAresult *pk = new BSAresult;
+    BSAresult *pk = new BSAresult("BsaResult");
     // std::cout<<"send result to HoM___\n";
     pk->setEntangled(result);
     send(pk, "toHoMController_port");
   } else {  // Was the last photon. End pulse detected.
-    BSAfinish *pk = new BSAfinish();
+    BSAfinish *pk = new BSAfinish("BsaFinish");
     pk->setKind(7);
     // std::cout<<"send last result to HoM___\n";
     pk->setEntangled(result);

--- a/quisp/modules/ConnectionManager.cc
+++ b/quisp/modules/ConnectionManager.cc
@@ -152,7 +152,7 @@ int ConnectionManager::fillPathDivision(std::vector<int> path, int i, int l, int
  * \todo Where should timeouts and error handling happen?
  **/
 void ConnectionManager::storeRuleSet(ConnectionSetupResponse *pk) {
-  InternalRuleSetForwarding *pk_internal = new InternalRuleSetForwarding;
+  InternalRuleSetForwarding *pk_internal = new InternalRuleSetForwarding("InternalRuleSetForwarding");
   pk_internal->setDestAddr(pk->getDestAddr());
   pk_internal->setSrcAddr(pk->getDestAddr());
 
@@ -172,7 +172,7 @@ void ConnectionManager::storeRuleSet(ConnectionSetupResponse *pk) {
  * and start the connection running.
  **/
 void ConnectionManager::storeRuleSetForApplication(ConnectionSetupResponse *pk) {
-  InternalRuleSetForwarding_Application *pk_internal = new InternalRuleSetForwarding_Application;
+  InternalRuleSetForwarding_Application *pk_internal = new InternalRuleSetForwarding_Application("InternalRuleSetForwardingApplication");
   pk_internal->setDestAddr(pk->getDestAddr());
   pk_internal->setSrcAddr(pk->getDestAddr());  // Should be original Src here?
   pk_internal->setKind(4);
@@ -292,8 +292,9 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
         // here we have to check the order of entanglement swapping
         swap_table swap_config;  // swapping configurations for path[i]
         swap_config = EntanglementSwappingConfig(path.at(i), path, swapping_partners, qnics, num_resource);
+
         RuleSet *swapping_rule = generateEntanglementSwappingRuleSet(createUniqueId(), path.at(i), swap_config);
-        ConnectionSetupResponse *pkr = new ConnectionSetupResponse;
+        ConnectionSetupResponse *pkr = new ConnectionSetupResponse("ConnSetupResponse(Swapping)");
         pkr->setDestAddr(path.at(i));
         pkr->setSrcAddr(myAddress);
         pkr->setKind(2);
@@ -312,7 +313,7 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
           tomography_ruleset = generateTomographyRuleSet(createUniqueId(), path.at(i), path.at(0), num_measure, qnics.at(0).snd.type, qnics.at(0).snd.index, num_resource);
         }
         if (tomography_ruleset != nullptr) {
-          ConnectionSetupResponse *pkr = new ConnectionSetupResponse;
+          ConnectionSetupResponse *pkr = new ConnectionSetupResponse("ConnSetupResponse(Tomography)");
           pkr->setDestAddr(path.at(i));
           pkr->setSrcAddr(myAddress);
           pkr->setKind(2);
@@ -336,7 +337,7 @@ void ConnectionManager::responder_alloc_req_handler(ConnectionSetupRequest *pk) 
       reserveQnic(src_inf.qnic.address);
     }
   } else {
-    RejectConnectionSetupRequest *pkt = new RejectConnectionSetupRequest;
+    RejectConnectionSetupRequest *pkt = new RejectConnectionSetupRequest("RejectConnSetup(by responder)");
     pkt->setKind(6);
     pkt->setDestAddr(pk->getActual_srcAddr());
     pkt->setSrcAddr(myAddress);
@@ -552,7 +553,7 @@ void ConnectionManager::intermediate_alloc_req_handler(ConnectionSetupRequest *p
       }
       send(pk, "RouterPort$o");
     } else {  // TODO after connection expired, this goes to false
-      RejectConnectionSetupRequest *pkt = new RejectConnectionSetupRequest;
+      RejectConnectionSetupRequest *pkt = new RejectConnectionSetupRequest("RejectConnSetup(by intermediate node)");
       pkt->setKind(6);
       pkt->setDestAddr(pk->getActual_srcAddr());
       pkt->setSrcAddr(myAddress);

--- a/quisp/modules/EntangledPhotonPairSource.cc
+++ b/quisp/modules/EntangledPhotonPairSource.cc
@@ -27,7 +27,7 @@ void EntangledPhotonPairSource::handleMessage(cMessage *msg) { send(msg, "to_qua
 
 PhotonicQubit *EntangledPhotonPairSource::generateEntangledPhotons() {
   Enter_Method("generateEntangledPhotons()");
-  PhotonicQubit *photon_one = new PhotonicQubit();
+  PhotonicQubit *photon_one = new PhotonicQubit("Photon");
   return photon_one;
   // PhotonicQubit *photon_two = new PhotonicQubit();
   // photon_one->addPar("gate") = 0;

--- a/quisp/modules/HardwareMonitor.cc
+++ b/quisp/modules/HardwareMonitor.cc
@@ -95,7 +95,7 @@ void HardwareMonitor::initialize(int stage) {
       // Not a very good solution, but makes sure that only 1 request per link is generated.
       if (myAddress > it->second.neighborQNode_address) {
         EV << "Generating tomography rules... for node " << it->second.neighborQNode_address << "\n";
-        LinkTomographyRequest *pk = new LinkTomographyRequest;
+        LinkTomographyRequest *pk = new LinkTomographyRequest("LinkTomographyRequest");
         pk->setDestAddr(it->second.neighborQNode_address);
         pk->setSrcAddr(myAddress);
         pk->setKind(6);
@@ -122,7 +122,7 @@ void HardwareMonitor::handleMessage(cMessage *msg) {
     /*Received a tomography request from neighbor*/
     LinkTomographyRequest *request = check_and_cast<LinkTomographyRequest *>(msg);
     /*Prepare an acknowledgement*/
-    LinkTomographyAck *pk = new LinkTomographyAck;
+    LinkTomographyAck *pk = new LinkTomographyAck("LinkTomographyAck");
     pk->setSrcAddr(myAddress);
     pk->setDestAddr(request->getSrcAddr());
     pk->setKind(6);
@@ -213,7 +213,7 @@ void HardwareMonitor::handleMessage(cMessage *msg) {
 
         // std::cout<<"Tomo done "<<local_qnic.address<<", in
         // node["<<myAddress<<"] \n";
-        StopEmitting *pk = new StopEmitting;
+        StopEmitting *pk = new StopEmitting("StopEmitting");
         pk->setQnic_address(local_qnic.address);
         pk->setDestAddr(myAddress);
         pk->setSrcAddr(myAddress);
@@ -586,7 +586,7 @@ specify how the resources are sorted.  Currently, this is hard-coded
 to select oldest first, and is geared toward symmetric tree.
   **/
 void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_address, QNIC_type qnic_type, int qnic_index, unsigned long RuleSet_id) {
-  LinkTomographyRuleSet *pk = new LinkTomographyRuleSet;
+  LinkTomographyRuleSet *pk = new LinkTomographyRuleSet("LinkTomographyRuleSet");
   pk->setDestAddr(my_address);
   pk->setSrcAddr(partner_address);
   pk->setNumber_of_measuring_resources(num_measure);

--- a/quisp/modules/HoM_Controller.cc
+++ b/quisp/modules/HoM_Controller.cc
@@ -49,7 +49,7 @@ void HoMController::internodeInitializer() {
   updateIDE_Parameter(true);
 
   accepted_burst_interval = (double)1 / (double)photon_detection_per_sec;
-  BSAstart *generatePacket = new BSAstart;
+  BSAstart *generatePacket = new BSAstart("BsaStart");
   scheduleAt(simTime() + par("Initial_notification_timing_buffer"), generatePacket);
   // scheduleAt(simTime(),generatePacket);
 }
@@ -66,7 +66,7 @@ void HoMController::standaloneInitializer() {
   updateIDE_Parameter(false);
 
   accepted_burst_interval = (double)1 / (double)photon_detection_per_sec;
-  BSAstart *generatePacket = new BSAstart;
+  BSAstart *generatePacket = new BSAstart("BsaStart");
   scheduleAt(simTime() + par("Initial_notification_timing_buffer"), generatePacket);
   // scheduleAt(simTime(),generatePacket);
 }
@@ -246,7 +246,7 @@ void HoMController::updateIDE_Parameter(bool receiver) {
 // Generates a BSA timing notifier. This is also called only once for the same reason as sendNotifiers().
 BSMtimingNotifier *HoMController::generateNotifier(double time, double speed_of_light_in_channel, double distance_to_neighbor, int destAddr, double accepted_burst_interval,
                                                    int photon_detection_per_sec, int max_buffer) {
-  BSMtimingNotifier *pk = new BSMtimingNotifier();
+  BSMtimingNotifier *pk = new BSMtimingNotifier("BsmTimingNotifier");
   // pk->setNumber_of_qubits(max_buffer);
   if (handshake == false)
     pk->setNumber_of_qubits(-1);  // if -1, neighbors will keep shooting photons anyway.
@@ -269,7 +269,7 @@ BSMtimingNotifier *HoMController::generateNotifier(double time, double speed_of_
 // Generates a packet that includes the BSA timing notifier and the BSA entanglement attempt results.
 CombinedBSAresults *HoMController::generateNotifier_c(double time, double speed_of_light_in_channel, double distance_to_neighbor, int destAddr, double accepted_burst_interval,
                                                       int photon_detection_per_sec, int max_buffer) {
-  CombinedBSAresults *pk = new CombinedBSAresults();
+  CombinedBSAresults *pk = new CombinedBSAresults("CombinedBsaResults");
   // pk->setNumber_of_qubits(max_buffer);
   if (handshake == false)
     pk->setNumber_of_qubits(-1);  // if -1, neighbors will keep shooting photons anyway.

--- a/quisp/modules/RuleEngine.cc
+++ b/quisp/modules/RuleEngine.cc
@@ -665,7 +665,7 @@ Interface_inf RuleEngine::getInterface_toNeighbor_Internal(int local_qnic_addres
 }
 
 void RuleEngine::scheduleFirstPhotonEmission(BSMtimingNotifier *pk, QNIC_type qnic_type) {
-  SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne;
+  SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne("SchedulePhotonTransmissionsOneByOne(First)");
   if (ntable.empty())  // Just do this once, unless the network changes during the simulation.
     ntable = hardware_monitor->passNeighborTable();  // Get neighbor table from Hardware Manager: neighbor address--> Interface_inf.
 
@@ -727,7 +727,7 @@ void RuleEngine::shootPhoton_internal(SchedulePhotonTransmissionsOnebyOne *pk) {
   }
 
   int qubit_index;
-  emt = new EmitPhotonRequest();
+  emt = new EmitPhotonRequest("EmitPhotonRequest(internal)");
   qubit_index = getOneFreeQubit_inQnic(Busy_OR_Free_QubitState_table[QNIC_R], pk->getQnic_index());
   Busy_OR_Free_QubitState_table[QNIC_R] = setQubitBusy_inQnic(Busy_OR_Free_QubitState_table[QNIC_R], pk->getQnic_index(), qubit_index);
   emt->setQubit_index(qubit_index);
@@ -759,7 +759,7 @@ void RuleEngine::shootPhoton(SchedulePhotonTransmissionsOnebyOne *pk) {
     return;
   }
 
-  emt = new EmitPhotonRequest();
+  emt = new EmitPhotonRequest("EmitPhotonRequest");
   int qubit_index = getOneFreeQubit_inQnic(Busy_OR_Free_QubitState_table[QNIC_E], pk->getQnic_index());
   Busy_OR_Free_QubitState_table[QNIC_E] = setQubitBusy_inQnic(Busy_OR_Free_QubitState_table[QNIC_E], pk->getQnic_index(), qubit_index);
   emt->setQubit_index(qubit_index);
@@ -785,7 +785,7 @@ void RuleEngine::shootPhoton(SchedulePhotonTransmissionsOnebyOne *pk) {
 }
 
 void RuleEngine::scheduleNextEmissionEvent(int qnic_index, int qnic_address, double interval, simtime_t timing, int num_sent, bool internal, int trial) {
-  SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne;
+  SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne("SchedulePhotonTransmissionsOneByOne");
   st->setQnic_index(qnic_index);
   st->setQnic_address(qnic_address);
   st->setInterval(interval);
@@ -1273,7 +1273,7 @@ void RuleEngine::traverseThroughAllProcesses2() {
             // only swapper knows which is left and right, but qnodes don't
 
             // packet for left node
-            SwappingResult *pkt_for_left = new SwappingResult;
+            SwappingResult *pkt_for_left = new SwappingResult("SwappingResult(Left)");
             pkt_for_left->setKind(5);  // cyan
             pkt_for_left->setDestAddr(pkt->getLeft_Dest());
             pkt_for_left->setSrcAddr(parentAddress);
@@ -1285,7 +1285,7 @@ void RuleEngine::traverseThroughAllProcesses2() {
             pkt_for_left->setNew_partner_qnic_type(pkt->getNew_partner_qnic_type_left());
 
             // packet for right node
-            SwappingResult *pkt_for_right = new SwappingResult;
+            SwappingResult *pkt_for_right = new SwappingResult("SwappingResult(Right)");
             pkt_for_right->setKind(5);  // cyan
             pkt_for_right->setDestAddr(pkt->getRight_Dest());
             pkt_for_right->setSrcAddr(parentAddress);

--- a/quisp/modules/SPDC_Controller.cc
+++ b/quisp/modules/SPDC_Controller.cc
@@ -99,11 +99,11 @@ void SPDC_Controller::handleMessage(cMessage *msg) {
     startPump();
   } else if (dynamic_cast<EmitPhotonRequest *>(msg) != nullptr) {
     epps->emitPhotons();
-    SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne;
+    SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne("SchedulePhotonTransmissionsOneByOne");
     scheduleAt(simTime() + max_accepted_rate, st);
   } else if (dynamic_cast<SchedulePhotonTransmissionsOnebyOne *>(msg) != nullptr) {
     epps->emitPhotons();
-    SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne;
+    SchedulePhotonTransmissionsOnebyOne *st = new SchedulePhotonTransmissionsOnebyOne("SchedulePhotonTransmissionsOneByOne");
     scheduleAt(simTime() + max_accepted_rate, st);
   }
   delete msg;
@@ -114,12 +114,12 @@ void SPDC_Controller::startPump() {
   //   emt = new  EmitPhotonRequest();
   //   scheduleAt(simTime()+timing_buffer+(max_accepted_rate*i), emt);
   // }
-  emt = new EmitPhotonRequest();
+  emt = new EmitPhotonRequest("EmitPhotonRequest");
   scheduleAt(simTime() + timing_buffer + (max_accepted_rate), emt);
 }
 
 EPPStimingNotifier *SPDC_Controller::generateNotifier(double distance_to_neighbor, double c, int destAddr) {
-  EPPStimingNotifier *pk = new EPPStimingNotifier();
+  EPPStimingNotifier *pk = new EPPStimingNotifier("EppsTimingNotifier");
   double time_to_reach = calculateTimeToTravel(distance_to_neighbor, c);
 
   // When the packet reaches = simitme()+time


### PR DESCRIPTION
This PR adds the name to the packets and then improves debuggability as the image below.
![Screen Shot 2020-09-16 at 14 08 13](https://user-images.githubusercontent.com/3610296/93295140-557eae80-f827-11ea-8f2c-3be68ef8eefb.png)

see also https://doc.omnetpp.org/omnetpp/manual/#sec:simple-modules:sending-and-receiving
> In the examples below, messages will be created with new cMessage("foo") where "foo" is a descriptive message name, used for visualization and debugging purposes. 


