### PR TITLE
add .envrc to gitignore for direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### direnv https://github.com/direnv/direnv
+.envrc
+
 ### quisp specific
 /doc/html/
 *.orig
@@ -41,7 +44,8 @@ tags
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*


### PR DESCRIPTION
I'm using [direnv](https://github.com/direnv/direnv) to set environment variable for OMNeT++.
direnv looks `.envrc` when I'm in the repository directory, so I want to ignore `.envrc` from git
`.envrc` looks like this. I don't want to type `$ cd ~/omnetpp-5.6.2 && source setenv && cd -` everytime.
```
PATH_add "$HOME/omnetpp-5.6.2/bin"
PATH_add "$HOME/omnetpp-5.6.2/tools/macosx/bin"
export QT_PLUGIN_PATH=$HOME/omnetpp-5.6.2/tools/macosx/plugins
export QT_SELECT=5
```