### PR TITLE
Refactor photonic switch

### DIFF
--- a/quisp/Makefile
+++ b/quisp/Makefile
@@ -39,7 +39,7 @@ OBJS = \
     $O/modules/EntangledPhotonPairSource.o \
     $O/modules/HardwareMonitor.o \
     $O/modules/HoM_Controller.o \
-    $O/modules/QNIC_photonic_switch.o \
+    $O/modules/PhotonicSwitch.o \
     $O/modules/Queue.o \
     $O/modules/RealTimeController.o \
     $O/modules/ResourceManager.o \

--- a/quisp/modules/PhotonicSwitch.cc
+++ b/quisp/modules/PhotonicSwitch.cc
@@ -10,92 +10,57 @@
 namespace quisp {
 namespace modules {
 
-PhotonicSwitch::PhotonicSwitch() { generatePacket = nullptr; }
-
 void PhotonicSwitch::initialize() {
-  // Check wether this QNIC's output is connected to a single neighbor for debugging purpose.
-  checkGateNumber();
-  checkAndsetNeighborAddress();
-  ReleaseReservation();
+  ensureCorrespondingNeighborAddress();
+  release();
 }
 
-void PhotonicSwitch::checkAndsetNeighborAddress() {
+/**
+ * this method finds the corresponding neighbor node and save its address to the QNIC parameter.
+ */
+void PhotonicSwitch::ensureCorrespondingNeighborAddress() {
   // |qnic_quantum_port$o -(next gate)-> quantum_port$i | ---(next gate)---> | quantum_port$i --> fromHoM_quantum_port$i
-  cGate *gt = getParentModule()->gate("qnic_quantum_port$o");  // Inner-port of this node in qnic - connected to another qnic in another node
-  int neighbor_address = gt->getNextGate()->getNextGate()->getOwnerModule()->par("address");
+  // Inner-port of this node in qnic - connected to another qnic in another node
+  cGate *gate = getParentModule()->gate("qnic_quantum_port$o");
+  int neighbor_address = gate->getNextGate()->getNextGate()->getOwnerModule()->par("address");
   getParentModule()->par("neighbor_node_address") = neighbor_address;
-  int neighbor_qnodeAddress = gt->getNextGate()->getNextGate()->getOwnerModule()->par("address");
-  // EV<<"\n ***********************"<<gt->getNextGate()->getName()<<gt->getNextGate()->getIndex();//Outer-port of the same QNode
-  // EV<<"\n ***********************"<<gt->getNextGate()->getNextGate()->getName()<<gt->getNextGate()->getNextGate()->getIndex();//Outer-port of the connected node
-  // EV<<"\n ***********************"<<gt->getNextGate()->getNextGate()->getNextGate()->getName()<<gt->getNextGate()->getNextGate()->getNextGate()->getIndex();
-  // EV<<"\n
-  // ***********************"<<gt->getNextGate()->getNextGate()->getNextGate()->getNextGate()->getName()<<gt->getNextGate()->getNextGate()->getNextGate()->getNextGate()->getIndex();//EV<<gt->getNextGate()->getName()<<gt->getNextGate()->getIndex();
-  // cModule *qnicType = module->getModuleByPath("networks.QNode.qnic");
 }
 
-void PhotonicSwitch::handleMessage(cMessage *msg) {
-  // scheduleAt(simTime(),msg);
-  send(msg, "toQNIC_quantum_port$o");  // Just send it outside.
-  // send(msg, "toqubit_quantum_port$o",0);
-  // delete msg;
-}
-
-void PhotonicSwitch::BubbleText(const char *txt) {
-  if (hasGUI()) {
-    char text[32];
-    sprintf(text, "%s", txt);
-    bubble(text);
-  }
-}
-
-void PhotonicSwitch::checkGateNumber() {
-  std::vector<const char *> gatesss = getParentModule()->getGateNames();
-  int num = gatesss.size();
-  /*if(num!=2){//!=2 because it is also conencted to the router if interHoM exists
-      error("A single QNIC has more than one connection... Not allowed.");
-  }*/
-  for (int i = 0; i < num; i++) {
-    EV << num << " gates in  " << getParentModule()->getName() << ": " << gatesss[i] << "\n";
-  }
-}
+void PhotonicSwitch::handleMessage(cMessage *msg) { send(msg, "toQNIC_quantum_port$o"); }
 
 cModule *PhotonicSwitch::getQNode() {
-  cModule *currentModule = getParentModule();
+  cModule *module = getParentModule();
   try {
-    cModuleType *QNodeType = cModuleType::get("networks.QNode");  // Assumes the node in a network has a type QNode
-    while (currentModule->getModuleType() != QNodeType) {
-      currentModule = currentModule->getParentModule();
+    // Assumes the node in a network has a type QNode
+    cModuleType *QNodeType = cModuleType::get("networks.QNode");
+    while (module->getModuleType() != QNodeType) {
+      module = module->getParentModule();
     }
-    return currentModule;
   } catch (std::exception &e) {
-    error("No module with QNode type found as a parent node of PhotonicSwitch. Have you changed the type name in ned file?");
+    error("No QNode module found as a parent node of PhotonicSwitch. Have you changed the type name in ned file?");
     endSimulation();
   }
-  return currentModule;
+  return module;
 }
-
-void PhotonicSwitch::checkQubitNumber() {}
 
 /**
  * At the moment, the only multiplexing scheme supported is circuit switching
- * managed at the QNIC level, so we have put a single reservation boolean
- * here associated with the QNIC.
- * On processing of a ConnectionSetupRequest, this flag is checked and if
- * available set.  If the QNIC is already reserved (e.g., competing
- * reservations are flowing in the network, and part of the path is
- * already reserved), then the ConnectionManager should fail this request
- * and send a RejectConnectionSetupRequest message.
+ * managed at the QNIC level, so we have put a single reservation boolean here associated with the QNIC.
+ * On processing of a ConnectionSetupRequest, this flag is checked and if available set.
+ * If the QNIC is already reserved
+ * (e.g., competing reservations are flowing in the network, and part of the path is already reserved),
+ * then the ConnectionManager should fail this request and send a RejectConnectionSetupRequest message.
  * \todo extend this to support other muxing styles (long-term research project,
  * but should build on Aparicio)
  */
-void PhotonicSwitch::Reserve() {
+void PhotonicSwitch::reserve() {
   getParentModule()->par("is_reserved") = true;
-  EV << "QNIC reserved!!\n";
+  EV_INFO << "QNIC reserved!\n";
 }
 
-void PhotonicSwitch::ReleaseReservation() {
+void PhotonicSwitch::release() {
   getParentModule()->par("is_reserved") = false;
-  EV << "QNIC reservation released!!\n";
+  EV_INFO << "QNIC reservation released!\n";
 }
 
 bool PhotonicSwitch::isReserved() { return getParentModule()->par("is_reserved"); }

--- a/quisp/modules/PhotonicSwitch.h
+++ b/quisp/modules/PhotonicSwitch.h
@@ -1,0 +1,54 @@
+/** \file PhotonicSwitch.h
+ *  \todo clean Clean code when it is simple.
+ *  \todo doc Write doxygen documentation.
+ *  \authors cldurand,takaakimatsuo
+ *
+ *  \brief PhotonicSwitch
+ */
+
+#ifndef MODULES_PHOTONICSWITCH_H_
+#define MODULES_PHOTONICSWITCH_H_
+
+#include <PhotonicQubit_m.h>
+#include <classical_messages_m.h>
+#include <omnetpp.h>
+#include <vector>
+
+using namespace omnetpp;
+
+namespace quisp {
+namespace modules {
+
+/** \class PhotonicSwitch PhotonicSwitch.cc
+ *  \todo Documentation of the class header.
+ *
+ *  \brief PhotonicSwitch
+ */
+class PhotonicSwitch : public cSimpleModule {
+ private:
+  int myAddress;
+  cMessage *generatePacket;  // Not the actual packet. Local message to invoke Events
+  cPar *sendIATime;
+  bool isBusy;  // Already requested a path selection for a Quantum app
+ protected:
+  virtual void initialize() override;
+  virtual void handleMessage(cMessage *msg) override;
+  virtual void BubbleText(const char *txt);
+  virtual void checkGateNumber();
+  virtual void checkQubitNumber();
+  virtual void checkAndsetNeighborAddress();
+  virtual cModule *getQNode();
+
+ public:
+  PhotonicSwitch();
+  int getAddress();
+  virtual void Reserve();
+  virtual void ReleaseReservation();
+  virtual bool isReserved();
+};
+}  // namespace modules
+}  // namespace quisp
+
+Define_Module(PhotonicSwitch);
+
+#endif MODULES_PHOTONICSWITCH_H_

--- a/quisp/modules/PhotonicSwitch.h
+++ b/quisp/modules/PhotonicSwitch.h
@@ -26,25 +26,18 @@ namespace modules {
  */
 class PhotonicSwitch : public cSimpleModule {
  private:
-  int myAddress;
-  cMessage *generatePacket;  // Not the actual packet. Local message to invoke Events
-  cPar *sendIATime;
-  bool isBusy;  // Already requested a path selection for a Quantum app
+  int my_address;
+  bool is_busy;  // Already requested a path selection for a Quantum app
+
  protected:
   virtual void initialize() override;
   virtual void handleMessage(cMessage *msg) override;
-  virtual void BubbleText(const char *txt);
-  virtual void checkGateNumber();
-  virtual void checkQubitNumber();
-  virtual void checkAndsetNeighborAddress();
+  virtual void ensureCorrespondingNeighborAddress();
   virtual cModule *getQNode();
-
- public:
-  PhotonicSwitch();
+  void reserve();
+  void release();
+  bool isReserved();
   int getAddress();
-  virtual void Reserve();
-  virtual void ReleaseReservation();
-  virtual bool isReserved();
 };
 }  // namespace modules
 }  // namespace quisp

--- a/quisp/networks/qnic.ned
+++ b/quisp/networks/qnic.ned
@@ -135,7 +135,7 @@ simple StationaryQubit
         inout tolens_quantum_port;
 }
 
-simple QNIC_photonic_switch
+simple PhotonicSwitch
 {
     parameters:
         int address;
@@ -186,7 +186,7 @@ module QNIC
             @display("t=Id $stationaryQubit_address;i=block/circle,blue;"); // modify display string
             std = emission_std;
         }
-        lens: QNIC_photonic_switch {
+        lens: PhotonicSwitch {
             address = self_qnic_address;
             @display("i=block/dispatch;");
         }


### PR DESCRIPTION
* rename the class: `QNIC_photonic_switch` -> `PhotonicSwitch`
* rename variables, methods and members
* remove useless comments