### PR TITLE
Updated Contribution Guide and VSCode setup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 Thank you for reading this page! We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
 
-- Reporting a bug
-- Discussing the current state of the code
-- Submitting a fix
-- Proposing new features
-- Becoming a maintainer
+* Reporting a bug
+* Discussing the current state of the code
+* Submitting a fix
+* Proposing new features
+* Becoming a maintainer
 
 When contributing to this repository, please first discuss the change you wish to make via issue, 
 email, or any other method with the owners of this repository before making a change.
@@ -29,6 +29,7 @@ The following is a set of guidelines, not rules. Use your best judgment, and fee
 
 [How can I contribute?](#how-can-i-contribute)
 
+  + [QuISP Development Setup](#quisp-development-setup)
   + [Reporting Bugs](#reporting-bugs)
   + [Pull Request Procedure](#pull-request-procedure)
 
@@ -72,6 +73,15 @@ All code changes should happen through pull requests.
 
 ## How can I contribute?
 
+### QuISP Development Setup
+
+We want to make QuISP development as easy as possible, be it installation, setting up working evironment, writing tests, or adding new features. We provide [some guides](/doc/development_setup/README.md) on how to do that depending on your machine operating system and how you want to run QuISP.
+
+* [Development Setup on MacOS](/doc/development_set/mac_setup.md)
+* [Development Setup using docker](/doc/development_set/docker_setup.md)
+* [Development Setup on Unix-based System](/doc/development_set/unix_setup.md)
+* [Development Setup on Windows](/doc/development_set/windows_setup.md)
+
 ### Reporting Bugs
 
 Report bugs using Github's [issues](https://github.com/sfc-aqua/quisp/issues)
@@ -109,7 +119,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 
 We define how to format code via `.clang-format` and lint vs `.clang-tidy` at project root. We also have a script which you can use to run the formatter and linter via `$ make format` or `$ sh docker_run_lint.sh` before committing. We follow code format from [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html). 
 
-* If you're writing code using [Visual Studio Code](https://code.visualstudio.com), we have a [guide](/doc/vscode_setup.md) on how to setup.
+* If you're writing code using [Visual Studio Code](https://code.visualstudio.com), we have a [guide](/doc/development_setup/vscode_setup.md) on how to setup.
 * If you're using OMNeT++ IDE, you can format the code seamlessly using [CppStyle](https://github.com/wangzw/CppStyle).
 
 ## License

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,18 +1,129 @@
-# Contributing (TBD)
-(Template from [here](https://gist.github.com/PurpleBooth/b24679402957c63ec426))
-When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. 
+# Contributing to QuISP
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Thank you for reading this page! We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
 
-## Pull Request Process
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
 
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
-   build.
-2. Verify the build test successfully passed and simulation is working on your own system.
-3. Format your changes with `$ make format` or `$sh docker_run_lint.sh` before committing.
-   These commands format the codes as following [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
-   If you're using OMNET++IDE, you can format the codes seamlessly with [CppStyle](https://github.com/wangzw/CppStyle).
+When contributing to this repository, please first discuss the change you wish to make via issue, 
+email, or any other method with the owners of this repository before making a change.
 
-### Attribution
-[website](https://aqua.sfc.wide.ad.jp/quisp_website/)
+We recommend reaching us via [QuISP Slack team](https://aqua-quisp.slack.com).
+
+The following is a set of guidelines, not rules. Use your best judgment, and feel free to propose change to this document via discussing with us on slack or pull request.
+
+**Table of Contents**
+
+[Code of Conduct](#code-of-conduct)
+
+[I just have a question about using QuISP!](#i-just-have-a-question-about-quisp)
+
+[What should I know before getting started?](#what-should-i-know-before-getting-started)
+
+  + [We Develop with Github](#we-develop-with-github)
+  + [We use Github Flow](#we-use-github-flow)
+  + [QuISP Design Decisions](#quisp-design-decisions)
+
+[How can I contribute?](#how-can-i-contribute)
+
+  + [Reporting Bugs](#reporting-bugs)
+  + [Pull Request Procedure](#pull-request-procedure)
+
+[Styleguides](#styleguides)
+
+[License](#license)
+
+  + [Any contributions you make will be under the BSD 3-Clause License](#any-contributions-you-make-will-be-under-the-bsd-3-clause-license)
+
+[Attribution](#attribution)
+
+[References](#references)
+
+## Code of Conduct
+
+Please note we have a [code of conduct](/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project. If you find unacceptable behaviour please report to us by email or slack.
+
+## I just have a question about using QuISP!
+
+Questions are welcome! Please don't file an issue to ask a question.
+We have quite detailed [documents](/doc) regarding the functionality of QuISP. We admit that most documents are still in progress and contribution are welcome!
+
+We also encourage you to [join our slack](https://aqua-quisp.slack.com) and ask questions there!
+
+* Even though slack is a chat service, it can take several hours for us to respond - please be patient!
+* We have channels for most of the important topics (e.g. `#links`, `#app-traffic`, `#muxing`, `#purificaton`) but if you aren't sure which channel to ask, we recommend asking in `#questions`.
+
+## What should I know before getting started
+
+### We Develop with Github
+
+We use github to host code, to track issues and feature requests, as well as accept pull requests.
+
+## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html)
+
+All code changes should happen through pull requests.
+
+## QuISP Design Decisions
+
+(TBD)
+
+## How can I contribute?
+
+### Reporting Bugs
+
+Report bugs using Github's [issues](https://github.com/sfc-aqua/quisp/issues)
+
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/sfc-aqua/quisp/issues/new/choose); it's that easy!
+
+**Write bug reports with detail, background, and sample code**
+
+Great bug reports tend to have:
+
+* A quick summary and/or background
+* Steps to reproduce
+  + Tell us what your setup is (OS, are you using local installation or docker version etc.)
+  + Be specific! (give us your `.ini` file, network name, parameters setting, actions that caused the bug, etc)
+  + Give sample code if you can. The report should includes sample code that *anyone* with a base QuISP setup can run to reproduce what you were seeing.
+* What you expected would happen
+* What actually happens (screenshots and timestamp/events# if it's deep in simulation)
+* Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People *love* thorough bug reports.
+
+## Pull Requests Procedure
+
+Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Verify that code can successfully build and simulation is working on your system.
+4. Ensure the test suite passes.
+5. Make sure your code lints. We treat warning from linter (`clang-tidy`) as errors (refer to [styleguides](#styleguides)).
+6. Issue that pull request!
+
+### Styleguides
+
+We define how to format code via `.clang-format` and lint vs `.clang-tidy` at project root. We also have a script which you can use to run the formatter and linter via `$ make format` or `$ sh docker_run_lint.sh` before committing. We follow code format from [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html). 
+
+* If you're writing code using [Visual Studio Code](https://code.visualstudio.com), we have a [guide](/doc/vscode_setup.md) on how to setup.
+* If you're using OMNeT++ IDE, you can format the code seamlessly using [CppStyle](https://github.com/wangzw/CppStyle).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under [3-Clause BSD License](/LICENSE).
+
+### Any contributions you make will be under the BSD 3-Clause License
+
+In short, when you submit code changes, your submissions are understood to be under the same [3-Clause BSD License](/LICENSE) that covers the project. Feel free to contact the maintainers if that's a concern.
+
+## Attribution
+
+[QuISP website](https://aqua.sfc.wide.ad.jp/quisp_website/)
+
+## References
+
+This document was adapted from two open-source contribution guidelines templates [here](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#pull-requests) and [here](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62).

--- a/Authors.md
+++ b/Authors.md
@@ -32,9 +32,10 @@
 * Samuel 'Hyensoo' Choi
 * Sara Metwalli
 * Makoto Nakai
+* Naphan Benchasattabuse
 
 
-## Developers of earlier-generation simulators (no direct code overap):
+## Developers of earlier-generation simulators (no direct code overlap):
 
 * Thaddeus Ladd
 * Luciano Aparicio

--- a/doc/development_setup/README.md
+++ b/doc/development_setup/README.md
@@ -1,0 +1,15 @@
+# QuISP Development Setup
+
+This document explains how to setup tests and linter for developing QuISP according to our guidelines.
+
+## Setup tests 
+
+* [MacOS local installation](/doc/development_setup/mac_setup.md)
+* [Unix-based local installation](/doc/development_setup/unix_setup.md)
+* [Docker QuISP](/doc/development_setup/docker_setup.md)
+* [Windows local installation](/doc/development_setup/windows_setup.md)
+
+## Editor and IDE setup
+
+* [Visual Studio Code setup](/doc/development_setup/vscode_setup.md)
+* [OMNeT++ IDE (Eclipse) setup](/doc/development_setup/omnet_ide_setup.md)

--- a/doc/development_setup/docker_setup.md
+++ b/doc/development_setup/docker_setup.md
@@ -1,0 +1,3 @@
+# Docker Setup
+
+(TBD)

--- a/doc/development_setup/mac_setup.md
+++ b/doc/development_setup/mac_setup.md
@@ -1,0 +1,3 @@
+# MacOS Setup
+
+(TBD)

--- a/doc/development_setup/unix_setup.md
+++ b/doc/development_setup/unix_setup.md
@@ -1,0 +1,3 @@
+# Unix-based System Setup
+
+(TBD)

--- a/doc/development_setup/vscode_setup.md
+++ b/doc/development_setup/vscode_setup.md
@@ -1,0 +1,97 @@
+# Visual Studio Code Development Setup
+
+Visual Studio Code is the editor of choice for many people (and most of our team members also use it), so we decided to make a guide on how to setup your workspace so you can get the most functionality out of VSCode (e.g. code formatting, linting, intellisense, etc) and developing QuISP is smooth as possible.
+
+## Prerequisites
+
+* You should have a working build of QuISP. If you haven't done so please follow this [guide](/doc/README.md) Intro & Install section.
+* You should have [opp_test and unit test (googletest) working and running](/doc/development_setup/README.md). 
+
+## Setup formatter and linter
+
+We recommend using [clangd](https://clangd.llvm.org) since it has VSCode integration via [official extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd). This will enable us to format code according to `.clang-format` file and lint and give hints according to rules defined in `.clang-tidy` file. 
+
+### Steps to setup clangd
+
+In this guide, we use [Homebrew](https://brew.sh) as our choice of package manager. If your preference is to use other package manager (e.g. [MacPorts](https://www.macports.org)) or install it from source, we won't cover it here.
+
+01. installing llvm (clangd is packaged with the llvm)
+
+``` shell
+$ brew install llvm
+```
+
+02. verify that your installation is successful
+
+``` shell
+$ clangd --version
+```
+
+It should print out something like this
+
+``` shell
+$ clangd version 12.0.0
+```
+
+03. Go to your VSCode and make sure to **uninstall or disable** official [C/C++ extension from Microsoft](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) since this extension can have weird interaction or making some features not working properly with clangd extension.
+04. Once you confirmed that C/C++ extension from Microsoft is **disabled** or **not installed**. Choose View –> Extensions, then search for “clangd” and install it.
+05. At this point, clangd still won't work properly because clangd relies on a file called `compiled_command.json` which contains the information of the project should be compiled. If you navigate to the code file in VSCode now (e.g. QuantumChannel.cc), you should see errors that it does not know where `omnetpp.h` is or error indicating wrong class name.
+06. In QuISP we use [GNU Make](https://www.gnu.org/software/make/) to build our project. So in order to create `compiled_command.json` we recommend using [Bear](https://github.com/rizsotto/Bear). Bear is a tool for generating compilation database which clang tools uses (including clangd).
+07. Install Bear via Homebrew
+
+``` 
+
+$ brew install bear
+```
+
+08. Generate the compilation database `compiled_command.json`. We need to make a clean build of QuISP again. At project root.
+
+``` 
+
+/quisp-project-root/ $ make clean; bear -- make
+```
+
+09. After successfully rebuild QuISP, confirm that `compiled_command.json` is created successfully. The file should contain something like snippets below. It will create one compile arguments for each file as one json object in the array.
+
+``` json
+[
+  {
+    "arguments": [
+      "/usr/local/Cellar/llvm/12.0.0/bin/clang-12",
+      "-c",
+      "-std=c++14",
+      "-O3",
+      "-DNDEBUG=1",
+      "-isystem",
+      "/Users/aqua/projects/omnetpp-5.6.2/tools/macosx/include",
+      "-Wno-deprecated-register",
+      "-Wno-unused-function",
+      "-fno-omit-frame-pointer",
+      "-DWITH_MPI",
+      "-DXMLPARSER=libxml",
+      "-DPREFER_QTENV",
+      "-DWITH_QTENV",
+      "-DWITH_PARSIM",
+      "-DWITH_NETBUILDER",
+      "-DWITH_OSG",
+      "-DWITH_OSGEARTH",
+      "-I.",
+      "-I/usr/local/Cellar/eigen/3.3.9/include/eigen3",
+      "-I/Users/aqua/projects/omnetpp-5.6.2/include",
+      "-o",
+      "out/clang-release//channels/QuantumChannel.o",
+      "channels/QuantumChannel.cc"
+    ],
+    "directory": "/Users/aqua/projects/quisp/quisp",
+    "file": "/Users/aqua/projects/quisp/quisp/channels/QuantumChannel.cc",
+    "output": "/Users/aqua/projects/quisp/quisp/out/clang-release//channels/QuantumChannel.o"
+  },
+  ...
+]
+```
+
+10. Navigate to code file in QuISP (e.g. QuantumChannel.cc), you should see all the errors disappear. 
+
+### Setting up Intellisense
+
+(TBD)

--- a/doc/development_setup/windows_setup.md
+++ b/doc/development_setup/windows_setup.md
@@ -1,0 +1,3 @@
+# Windows Setup
+
+(TBD)


### PR DESCRIPTION
I have updated the contribution guide to include more information and how we should do things going forward.
I also added a guide to setup clangd integration with Visual Studio Code. 

This is still work in progress for documents in general since I added a few more templates that need to be filled in as well. But I believe this should be merge into the master branch since VSCode setup and contribution guide is useful to have right now. 