### PR TITLE
Improve ci docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,14 @@ services:
   - docker
 
 install:
-  - travis_wait sh docker_build.sh
+  - docker build -f ./Dockerfile.travis --build-arg GTEST_VERSION=1.10.0 -t quisp .
 
 script:
-  - sh docker_run_lint.sh
-  - sh docker_run_test.sh
+  - bash docker_run_lint.sh
+  - docker run --rm -i -v "$TRAVIS_BUILD_DIR:/root/quisp" quisp /bin/sh -c "cd /root/quisp/test; /bin/bash test.sh"
   - cd test && sudo python -m unittest discover && sudo rm testresults.txt && echo "test done"
 branches:
   only:
     - master
     - Unittest
+    - make-build-faster-2

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -1,0 +1,20 @@
+FROM omnetpp/omnetpp:u18.04-5.6.2
+
+RUN apt-get update -y && apt install -y --no-install-recommends libeigen3-dev cmake g++ clang-format clang-tidy
+
+# Google test need HACK
+ARG GTEST_VERSION
+RUN mkdir -p /root/clibrary
+WORKDIR /root/clibrary
+RUN chmod 755 /root/clibrary && \
+    wget https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz -O gtest.tar.gz --progress=bar &&\
+    tar -zxvf gtest.tar.gz &&\
+    rm gtest.tar.gz &&\
+    mv /root/clibrary/googletest-release-${GTEST_VERSION} /root/clibrary/googletest &&\
+    chmod 755 /root/clibrary/googletest &&\
+    cd /root/clibrary/googletest &&\
+    mkdir build && chmod 755 build &&\
+    cd /root/clibrary/googletest/build &&\
+    cmake .. -DBUILD_SHARED_LIBS=0 &&\
+    make
+ENV GTEST_ROOT /root/clibrary/googletest/build/googletest/:$PATH

--- a/docker_run_lint.sh
+++ b/docker_run_lint.sh
@@ -1,17 +1,16 @@
-#!/bin/sh
-if [ "$TRAVIS" == "true" ] ; then
+#!/bin/bash
+if [ "$TRAVIS" = "true" ]; then
     DIFF=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
-    echo $DIFF
     SRCS=$(echo $DIFF | tr " " "\n" | grep 'quisp/.*.cc$' | tr "\n" " ")
     HEADERS=$(echo $DIFF | tr " " "\n" | grep 'quisp/.*.h$' | tr "\n" ",")
     OPTS="-O3 -DNDEBUG=1 -MMD -MP -MF tidy.d -fPIC -Wno-deprecated-register -Wno-unused-function -fno-omit-frame-pointer -DHAVE_SWAPCONTEXT -DXMLPARSER=libxml -DPREFER_QTENV -DWITH_QTENV -DWITH_PARSIM -DWITH_NETBUILDER -DWITH_OSGEARTH -I/usr/include/eigen3 -I./quisp -I/root/omnetpp/include"
 
-    if [ "$SRCS" == "" ]; then 
+    if [ "$SRCS" = "" ]; then 
         echo "no change"
         exit 0
     fi
 
-docker run --rm  -i --name quisp -e TRAVIS -e TRAVIS_COMMIT_RANGE -v "$(pwd):/root/quisp" -u "$(id -u):$(id -g)" quisp /bin/sh <<-EOF
+docker run --rm  -i --name quisp -e TRAVIS -e TRAVIS_COMMIT_RANGE -v "$TRAVIS_BUILD_DIR:/root/quisp" -u "$(id -u):$(id -g)" quisp /bin/sh <<-EOF
     cd /root/quisp
     clang-tidy -warnings-as-errors="*" -header-filter="$HEADERS" $SRCS -- $OPTS
 EOF

--- a/docker_run_test.sh
+++ b/docker_run_test.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
-docker run --rm -it --name quisp -v "$(pwd):/root/quisp" -u "$(id -u):$(id -g)" quisp /bin/sh -c "cd /root/quisp/test/; /bin/bash test.sh"
+#!/bin/bash
+docker run --rm -it --name quisp -v "$(pwd):/root/quisp" -u "$(id -u):$(id -g)" quisp /bin/sh -c "cd /root/quisp/test; /bin/bash test.sh"
 # docker exec -it quisp /bin/bash

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,9 +16,11 @@ NUM_TEST=35
 # This "init" and "next" is identifier of the experiments
 # for((i=0; i<${#Experiments[@]}; i++)); do
 for((i=0; i<$NUM_TEST; i++)); do
+echo "start test $i"
 echo "init$i" >> /root/quisp/test/testresults.txt 
 /root/quisp/quisp/out/clang-release/quisp  -u Cmdenv --cmdenv-express-mode=true -c "Test$i" -f /root/quisp/quisp/networks/test.ini | grep "fidelity" | tr ";" "\n" | tr "{" "\n"| tr "}" "\n"|sed s/"<-->"/"\n"/g>> /root/quisp/test/testresults.txt
 echo "next">>/root/quisp/test/testresults.txt
+echo "finish test $i"
 done
 # ==== 
 # On docker


### PR DESCRIPTION
This PR improves CI build and it makes build time 2x faster.
`Dockerfile` builds omnet++ and its IDE, but they provide the docker image, which contains an already compiled version of omnet++.
So I created the new slim version of `Dockerfile` for CI and reduced build time for omnet++ itself.