### PR TITLE
Apply component provider to QRSA

### DIFF
--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
@@ -7,7 +7,7 @@
  */
 #include <PhotonicQubit_m.h>
 #include <classical_messages_m.h>
-#include <modules/QRSA/HardwareMonitor/HardwareMonitor.h>
+#include <modules/QRSA/HardwareMonitor/IHardwareMonitor.h>
 #include <omnetpp.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/quisp/modules/QNIC.h
+++ b/quisp/modules/QNIC.h
@@ -38,7 +38,7 @@ typedef struct {
   QNIC_id snd;
 } QNIC_id_pair;
 
-typedef struct : QNIC_id {
+typedef struct QNIC : QNIC_id {
   cModule* pointer;  // Pointer to that particular QNIC.
   int address;
 } QNIC;

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -7,6 +7,8 @@
  */
 
 #include "ConnectionManager.h"
+#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
+#include "utils/ComponentProvider.h"
 
 using namespace omnetpp;
 using namespace quisp::messages;
@@ -14,10 +16,11 @@ using namespace quisp::rules;
 
 namespace quisp {
 namespace modules {
+ConnectionManager::ConnectionManager() : provider(utils::ComponentProvider{this}) {}
 
 void ConnectionManager::initialize() {
-  routing_daemon = check_and_cast<RoutingDaemon *>(getParentModule()->getSubmodule("rd"));
-  hardware_monitor = check_and_cast<HardwareMonitor *>(getParentModule()->getSubmodule("hm"));
+  routing_daemon = provider.getRoutingDaemon();
+  hardware_monitor = provider.getHardwareMonitor();
   my_address = par("address");
   num_of_qnics = par("total_number_of_qnics");
 

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
@@ -8,14 +8,7 @@
 #ifndef MODULES_CONNECTIONMANAGER_H_
 #define MODULES_CONNECTIONMANAGER_H_
 
-#include <classical_messages_m.h>
-#include <modules/QNIC.h>
-#include <omnetpp.h>
-#include <rules/RuleSet.h>
-#include <vector>
-#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
-#include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
-#include "modules/QRSA/RuleEngine/RuleEngine.h"
+#include "IConnectionManager.h"
 
 using namespace omnetpp;
 using namespace quisp::messages;
@@ -23,23 +16,6 @@ using namespace quisp::rules;
 
 namespace quisp {
 namespace modules {
-
-typedef struct {  // This is a little bit redundant
-  int left_partner;
-  QNIC_type lqnic_type;
-  int lqnic_index;
-  int lqnic_address;
-  int lres;
-  int right_partner;
-  QNIC_type rqnic_type;
-  int rqnic_index;
-  int rqnic_address;
-  int rres;
-  int self_left_qnic_index;
-  QNIC_type self_left_qnic_type;
-  int self_right_qnic_index;
-  QNIC_type self_right_qnic_type;
-} SwappingConfig;
 
 /** \class ConnectionManager ConnectionManager.cc
  *  \todo Documentation of the class header.
@@ -65,16 +41,20 @@ typedef struct {  // This is a little bit redundant
  * It is also responsible for the end-to-end reservation of resources,
  * as dictated by the multiplexing (muxing) discipline in use.
  */
-class ConnectionManager : public cSimpleModule {
+class ConnectionManager : public IConnectionManager {
+ public:
+  ConnectionManager();
+
  private:
   int my_address;
   int num_of_qnics;
   std::map<int, bool> qnic_res_table;
-  RoutingDaemon *routing_daemon;
-  HardwareMonitor *hardware_monitor;
+  IRoutingDaemon *routing_daemon;
+  IHardwareMonitor *hardware_monitor;
+  utils::ComponentProvider provider;
 
-  virtual void initialize() override;
-  virtual void handleMessage(cMessage *msg) override;
+  void initialize() override;
+  void handleMessage(cMessage *msg) override;
 
   void respondToRequest(ConnectionSetupRequest *pk);
   void relayRequestToNextHop(ConnectionSetupRequest *pk);

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
@@ -44,6 +44,7 @@ namespace modules {
 class ConnectionManager : public IConnectionManager {
  public:
   ConnectionManager();
+  utils::ComponentProvider provider;
 
  private:
   int my_address;
@@ -51,7 +52,6 @@ class ConnectionManager : public IConnectionManager {
   std::map<int, bool> qnic_res_table;
   IRoutingDaemon *routing_daemon;
   IHardwareMonitor *hardware_monitor;
-  utils::ComponentProvider provider;
 
   void initialize() override;
   void handleMessage(cMessage *msg) override;

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
@@ -1,0 +1,31 @@
+#include "ConnectionManager.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <omnetpp.h>
+#include "test_utils/TestUtils.h"
+
+namespace {
+using namespace omnetpp;
+using namespace quisp_test;
+class Strategy : public quisp_test::TestComponentProviderStrategy {
+ public:
+  Strategy() {}
+  ~Strategy() {}
+};
+
+class ConnectionManagerTestTarget : public quisp::modules::ConnectionManager {
+ public:
+  using quisp::modules::ConnectionManager::par;
+  ConnectionManagerTestTarget() : quisp::modules::ConnectionManager() {
+    setParInt(this, "address", 123);
+    this->setName("connection_manager_test_target");
+    this->provider.setStrategy(std::make_unique<Strategy>());
+  }
+};
+
+TEST(ConnectionManagerTest, Init) {
+  ConnectionManagerTestTarget c;
+  ASSERT_EQ(c.par("address").intValue(), 123);
+}
+
+}  // namespace

--- a/quisp/modules/QRSA/ConnectionManager/IConnectionManager.h
+++ b/quisp/modules/QRSA/ConnectionManager/IConnectionManager.h
@@ -1,0 +1,45 @@
+#ifndef MODULES_ICONNECTIONMANAGER_H_
+#define MODULES_ICONNECTIONMANAGER_H_
+
+#include <classical_messages_m.h>
+#include <modules/QNIC.h>
+#include <modules/QRSA/HardwareMonitor/HardwareMonitor.h>
+#include <modules/QRSA/RoutingDaemon/RoutingDaemon.h>
+#include <modules/QRSA/RuleEngine/RuleEngine.h>
+#include <omnetpp.h>
+#include <rules/RuleSet.h>
+#include <utils/ComponentProvider.h>
+#include <vector>
+
+using namespace omnetpp;
+using namespace quisp::messages;
+using namespace quisp::rules;
+
+namespace quisp {
+namespace modules {
+
+typedef struct {  // This is a little bit redundant
+  int left_partner;
+  QNIC_type lqnic_type;
+  int lqnic_index;
+  int lqnic_address;
+  int lres;
+  int right_partner;
+  QNIC_type rqnic_type;
+  int rqnic_index;
+  int rqnic_address;
+  int rres;
+  int self_left_qnic_index;
+  QNIC_type self_left_qnic_type;
+  int self_right_qnic_index;
+  QNIC_type self_right_qnic_type;
+} SwappingConfig;
+
+class IConnectionManager : public cSimpleModule {
+ public:
+  virtual ~IConnectionManager(){};
+};
+
+}  // namespace modules
+}  // namespace quisp
+#endif /* MODULES_ICONNECTIONMANAGER_H_ */

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -22,6 +22,9 @@ namespace modules {
 
 using namespace rules;
 
+HardwareMonitor::HardwareMonitor() {}
+HardwareMonitor::~HardwareMonitor() {}
+
 // HardwareMonitor is also responsible for calculating the rssi/oka's protocol/fidelity calculate and give it to the RoutingDaemon
 void HardwareMonitor::initialize(int stage) {
   EV_INFO << "HardwareMonitor booted\n";

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
@@ -11,6 +11,7 @@
 
 #include "IHardwareMonitor.h"
 #include "modules/QNIC/StationaryQubit/StationaryQubit.h"
+#include "utils/ComponentProvider.h"
 
 namespace quisp {
 namespace modules {
@@ -30,6 +31,9 @@ class HardwareMonitor : public IHardwareMonitor {
   std::unique_ptr<InterfaceInfo> findInterfaceByNeighborAddr(int neighbor_address) override;
   std::unique_ptr<ConnectionSetupInfo> findConnectionInfoByQnicAddr(int qnic_address) override;
 
+ protected:
+  utils::ComponentProvider provider;
+
  private:
   int my_address;
 
@@ -41,9 +45,6 @@ class HardwareMonitor : public IHardwareMonitor {
   int num_qnic_rp;
   int num_qnic_total;
 
-  cModuleType *QNodeType = cModuleType::get("modules.QNode");
-  cModuleType *SPDCType = cModuleType::get("modules.SPDC");
-  cModuleType *HoMType = cModuleType::get("modules.HoM");
   bool do_link_level_tomography = false;
   int num_purification = 0;
   bool X_Purification = false;
@@ -73,7 +74,6 @@ class HardwareMonitor : public IHardwareMonitor {
   void prepareNeighborTable();
 
   virtual std::unique_ptr<NeighborInfo> createNeighborInfo(const cModule &thisNode);
-  virtual cModule *getQNode();
   virtual std::unique_ptr<NeighborInfo> getNeighbor(cModule *qnic_pointer);
   virtual InterfaceInfo getQnicInterfaceByQnicAddr(int qnic_index, QNIC_type qnic_type);
   virtual void sendLinkTomographyRuleSet(int my_address, int partner_address, QNIC_type qnic_type, int qnic_index, unsigned long rule_id);

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor_test.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor_test.cc
@@ -1,0 +1,66 @@
+#include "HardwareMonitor.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <omnetpp.h>
+#include <test_utils/TestUtils.h>
+#include "modules/QNIC.h"
+#include "modules/QNIC/StationaryQubit/StationaryQubit.h"
+#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
+#include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
+#include "omnetpp/csimulation.h"
+
+namespace {
+
+using namespace omnetpp;
+using namespace quisp::utils;
+using namespace quisp::modules;
+using namespace quisp_test;
+
+class MockStationaryQubit : public StationaryQubit {
+ public:
+  MOCK_METHOD(void, emitPhoton, (int pulse), (override));
+  MOCK_METHOD(void, setFree, (bool consumed), (override));
+};
+
+class Strategy : public quisp_test::TestComponentProviderStrategy {
+ public:
+  Strategy() : mockQubit(nullptr) {}
+  Strategy(MockStationaryQubit* _qubit) : mockQubit(_qubit) {}
+  ~Strategy() { delete mockQubit; }
+  MockStationaryQubit* mockQubit = nullptr;
+  StationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
+    if (mockQubit == nullptr) mockQubit = new MockStationaryQubit();
+    return mockQubit;
+  };
+};
+
+class HardwareMonitorTestTarget : public quisp::modules::HardwareMonitor {
+ public:
+  using quisp::modules::HardwareMonitor::initialize;
+  using quisp::modules::HardwareMonitor::par;
+  HardwareMonitorTestTarget(MockStationaryQubit* mockQubit) : quisp::modules::HardwareMonitor() {
+    setParInt(this, "address", 123);
+    setParInt(this, "number_of_qnics_rp", 0);
+    setParInt(this, "number_of_qnics_r", 0);
+    setParInt(this, "number_of_qnics", 0);
+    setParBool(this, "link_tomography", false);
+    setParStr(this, "tomography_output_filename", "test_file");
+    setParStr(this, "file_dir_name", "out/tests");
+    setParInt(this, "initial_purification", 0);
+    setParBool(this, "X_purification", true);
+    setParBool(this, "Z_purification", true);
+    setParInt(this, "Purification_type", 0);
+    setParInt(this, "num_measure", 0);
+
+    this->setName("hardware_monitor_test_target");
+    this->provider.setStrategy(std::make_unique<Strategy>(mockQubit));
+  }
+};
+
+TEST(HardwareMonitorTestTarget, Init) {
+  HardwareMonitorTestTarget c{nullptr};
+  c.initialize(0);
+  ASSERT_EQ(c.par("address").intValue(), 123);
+}
+
+}  // namespace

--- a/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
@@ -1,5 +1,5 @@
-#ifndef QUISP_MODULES_IHARDWAREMONITOR_H_
-#define QUISP_MODULES_IHARDWAREMONITOR_H_
+#ifndef QUISP_MODULES_I_HARDWAREMONITOR_H_
+#define QUISP_MODULES_I_HARDWAREMONITOR_H_
 #include <memory>
 #include "modules/QNIC.h"
 #include "omnetpp/csimplemodule.h"

--- a/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
@@ -1,0 +1,87 @@
+#ifndef QUISP_MODULES_IHARDWAREMONITOR_H_
+#define QUISP_MODULES_IHARDWAREMONITOR_H_
+#include <memory>
+#include "modules/QNIC.h"
+#include "omnetpp/csimplemodule.h"
+using namespace omnetpp;
+namespace quisp {
+namespace modules {
+using quisp::modules::QNIC;
+using quisp::modules::QNIC_N;
+
+struct NeighborInfo {
+  // QNode, SPDC, HOM
+  cModuleType *type;
+  int address;
+  int neighborQNode_address;  // QNode (May be across SDPC or HOM node)
+};
+
+struct InterfaceInfo {
+  // QubitAddr(int node_addr, int qnic_index, int qubit_index):node_address(node_addr),qnic_index(qnic_index),qubit_index(qubit_index){}
+  QNIC qnic;
+  double initial_fidelity = -1; /*Oka's protocol?*/
+  int buffer_size;
+  double link_cost;
+  int neighborQNode_address;
+  int neighborQNode_qnic_type;
+  QNIC neighbor_qnic;
+};
+
+struct ConnectionSetupInfo {
+  QNIC_id qnic;
+  int neighbor_address;
+  int quantum_link_cost;
+};
+
+const ConnectionSetupInfo NULL_CONNECTION_SETUP_INFO{.qnic =
+                                                         {
+                                                             .type = QNIC_N,
+                                                             .index = -1,
+                                                         },
+                                                     .neighbor_address = -1,
+                                                     .quantum_link_cost = -1};
+
+struct tomography_outcome {
+  char my_basis;
+  bool my_output_is_plus;
+  char my_GOD_clean;
+  char partner_basis;
+  bool partner_output_is_plus;
+  char partner_GOD_clean;
+};
+
+struct output_count {
+  int total_count;
+  int plus_plus;
+  int plus_minus;
+  int minus_plus;
+  int minus_minus;
+};
+
+struct link_cost {
+  simtime_t tomography_time;
+  int tomography_measurements;
+  double Bellpair_per_sec;
+};
+
+// qnic_index -> InterfaceInfo
+typedef std::map<int, InterfaceInfo> NeighborTable;
+
+// basis combination -> raw output count
+// e.g.
+// "XX" -> {plus_plus = 56, plus_minus = 55, minus_plus = 50, minus_minus = 50},
+// "XY" -> {....
+typedef std::map<std::string, output_count> raw_data;
+typedef std::map<int, tomography_outcome> Temporal_Tomography_Output_Holder;  // measurement_count_id -> outcome. For single qnic
+
+class IHardwareMonitor : public cSimpleModule {
+ public:
+  virtual ~IHardwareMonitor(){};
+  virtual NeighborTable passNeighborTable() = 0;
+  virtual int getQnicNumQubits(int qnic_index, QNIC_type qnic_type) = 0;
+  virtual std::unique_ptr<InterfaceInfo> findInterfaceByNeighborAddr(int neighbor_address) = 0;
+  virtual std::unique_ptr<ConnectionSetupInfo> findConnectionInfoByQnicAddr(int qnic_address) = 0;
+};
+}  // namespace modules
+}  // namespace quisp
+#endif

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
@@ -5,6 +5,8 @@
 #include <utils/IComponentProviderStrategy.h>
 #include "modules/QNIC.h"
 #include "modules/QNIC/StationaryQubit/StationaryQubit.h"
+#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
+#include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
 #include "omnetpp/csimulation.h"
 
 namespace {
@@ -26,6 +28,8 @@ class TestComponentProviderStrategy : public IComponentProviderStrategy {
   ~TestComponentProviderStrategy() { delete mockQubit; }
   MockStationaryQubit* mockQubit = nullptr;
   omnetpp::cModule* getQNode() override { return nullptr; }
+  RoutingDaemon* getRoutingDaemon() override { return nullptr; }
+  HardwareMonitor* getHardwareMonitor() override { return nullptr; }
   StationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
     if (mockQubit == nullptr) mockQubit = new MockStationaryQubit();
     return mockQubit;

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
@@ -8,6 +8,7 @@
 #include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
 #include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
 #include "omnetpp/csimulation.h"
+#include "test_utils/TestUtils.h"
 
 namespace {
 
@@ -21,15 +22,12 @@ class MockStationaryQubit : public StationaryQubit {
   MOCK_METHOD(void, setFree, (bool consumed), (override));
 };
 
-class TestComponentProviderStrategy : public IComponentProviderStrategy {
+class Strategy : public quisp_test::TestComponentProviderStrategy {
  public:
-  TestComponentProviderStrategy() : mockQubit(nullptr) {}
-  TestComponentProviderStrategy(MockStationaryQubit* _qubit) : mockQubit(_qubit) {}
-  ~TestComponentProviderStrategy() { delete mockQubit; }
+  Strategy() : mockQubit(nullptr) {}
+  Strategy(MockStationaryQubit* _qubit) : mockQubit(_qubit) {}
+  ~Strategy() { delete mockQubit; }
   MockStationaryQubit* mockQubit = nullptr;
-  omnetpp::cModule* getQNode() override { return nullptr; }
-  RoutingDaemon* getRoutingDaemon() override { return nullptr; }
-  HardwareMonitor* getHardwareMonitor() override { return nullptr; }
   StationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
     if (mockQubit == nullptr) mockQubit = new MockStationaryQubit();
     return mockQubit;
@@ -47,7 +45,7 @@ class RTCTestTarget : public quisp::modules::RealTimeController {
     p->setIntValue(123);
     this->addPar(p);
     this->setName("rtc_test_target");
-    this->provider.setStrategy(std::make_unique<TestComponentProviderStrategy>(mockQubit));
+    this->provider.setStrategy(std::make_unique<Strategy>(mockQubit));
   }
 };
 

--- a/quisp/modules/QRSA/RoutingDaemon/IRoutingDaemon.h
+++ b/quisp/modules/QRSA/RoutingDaemon/IRoutingDaemon.h
@@ -1,0 +1,18 @@
+#ifndef MODULES_IROUTING_DAEMON_H_
+#define MODULES_IROUTING_DAEMON_H_
+
+#include "omnetpp/csimplemodule.h"
+
+using omnetpp::cSimpleModule;
+
+namespace quisp {
+namespace modules {
+
+class IRoutingDaemon : public cSimpleModule {
+ public:
+  virtual int return_QNIC_address_to_destAddr(int destAddr) = 0;
+};
+}  // namespace modules
+}  // namespace quisp
+
+#endif

--- a/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.h
+++ b/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.h
@@ -9,9 +9,7 @@
 #define MODULES_ROUTINGDAEMON_H_
 
 #include <modules/QNIC.h>
-#include <omnetpp.h>
-
-using namespace omnetpp;
+#include "IRoutingDaemon.h"
 
 /** \class RoutingDaemon RoutingDaemon.cc
  *  \todo Documentation of the class header.
@@ -22,19 +20,19 @@ using namespace omnetpp;
 namespace quisp {
 namespace modules {
 
-class RoutingDaemon : public cSimpleModule {
+class RoutingDaemon : public IRoutingDaemon {
  private:
   int myAddress;
   typedef std::map<int, QNIC> RoutingTable;  // destaddr -> {gate_index (We need this to access qnic, but it is not unique because we have 3 types of qnics), qnic_address (unique)}
   RoutingTable qrtable;
 
  protected:
-  virtual void initialize(int stage) override;
-  virtual void handleMessage(cMessage *msg) override;
-  virtual int numInitStages() const override { return 3; };
+  void initialize(int stage) override;
+  void handleMessage(cMessage *msg) override;
+  int numInitStages() const override { return 3; };
 
  public:
-  virtual int return_QNIC_address_to_destAddr(int destAddr);
+  int return_QNIC_address_to_destAddr(int destAddr) override;
 };
 
 }  // namespace modules

--- a/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
+++ b/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
@@ -1,0 +1,93 @@
+#ifndef QUISP_MODULES_IRULEENGINE_H_
+#define QUISP_MODULES_IRULEENGINE_H_
+
+#include <omnetpp.h>
+#include <rules/RuleSet.h>
+#include <vector>
+
+#include "../../PhysicalConnection/BSA/HoMController.h"
+#include "classical_messages_m.h"
+#include "modules/QNIC/StationaryQubit/StationaryQubit.h"
+#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
+#include "modules/QRSA/RealTimeController/IRealTimeController.h"
+#include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
+#include "modules/QUBIT.h"
+
+using namespace omnetpp;
+
+namespace quisp {
+namespace modules {
+using namespace rules;
+
+typedef struct {
+  unsigned long ruleset_id;
+  int rule_id;
+  int index;
+} process_id;
+
+struct purification_result {
+  process_id id;
+  bool outcome;
+};
+
+struct Doublepurification_result {
+  process_id id;
+  bool Xpurification_outcome;
+  bool Zpurification_outcome;
+};
+
+struct Triplepurification_result {
+  process_id id;
+  bool Xpurification_outcome;
+  bool Zpurification_outcome;
+  bool DS_purification_outcome;
+};
+
+struct Quatropurification_result {
+  process_id id;
+  bool Xpurification_outcome;
+  bool Zpurification_outcome;
+  bool DS_Xpurification_outcome;
+  bool DS_Zpurification_outcome;
+};
+
+struct swapping_result {
+  process_id id;
+  int new_partner;
+  int new_partner_qnic_index;
+  int new_partner_qnic_address;
+  int measured_qubit_index;
+  QNIC_type new_partner_qnic_type;
+  int operation_type;
+};
+
+// Process = RuleSet
+typedef struct {
+  int ownner_addr;
+  // int process_ID;
+  RuleSet *Rs;
+} process;
+
+typedef std::map<int, QubitState> QubitStateTable;
+typedef std::multimap<int, purification_result> PurificationTable;
+typedef std::multimap<int, Doublepurification_result> DoublePurificationTable;
+typedef std::multimap<int, Quatropurification_result> QuatroPurificationTable;
+typedef std::multimap<int, Triplepurification_result> TriplePurificationTable;
+typedef std::map<int, QubitAddr_cons> sentQubitIndexTracker;  // nth shot -> node/qnic/qubit index (node addr not needed actually)
+typedef std::map<int, bool> trial_tracker;  // trial index, false or true (that trial is over or not)
+typedef std::map<int, process> running_processes;  // index -> process
+typedef std::map<int, Rule *> rule_ptr;
+
+class IRuleEngine : public cSimpleModule {
+ public:
+  ~IRuleEngine() {}
+  virtual void freeResource(int qnic_index, int qubit_index, QNIC_type qnic_type) = 0;
+  virtual void freeConsumedResource(int qnic_index, StationaryQubit *qubit, QNIC_type qnic_type) = 0;
+  virtual void dynamic_ResourceAllocation(int qnic_type, int qnic_index) = 0;
+  virtual void ResourceAllocation(int qnic_type, int qnic_index) = 0;
+};
+
+}  // namespace modules
+}  // namespace quisp
+
+#endif /* MODULES_IRULEENGINE_H_ */

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -799,7 +799,7 @@ void RuleEngine::scheduleNextEmissionEvent(int qnic_index, int qnic_address, dou
     scheduleAt(simTime() + interval, st);
 }
 
-RuleEngine::QubitStateTable RuleEngine::initializeQubitStateTable(QubitStateTable table, QNIC_type qnic_type) {
+QubitStateTable RuleEngine::initializeQubitStateTable(QubitStateTable table, QNIC_type qnic_type) {
   int qnics = -1;
   switch (qnic_type) {
     case QNIC_E:
@@ -853,7 +853,7 @@ int RuleEngine::countFreeQubits_inQnic(QubitStateTable table, int qnic_index) {
   return num_free;
 }
 
-RuleEngine::QubitStateTable RuleEngine::setQubitBusy_inQnic(QubitStateTable table, int qnic_index, int qubit_index) {
+QubitStateTable RuleEngine::setQubitBusy_inQnic(QubitStateTable table, int qnic_index, int qubit_index) {
   for (auto it = table.cbegin(); it != table.cend(); ++it) {
     if (it->second.isBusy == false && it->second.thisQubit_addr.qnic_index == qnic_index && it->second.thisQubit_addr.qubit_index == qubit_index) {
       table[it->first].isBusy = true;
@@ -865,7 +865,7 @@ RuleEngine::QubitStateTable RuleEngine::setQubitBusy_inQnic(QubitStateTable tabl
   return table;
 }
 
-RuleEngine::QubitStateTable RuleEngine::setQubitFree_inQnic(QubitStateTable table, int qnic_index, int qubit_index) {
+QubitStateTable RuleEngine::setQubitFree_inQnic(QubitStateTable table, int qnic_index, int qubit_index) {
   for (auto it = table.cbegin(); it != table.cend(); ++it) {
     // std::cout<<it->first<<" table = "<<table[it->first].isBusy<<"\n";
     if (it->second.isBusy == true && it->second.thisQubit_addr.qnic_index == qnic_index && it->second.thisQubit_addr.qubit_index == qubit_index) {

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.h
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.h
@@ -21,6 +21,7 @@
 #include "modules/QRSA/RealTimeController/IRealTimeController.h"
 #include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
 #include "modules/QUBIT.h"
+#include "utils/ComponentProvider.h"
 
 using namespace omnetpp;
 
@@ -44,6 +45,7 @@ class RuleEngine : public IRuleEngine {
   simsignal_t actual_resSignal;
   // friend class Action;
  public:
+  RuleEngine();
   int parentAddress;  // Parent QNode's address
   EmitPhotonRequest *emt;
   NeighborTable ntable;
@@ -60,8 +62,8 @@ class RuleEngine : public IRuleEngine {
   QubitStateTable *Busy_OR_Free_QubitState_table;
   bool *terminated_qnic;  // When you need to intentionally stop the link to make the simulation lighter.
   sentQubitIndexTracker *tracker;
-  HardwareMonitor *hardware_monitor;
-  RoutingDaemon *routingdaemon;
+  IHardwareMonitor *hardware_monitor;
+  IRoutingDaemon *routingdaemon;
   IRealTimeController *realtime_controller;
   int *qnic_burst_trial_counter;
   qnicResources *allResources;  // Size will be defined in initialization. If 3 qnic types, then size is 3. Type defined in QUBIT.h
@@ -85,7 +87,6 @@ class RuleEngine : public IRuleEngine {
   void initialize() override;
   void finish() override;
   void handleMessage(cMessage *msg) override;
-  cModule *getQNode();
   int countFreeQubits_inQnic(QubitStateTable table, int qnic_index);
   int getOneFreeQubit_inQnic(QubitStateTable table, int qnic_index);
   QubitStateTable setQubitBusy_inQnic(QubitStateTable table, int qnic_index, int qubit_index);
@@ -116,7 +117,6 @@ class RuleEngine : public IRuleEngine {
 
   void updateResources_EntanglementSwapping(swapping_result swapr);
 
- private:
   utils::ComponentProvider provider;
 };
 

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -1,0 +1,68 @@
+#include "RuleEngine.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <omnetpp.h>
+#include <test_utils/TestUtils.h>
+#include "modules/QNIC.h"
+#include "modules/QNIC/StationaryQubit/StationaryQubit.h"
+#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
+#include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
+#include "modules/QRSA/RuleEngine/RuleEngine.h"
+#include "omnetpp/csimulation.h"
+
+namespace {
+
+using namespace omnetpp;
+using namespace quisp::utils;
+using namespace quisp::modules;
+using namespace quisp_test;
+
+class MockStationaryQubit : public StationaryQubit {
+ public:
+  MOCK_METHOD(void, emitPhoton, (int pulse), (override));
+  MOCK_METHOD(void, setFree, (bool consumed), (override));
+};
+
+class Strategy : public quisp_test::TestComponentProviderStrategy {
+ public:
+  Strategy() : mockQubit(nullptr) {}
+  Strategy(MockStationaryQubit* _qubit) : mockQubit(_qubit) {}
+  ~Strategy() { delete mockQubit; }
+  MockStationaryQubit* mockQubit = nullptr;
+  StationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
+    if (mockQubit == nullptr) mockQubit = new MockStationaryQubit();
+    return mockQubit;
+  };
+};
+
+class RuleEngineTestTarget : public quisp::modules::RuleEngine {
+ public:
+  using quisp::modules::RuleEngine::initialize;
+  using quisp::modules::RuleEngine::par;
+  RuleEngineTestTarget(MockStationaryQubit* mockQubit) : quisp::modules::RuleEngine() {
+    setParInt(this, "address", 123);
+    setParInt(this, "number_of_qnics_rp", 0);
+    setParInt(this, "number_of_qnics_r", 0);
+    setParInt(this, "number_of_qnics", 0);
+    setParInt(this, "total_number_of_qnics", 0);
+    // setParBool(this, "link_tomography", false);
+    // setParStr(this, "tomography_output_filename", "test_file");
+    // setParStr(this, "file_dir_name", "out/tests");
+    // setParInt(this, "initial_purification", 0);
+    // setParBool(this, "X_purification", true);
+    // setParBool(this, "Z_purification", true);
+    // setParInt(this, "Purification_type", 0);
+    // setParInt(this, "num_measure", 0);
+
+    this->setName("rule_engine_test_target");
+    this->provider.setStrategy(std::make_unique<Strategy>(mockQubit));
+  }
+};
+
+TEST(RuleEngineTest, Init) {
+  RuleEngineTestTarget c{nullptr};
+  c.initialize();
+  ASSERT_EQ(c.par("address").intValue(), 123);
+}
+
+}  // namespace

--- a/quisp/test_utils/TestUtils.cc
+++ b/quisp/test_utils/TestUtils.cc
@@ -1,0 +1,21 @@
+#include "TestUtils.h"
+namespace quisp_test {
+void setParInt(cModule *module, const char *name, const int val) {
+  omnetpp::cParImpl *p = new omnetpp::cIntParImpl();
+  p->setName(name);
+  p->setIntValue(val);
+  module->addPar(p);
+}
+void setParStr(cModule *module, const char *name, const char *val) {
+  omnetpp::cParImpl *p = new omnetpp::cStringParImpl();
+  p->setName(name);
+  p->setStringValue(val);
+  module->addPar(p);
+}
+void setParBool(cModule *module, const char *name, const bool val) {
+  omnetpp::cParImpl *p = new omnetpp::cBoolParImpl();
+  p->setName(name);
+  p->setBoolValue(val);
+  module->addPar(p);
+}
+}  // namespace quisp_test

--- a/quisp/test_utils/TestUtils.h
+++ b/quisp/test_utils/TestUtils.h
@@ -1,0 +1,39 @@
+#ifndef QUISP_UTILS_TEST_UTILS_H_
+#define QUISP_UTILS_TEST_UTILS_H_
+
+#include <modules/QNIC.h>
+#include <modules/QNIC/StationaryQubit/StationaryQubit.h>
+#include <modules/QRSA/HardwareMonitor/IHardwareMonitor.h>
+#include <modules/QRSA/RoutingDaemon/IRoutingDaemon.h>
+#include <utils/IComponentProviderStrategy.h>
+#include <utils/utils.h>
+#include <memory>
+
+namespace quisp_test {
+using quisp::modules::IHardwareMonitor;
+using quisp::modules::IRoutingDaemon;
+using quisp::modules::QNIC_type;
+using quisp::modules::StationaryQubit;
+using quisp::utils::IComponentProviderStrategy;
+
+void setParInt(cModule *module, const char *name, const int val);
+void setParBool(cModule *module, const char *name, const bool val);
+void setParStr(cModule *module, const char *name, const char *val);
+
+class TestComponentProviderStrategy : public IComponentProviderStrategy {
+ public:
+  TestComponentProviderStrategy() {}
+  virtual ~TestComponentProviderStrategy() {}
+  virtual cModule *getQNode() override { return nullptr; };
+  virtual cModule *getNeighborNode(cModule *qnic) override { return nullptr; };
+  virtual bool isQNodeType(const cModuleType *const type) override { return false; };
+  virtual bool isHoMNodeType(const cModuleType *const type) override { return false; };
+  virtual bool isSPDCNodeType(const cModuleType *const type) override { return false; };
+  virtual StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override { return nullptr; };
+  virtual IRoutingDaemon *getRoutingDaemon() override { return nullptr; };
+  virtual IHardwareMonitor *getHardwareMonitor() override { return nullptr; };
+};
+
+}  // namespace quisp_test
+
+#endif /* QUISP_UTILS_TEST_UTILS_H_ */

--- a/quisp/test_utils/TestUtils.h
+++ b/quisp/test_utils/TestUtils.h
@@ -4,6 +4,7 @@
 #include <modules/QNIC.h>
 #include <modules/QNIC/StationaryQubit/StationaryQubit.h>
 #include <modules/QRSA/HardwareMonitor/IHardwareMonitor.h>
+#include <modules/QRSA/RealTimeController/IRealTimeController.h>
 #include <modules/QRSA/RoutingDaemon/IRoutingDaemon.h>
 #include <utils/IComponentProviderStrategy.h>
 #include <utils/utils.h>
@@ -11,6 +12,7 @@
 
 namespace quisp_test {
 using quisp::modules::IHardwareMonitor;
+using quisp::modules::IRealTimeController;
 using quisp::modules::IRoutingDaemon;
 using quisp::modules::QNIC_type;
 using quisp::modules::StationaryQubit;
@@ -30,8 +32,10 @@ class TestComponentProviderStrategy : public IComponentProviderStrategy {
   virtual bool isHoMNodeType(const cModuleType *const type) override { return false; };
   virtual bool isSPDCNodeType(const cModuleType *const type) override { return false; };
   virtual StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override { return nullptr; };
+  virtual cModule *getQNIC(int qnic_index, QNIC_type qnic_type) override { return nullptr; };
   virtual IRoutingDaemon *getRoutingDaemon() override { return nullptr; };
   virtual IHardwareMonitor *getHardwareMonitor() override { return nullptr; };
+  virtual IRealTimeController *getRealTimeController() override { return nullptr; };
 };
 
 }  // namespace quisp_test

--- a/quisp/unit_test_main.cc
+++ b/quisp/unit_test_main.cc
@@ -19,6 +19,7 @@ int main(int argc, char **argv) {
    * so it will cause segmentation faults or exceptions if there's no simulation env.
    */
   auto *sim = new omnetpp::cSimulation("test_sim", omnetpp::cSimulation::getStaticEnvir());
+  omnetpp::cComponent::clearSignalState();
   omnetpp::cSimulation::setActiveSimulation(sim);
   omnetpp::SimTime::setScaleExp(-3);
   ::testing::InitGoogleTest(&argc, argv);

--- a/quisp/utils/ComponentProvider.cc
+++ b/quisp/utils/ComponentProvider.cc
@@ -1,6 +1,7 @@
 #include "ComponentProvider.h"
 #include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
 #include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
+#include "omnetpp/cmodule.h"
 
 namespace quisp {
 namespace utils {
@@ -10,6 +11,24 @@ ComponentProvider::ComponentProvider(cModule *_module) : module(_module) {}
 cModule *ComponentProvider::getQNode() {
   ensureStrategy();
   return strategy->getQNode();
+}
+
+cModule *ComponentProvider::getNeighborNode(cModule *qnic) {
+  ensureStrategy();
+  return strategy->getNeighborNode(qnic);
+}
+
+bool ComponentProvider::isHoMNodeType(const cModuleType *const type) {
+  ensureStrategy();
+  return strategy->isHoMNodeType(type);
+}
+bool ComponentProvider::isSPDCNodeType(const cModuleType *const type) {
+  ensureStrategy();
+  return strategy->isSPDCNodeType(type);
+}
+bool ComponentProvider::isQNodeType(const cModuleType *const type) {
+  ensureStrategy();
+  return strategy->isQNodeType(type);
 }
 
 StationaryQubit *ComponentProvider::getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) {

--- a/quisp/utils/ComponentProvider.cc
+++ b/quisp/utils/ComponentProvider.cc
@@ -2,6 +2,7 @@
 #include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
 #include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
 #include "omnetpp/cmodule.h"
+#include "utils/utils.h"
 
 namespace quisp {
 namespace utils {
@@ -35,6 +36,10 @@ StationaryQubit *ComponentProvider::getStationaryQubit(int qnic_index, int qubit
   ensureStrategy();
   return strategy->getStationaryQubit(qnic_index, qubit_index, qnic_type);
 }
+cModule *ComponentProvider::getQNIC(int qnic_index, QNIC_type qnic_type) {
+  ensureStrategy();
+  return strategy->getQNIC(qnic_index, qnic_type);
+}
 
 IHardwareMonitor *ComponentProvider::getHardwareMonitor() {
   ensureStrategy();
@@ -44,6 +49,10 @@ IHardwareMonitor *ComponentProvider::getHardwareMonitor() {
 IRoutingDaemon *ComponentProvider::getRoutingDaemon() {
   ensureStrategy();
   return strategy->getRoutingDaemon();
+}
+IRealTimeController *ComponentProvider::getRealTimeController() {
+  ensureStrategy();
+  return strategy->getRealTimeController();
 }
 
 void ComponentProvider::setStrategy(std::unique_ptr<IComponentProviderStrategy> _strategy) { strategy = std::move(_strategy); }

--- a/quisp/utils/ComponentProvider.cc
+++ b/quisp/utils/ComponentProvider.cc
@@ -1,4 +1,6 @@
 #include "ComponentProvider.h"
+#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
+#include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
 
 namespace quisp {
 namespace utils {
@@ -13,6 +15,16 @@ cModule *ComponentProvider::getQNode() {
 StationaryQubit *ComponentProvider::getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) {
   ensureStrategy();
   return strategy->getStationaryQubit(qnic_index, qubit_index, qnic_type);
+}
+
+IHardwareMonitor *ComponentProvider::getHardwareMonitor() {
+  ensureStrategy();
+  return strategy->getHardwareMonitor();
+}
+
+IRoutingDaemon *ComponentProvider::getRoutingDaemon() {
+  ensureStrategy();
+  return strategy->getRoutingDaemon();
 }
 
 void ComponentProvider::setStrategy(std::unique_ptr<IComponentProviderStrategy> _strategy) { strategy = std::move(_strategy); }

--- a/quisp/utils/ComponentProvider.h
+++ b/quisp/utils/ComponentProvider.h
@@ -22,6 +22,8 @@ class ComponentProvider {
 
   omnetpp::cModule *getQNode();
   StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type);
+  IRoutingDaemon *getRoutingDaemon();
+  IHardwareMonitor *getHardwareMonitor();
 
   // when a this class instantiated, a strategy class instantiation may fail because
   // the strategy class may depend on other modules instantiated by OMNeT++'s NED file.

--- a/quisp/utils/ComponentProvider.h
+++ b/quisp/utils/ComponentProvider.h
@@ -3,6 +3,7 @@
 
 #include "DefaultComponentProviderStrategy.h"
 #include "IComponentProviderStrategy.h"
+#include "omnetpp/cmodule.h"
 #include "utils.h"
 
 namespace quisp {
@@ -20,7 +21,11 @@ class ComponentProvider {
  public:
   ComponentProvider(omnetpp::cModule *_module);
 
-  omnetpp::cModule *getQNode();
+  cModule *getQNode();
+  cModule *getNeighborNode(cModule *qnic);
+  bool isQNodeType(const cModuleType *const type);
+  bool isHoMNodeType(const cModuleType *const type);
+  bool isSPDCNodeType(const cModuleType *const type);
   StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type);
   IRoutingDaemon *getRoutingDaemon();
   IHardwareMonitor *getHardwareMonitor();

--- a/quisp/utils/ComponentProvider.h
+++ b/quisp/utils/ComponentProvider.h
@@ -27,8 +27,10 @@ class ComponentProvider {
   bool isHoMNodeType(const cModuleType *const type);
   bool isSPDCNodeType(const cModuleType *const type);
   StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type);
+  cModule *getQNIC(int qnic_index, QNIC_type qnic_type);
   IRoutingDaemon *getRoutingDaemon();
   IHardwareMonitor *getHardwareMonitor();
+  IRealTimeController *getRealTimeController();
 
   // when a this class instantiated, a strategy class instantiation may fail because
   // the strategy class may depend on other modules instantiated by OMNeT++'s NED file.

--- a/quisp/utils/DefaultComponentProviderStrategy.cc
+++ b/quisp/utils/DefaultComponentProviderStrategy.cc
@@ -1,4 +1,7 @@
 #include "DefaultComponentProviderStrategy.h"
+#include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
+#include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
+#include "omnetpp/cmodule.h"
 
 namespace quisp {
 namespace utils {
@@ -25,5 +28,22 @@ StationaryQubit *DefaultComponentProviderStrategy::getStationaryQubit(int qnic_i
   return check_and_cast<StationaryQubit *>(qubit);
 }
 
+IRoutingDaemon *DefaultComponentProviderStrategy::getRoutingDaemon() {
+  auto *qrsa = getQRSA();
+  return check_and_cast<IRoutingDaemon *>(qrsa->getSubmodule("rd"));
+}
+IHardwareMonitor *DefaultComponentProviderStrategy::getHardwareMonitor() {
+  auto *qrsa = getQRSA();
+  return check_and_cast<IHardwareMonitor *>(qrsa->getSubmodule("hm"));
+}
+
+cModule *DefaultComponentProviderStrategy::getQRSA() {
+  auto *qnode = getQNode();
+  auto *qrsa = qnode->getSubmodule("qrsa");
+  if (qrsa == nullptr) {
+    throw cRuntimeError("QRSA module not found.");
+  }
+  return qrsa;
+}
 }  // namespace utils
 }  // namespace quisp

--- a/quisp/utils/DefaultComponentProviderStrategy.cc
+++ b/quisp/utils/DefaultComponentProviderStrategy.cc
@@ -1,6 +1,7 @@
 #include "DefaultComponentProviderStrategy.h"
 #include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
 #include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
+#include "omnetpp/cexception.h"
 #include "omnetpp/cmodule.h"
 
 namespace quisp {
@@ -17,6 +18,12 @@ cModule *DefaultComponentProviderStrategy::getQNode() {
     }
   }
   return currentModule;
+}
+cModule *DefaultComponentProviderStrategy::getNeighborNode(cModule *qnic) {
+  if (qnic == nullptr) throw cRuntimeError("failed to get neighbor node. given qnic is nullptr");
+  auto *neighbor_node = qnic->gate("qnic_quantum_port$o")->getNextGate()->getNextGate()->getOwnerModule();
+  if (neighbor_node == nullptr) throw cRuntimeError("failed to get neighbor node. neighbor node is nullptr");
+  return neighbor_node;
 }
 
 StationaryQubit *DefaultComponentProviderStrategy::getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) {
@@ -45,5 +52,9 @@ cModule *DefaultComponentProviderStrategy::getQRSA() {
   }
   return qrsa;
 }
+
+bool DefaultComponentProviderStrategy::isHoMNodeType(const cModuleType *const type) { return type == HoMType; }
+bool DefaultComponentProviderStrategy::isQNodeType(const cModuleType *const type) { return type == QNodeType; }
+bool DefaultComponentProviderStrategy::isSPDCNodeType(const cModuleType *const type) { return type == SPDCType; }
 }  // namespace utils
 }  // namespace quisp

--- a/quisp/utils/DefaultComponentProviderStrategy.h
+++ b/quisp/utils/DefaultComponentProviderStrategy.h
@@ -12,10 +12,14 @@ class DefaultComponentProviderStrategy : public IComponentProviderStrategy {
   DefaultComponentProviderStrategy(cModule *_self);
   cModule *getQNode() override;
   StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override;
+  IRoutingDaemon *getRoutingDaemon() override;
+  IHardwareMonitor *getHardwareMonitor() override;
 
  private:
   const cModuleType *const QNodeType = cModuleType::get("modules.QNode");
   cModule *self;
+
+  cModule *getQRSA();
 };
 
 }  // namespace utils

--- a/quisp/utils/DefaultComponentProviderStrategy.h
+++ b/quisp/utils/DefaultComponentProviderStrategy.h
@@ -16,8 +16,10 @@ class DefaultComponentProviderStrategy : public IComponentProviderStrategy {
   bool isHoMNodeType(const cModuleType *const type) override;
   bool isSPDCNodeType(const cModuleType *const type) override;
   StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override;
+  cModule *getQNIC(int qnic_index, QNIC_type qnic_type) override;
   IRoutingDaemon *getRoutingDaemon() override;
   IHardwareMonitor *getHardwareMonitor() override;
+  IRealTimeController *getRealTimeController() override;
 
  private:
   const cModuleType *const QNodeType = cModuleType::get("modules.QNode");

--- a/quisp/utils/DefaultComponentProviderStrategy.h
+++ b/quisp/utils/DefaultComponentProviderStrategy.h
@@ -11,14 +11,19 @@ class DefaultComponentProviderStrategy : public IComponentProviderStrategy {
  public:
   DefaultComponentProviderStrategy(cModule *_self);
   cModule *getQNode() override;
+  cModule *getNeighborNode(cModule *qnic) override;
+  bool isQNodeType(const cModuleType *const type) override;
+  bool isHoMNodeType(const cModuleType *const type) override;
+  bool isSPDCNodeType(const cModuleType *const type) override;
   StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override;
   IRoutingDaemon *getRoutingDaemon() override;
   IHardwareMonitor *getHardwareMonitor() override;
 
  private:
   const cModuleType *const QNodeType = cModuleType::get("modules.QNode");
+  const cModuleType *const SPDCType = cModuleType::get("modules.SPDC");
+  const cModuleType *const HoMType = cModuleType::get("modules.HoM");
   cModule *self;
-
   cModule *getQRSA();
 };
 

--- a/quisp/utils/IComponentProviderStrategy.h
+++ b/quisp/utils/IComponentProviderStrategy.h
@@ -13,6 +13,8 @@ class IComponentProviderStrategy {
   virtual ~IComponentProviderStrategy() {}
   virtual cModule *getQNode() = 0;
   virtual StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) = 0;
+  virtual IRoutingDaemon *getRoutingDaemon() = 0;
+  virtual IHardwareMonitor *getHardwareMonitor() = 0;
 };
 
 }  // namespace utils

--- a/quisp/utils/IComponentProviderStrategy.h
+++ b/quisp/utils/IComponentProviderStrategy.h
@@ -17,8 +17,10 @@ class IComponentProviderStrategy {
   virtual bool isHoMNodeType(const cModuleType *const module) = 0;
   virtual bool isSPDCNodeType(const cModuleType *const module) = 0;
   virtual StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) = 0;
+  virtual cModule *getQNIC(int qnic_index, QNIC_type qnic_type) = 0;
   virtual IRoutingDaemon *getRoutingDaemon() = 0;
   virtual IHardwareMonitor *getHardwareMonitor() = 0;
+  virtual IRealTimeController *getRealTimeController() = 0;
 };
 
 }  // namespace utils

--- a/quisp/utils/IComponentProviderStrategy.h
+++ b/quisp/utils/IComponentProviderStrategy.h
@@ -12,6 +12,10 @@ class IComponentProviderStrategy {
   IComponentProviderStrategy() {}
   virtual ~IComponentProviderStrategy() {}
   virtual cModule *getQNode() = 0;
+  virtual cModule *getNeighborNode(cModule *qnic) = 0;
+  virtual bool isQNodeType(const cModuleType *const module) = 0;
+  virtual bool isHoMNodeType(const cModuleType *const module) = 0;
+  virtual bool isSPDCNodeType(const cModuleType *const module) = 0;
   virtual StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) = 0;
   virtual IRoutingDaemon *getRoutingDaemon() = 0;
   virtual IHardwareMonitor *getHardwareMonitor() = 0;

--- a/quisp/utils/utils.h
+++ b/quisp/utils/utils.h
@@ -4,6 +4,7 @@
 #include <modules/QNIC.h>
 #include <modules/QNIC/StationaryQubit/StationaryQubit.h>
 #include <modules/QRSA/HardwareMonitor/IHardwareMonitor.h>
+#include <modules/QRSA/RealTimeController/IRealTimeController.h>
 #include <modules/QRSA/RoutingDaemon/IRoutingDaemon.h>
 #include <omnetpp.h>
 
@@ -11,6 +12,7 @@ namespace quisp {
 namespace utils {
 
 using modules::IHardwareMonitor;
+using modules::IRealTimeController;
 using modules::IRoutingDaemon;
 using modules::QNIC_N;
 using modules::QNIC_names;

--- a/quisp/utils/utils.h
+++ b/quisp/utils/utils.h
@@ -3,11 +3,15 @@
 
 #include <modules/QNIC.h>
 #include <modules/QNIC/StationaryQubit/StationaryQubit.h>
+#include <modules/QRSA/HardwareMonitor/IHardwareMonitor.h>
+#include <modules/QRSA/RoutingDaemon/IRoutingDaemon.h>
 #include <omnetpp.h>
 
 namespace quisp {
 namespace utils {
 
+using modules::IHardwareMonitor;
+using modules::IRoutingDaemon;
 using modules::QNIC_N;
 using modules::QNIC_names;
 using modules::QNIC_type;


### PR DESCRIPTION
apply `ComponentProvider` to QRSA modules
* create interfaces for QRSA modules
* add `ComponentProvider` member into each module
* add tests

now there is no test for `RoutingDaemon` because I don't have any idea to write a test for `RoutingDaemon`.
we should write a module test for `RoutingDaemon`.