### PR TITLE
Add eigen3 as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "googletest"]
 	path = googletest
 	url = https://github.com/google/googletest
+[submodule "eigen"]
+	path = eigen
+	url = https://gitlab.com/libeigen/eigen.git

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,12 @@ makefile-lib:
 
 clean:
 	$(RM) quisp/Makefile quisp/quisp quisp/quisp_dbg quisp/run_unit_test quisp/libquisp*
-	$(RM) -r quisp/out googletest/build
-	$(RM) -r quisp/out eigen/build
+	$(RM) -r quisp/out
+
+distclean:
+	git submodule deinit --all
+	make clean
+
 
 checkmakefile:
 	@if [ ! -f $(QUISP_MAKEFILE) ]; then \

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,16 @@ googletest/build/lib: googletest/build
 
 googletest: googletest/build/lib
 
+
+eigen/CMakeLists.txt:
+	git submodule update --init
+
+eigen/build/eigen3.pc: eigen/CMakeLists.txt
+	cmake ./eigen -B ./eigen/build -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=./eigen/build
+	make -C eigen/build install
+
+eigen: eigen/build/eigen3.pc
+
 makefile-exe:
 	cd quisp && opp_makemake -f --deep -O out -i ./makefrag
 
@@ -46,6 +56,7 @@ makefile-lib:
 clean:
 	$(RM) quisp/Makefile quisp/quisp quisp/quisp_dbg quisp/run_unit_test quisp/libquisp*
 	$(RM) -r quisp/out googletest/build
+	$(RM) -r quisp/out eigen/build
 
 checkmakefile:
 	@if [ ! -f $(QUISP_MAKEFILE) ]; then \

--- a/Makefile
+++ b/Makefile
@@ -37,20 +37,15 @@ googletest/build/lib: googletest/build
 
 googletest: googletest/build/lib
 
-
 eigen/CMakeLists.txt:
 	git submodule update --init
 
-eigen/build/eigen3.pc: eigen/CMakeLists.txt
-	cmake ./eigen -B ./eigen/build -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=./eigen/build
-	make -C eigen/build install
+eigen: eigen/CMakeLists.txt
 
-eigen: eigen/build/eigen3.pc
-
-makefile-exe:
+makefile-exe: eigen
 	cd quisp && opp_makemake -f --deep -O out -i ./makefrag
 
-makefile-lib:
+makefile-lib: eigen
 	cd quisp && opp_makemake -f --deep -O out -i ./makefrag -M debug  --make-so
 
 clean:
@@ -58,7 +53,7 @@ clean:
 	$(RM) -r quisp/out
 
 distclean:
-	git submodule deinit --all
+	git submodule deinit --all -f
 	make clean
 
 

--- a/doc/Build_on_docker.md
+++ b/doc/Build_on_docker.md
@@ -1,6 +1,6 @@
 # installation omnetpp gui and quisp on docker (For OSX)
 
-This is instruction for installing omnetpp and quisp on docker.  
+This is instruction for installing omnetpp and quisp on docker.
 This on MacOS Catalina (10.15.3) and Mojave(10.14).
 
 ## TL;DR
@@ -37,7 +37,7 @@ After you have successfully installed the related tools, please reboot your lapt
 
 3. Build docker container
 
-Open terminal and move to the `quisp/`, 
+Open terminal and move to the `quisp/`,
 
 ```zsh
 $ sh docker_build.sh
@@ -101,7 +101,7 @@ Download XQuartz from [**here**](https://www.xquartz.org/).
 $ brew install socat
 ```
 
-These are nessesary for building GUI version of omnet.  
+These are nessesary for building GUI version of omnet.
 If you finish installing those tools successfully, **reboot your mac** and check **$DISPLAY** like,
 
 ```zsh
@@ -113,7 +113,7 @@ If you can't see any values in $DISPLAY, uninstall XQuartz and install it again.
 
 ## 3. Build docker container
 
-Next, let's build the docker container on your Mac.  
+Next, let's build the docker container on your Mac.
 (This might take a lot of time. Probably, about 15 min)
 ***!!!!!<CHANGE WHEN THIS BECOME OSS>***
 ```zsh
@@ -151,7 +151,7 @@ Enter on the **xterm** (not your default terminal)
 > xhost <your ip address>
 ```
 
-\<your ip address> is your host ip address you checked previously.  
+\<your ip address> is your host ip address you checked previously.
 
 If you have trouble with using `xhost`, and [see](./xhost_trouble_shooting.md).
 
@@ -165,7 +165,7 @@ $ socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"&
 
 Open the file which has Dockerfile (in quisp)
 
-```zsh 
+```zsh
 $ sh quisp_docker.sh
 ```
 
@@ -177,7 +177,7 @@ You can run your container and **in the container**, run
 You can use omnetpp and quisp on docker container.
 
 ## 5.Set up your OMNET++
-After the logo shows up, you will see the following tab. You can just press "Launch" button. 
+After the logo shows up, you will see the following tab. You can just press "Launch" button.
 
 ![Setup](https://user-images.githubusercontent.com/45162150/74584459-e7b2a000-5015-11ea-95a0-cd811ed9b25d.png)
 
@@ -215,31 +215,7 @@ This is what the "Properties" page looks like. Next, you should click the "Makem
 ![](https://i.imgur.com/2njDPBi.png)
 
 
-Then, you have to click \UTF{2460}~\UTF{2462} in the following image.
-
-![](https://i.imgur.com/Zwqql8b.png)
-
-
-You will go to the following page, so you should click the "Compile" tab.
-
-![](https://i.imgur.com/wdeH3pC.png)
-
-After you click the "Compile" tab, You will see the following page.
-
-![](https://i.imgur.com/CTB85mk.png)
-
-Then, you should click the small icon which is pointed by an arrow, 
-
-![](https://i.imgur.com/Up47pD1.png)
-
-and you should put "usr/include/eigen3" in the blank and Press "OK".
-
-Then, you will go back to the "Compile" tab, so press "OK"
-
-![](https://i.imgur.com/0TnZxmR.png)
-
-
-After that, you will go back to its previous page, so press "Apply and Close" button.
+click "quisp" in the center list and click "Makemake" in "Build" area  on right side (make it same as the screenshot below). and then press "Apply and Close" button.
 
 ![](https://i.imgur.com/TH3yLUM.png)
 

--- a/doc/Build_on_windows.md
+++ b/doc/Build_on_windows.md
@@ -4,7 +4,7 @@
 * Before You Start
 * OMNeT++ Installation
 * Install Needed Tools for the GUI
-* Cloning and Building Quisp 
+* Cloning and Building Quisp
 * Running A Simulation
 
 
@@ -35,7 +35,7 @@ $ ./configure
 $ make
 ```
 
-This might take a while to finish executing. 
+This might take a while to finish executing.
 
 **To verify** that the installation has been successful, run the following:
 
@@ -63,33 +63,31 @@ Yay!! your installation was successful!!
 $ omnetpp
 ```
 
-###### Whenever you want to run omnetpp, you will need to run from the mingwenv console.
+*Whenever you want to run omnetpp, you will need to run from the mingwenv console*
 
 
 
 ![](img/8.jpg)
 
-## 2- Install Needed Tools for the GUI
-To run the simulation GUI, you will need to install *Eigen*.
-
-In the mingwenv console, type the following command:
-```
-git clone https://gitlab.com/libeigen/eigen.git
-```
-For more information on Eigen, please visit [this](http://eigen.tuxfamily.org/index.php?title=Main_Page) site.
-
-
-## 3- Cloning and Building Quisp
+## 2-  Cloning and Building Quisp
 
 To clone and build Quisp, one your terminal (use the mingwenv console to clone the repo) and type the follwoing commands:
 ```
 $ git clone https://github.com/sfc-aqua/quisp.git
 ```
 
+## 3-  Install dependencies
+
+To install dependencies (Eigen and Googletest), one your terminal (use the mingwenv console to clone the repo) and type the follwoing commands:
+```
+$ cd quisp
+$ make eigen
+```
+
 ## 4- Set up OMNeT for the Simulation
 
-*Execute* the command `omnetpp` from mingwenv console. When the dialogue comes up, select your workspace and click *Launch*.  
-  
+*Execute* the command `omnetpp` from mingwenv console. When the dialogue comes up, select your workspace and click *Launch*.
+
 *Warning: Setting workspace as `<Directory where you extracted omnetpp>\omnetpp-5.x.x\quisp` is highly recommended.*
 
 
@@ -122,7 +120,7 @@ Select `quisp` and click *Finish*
 
 <img src="img/14-fix.png"  width="50%" height="50%">
 
-That will make *quisp* and *quisp* appear in your **Project Explorer** 
+That will make *quisp* and *quisp* appear in your **Project Explorer**
 
 Select quisp, right-click on it and choose *properties*.
 
@@ -131,18 +129,10 @@ Select quisp, right-click on it and choose *properties*.
 ![](img/16.jpg)
 
 In the screen that shows up, expand OMNeT++, click on Makemake.
-Select quisp from the middle and on the right-habd side, choose Makemake and then click on options. 
-
+Select quisp from the middle and on the right-habd side, choose Makemake and then just click on apply. now we don't need to setup options!
 
 
 ![](img/17.jpg)
-
-In the compile tab, click the add button ![](img/bu.jpg)
-and then choose the directroy for **Eigen** and click OK
-
-
-
-![](img/171.jpg)
 
 In the *Project Explorer* right-click on quisp and choose *Run As* > *OMNeT++ Simulation*.
 
@@ -165,7 +155,7 @@ Test the simulation by choosing a *Config name*
 ![](img/20.jpg)
 
 
-And Voilà !!! 
+And Voilà !!!
 
 
 

--- a/doc/Build_on_windows.md
+++ b/doc/Build_on_windows.md
@@ -76,15 +76,7 @@ To clone and build Quisp, one your terminal (use the mingwenv console to clone t
 $ git clone https://github.com/sfc-aqua/quisp.git
 ```
 
-## 3-  Install dependencies
-
-To install dependencies (Eigen and Googletest), one your terminal (use the mingwenv console to clone the repo) and type the follwoing commands:
-```
-$ cd quisp
-$ make eigen
-```
-
-## 4- Set up OMNeT for the Simulation
+## 3- Set up OMNeT for the Simulation
 
 *Execute* the command `omnetpp` from mingwenv console. When the dialogue comes up, select your workspace and click *Launch*.
 
@@ -162,7 +154,7 @@ And Voilà !!!
 ![](img/22.jpg)
 
 
-## 5- Running A Simulation
+## 4- Running A Simulation
 
 From File > Set Up an Unconfigured Network...
 

--- a/doc/Build_on_windows.md
+++ b/doc/Build_on_windows.md
@@ -121,7 +121,7 @@ Select quisp, right-click on it and choose *properties*.
 ![](img/16.jpg)
 
 In the screen that shows up, expand OMNeT++, click on Makemake.
-Select quisp from the middle and on the right-habd side, choose Makemake and then just click on apply. now we don't need to setup options!
+Select quisp from the middle and on the right-hand side, choose Makemake and then just click on apply. now we don't need to setup options!
 
 
 ![](img/17.jpg)

--- a/quisp/makefrag
+++ b/quisp/makefrag
@@ -17,18 +17,15 @@ TEST_LIBS=-L../googletest/build/lib -lgtest -lgmock
 # check eigen3 is in PKG_CONFIG_PATH
 PKG_CONFIG_STATUS=$(shell pkg-config eigen3 --cflags 2>/dev/null 1>&2; echo $$?)
 ifneq ('0','$(PKG_CONFIG_STATUS)')
-ifeq (,$(wildcard $(CURDIR)/../eigen/build/eigen3.pc))
-$(error 'eigen3 is not found. run "make eigen" first)
-endif
 # using quisp/eigen
-PKG_CONFIG_PATH:=$(CURDIR)/../eigen/build/
-INCLUDE_PATH+=-I. $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config eigen3 --cflags)
+INCLUDE_PATH+=-I. -I$(CURDIR)/../eigen/
 else
 INCLUDE_PATH+=-I. $(shell pkg-config eigen3 --cflags)
 endif
 
+INCLUDE_PATH+=-I.
 
-default: all
+default: eigen all
 
 format:
 	clang-format -i $(SRCS) $(HEADERS)
@@ -53,5 +50,21 @@ $(TARGET_DIR)/run_unit_test: $(TARGET_DIR)/$(TARGET) $(TEST_OBJS)  $(wildcard $(
 run-unit-test: $(TARGET_DIR)/run_unit_test
 	$(TARGET_DIR)/run_unit_test
 
+.PHONY: eigen
+# check eigen exists and setup eigen if needed.
 eigen:
+	PKG_CONFIG_STATUS=$(shell pkg-config eigen3 --cflags 2>/dev/null 1>&2; echo $$?)
+# check eigen3 exists on pkg-config
+ifneq ('0','$(PKG_CONFIG_STATUS)')
+# check eigen is installed on quisp/eigen
+ifeq (,$(wildcard $(CURDIR)/../eigen/CMakeLists.txt))
 	make eigen -C $(CURDIR)/..
+endif
+	# using quisp/eigen
+	INCLUDE_PATH+=-I$(CURDIR)/../eigen/
+else
+	INCLUDE_PATH+=-I. $(shell pkg-config eigen3 --cflags)
+endif
+
+all: eigen
+

--- a/quisp/makefrag
+++ b/quisp/makefrag
@@ -17,11 +17,16 @@ TEST_LIBS=-L../googletest/build/lib -lgtest -lgmock
 # check eigen3 is in PKG_CONFIG_PATH
 PKG_CONFIG_STATUS=$(shell pkg-config eigen3 --cflags 2>/dev/null 1>&2; echo $$?)
 ifneq ('0','$(PKG_CONFIG_STATUS)')
-$(warning 'eigen3 is not found in pkg-config. check you PKG_CONFIG_PATH')
-$(warning 'your PKG_CONFIG_PATH is $(PKG_CONFIG_PATH)')
+ifeq (,$(wildcard $(CURDIR)/../eigen/build/eigen3.pc))
+$(error 'eigen3 is not found. run "make eigen" first)
+endif
+# using quisp/eigen
+PKG_CONFIG_PATH:=$(CURDIR)/../eigen/build/
+INCLUDE_PATH+=-I. $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config eigen3 --cflags)
+else
+INCLUDE_PATH+=-I. $(shell pkg-config eigen3 --cflags)
 endif
 
-INCLUDE_PATH+=-I. $(shell pkg-config eigen3 --cflags)
 
 default: all
 
@@ -47,3 +52,6 @@ $(TARGET_DIR)/run_unit_test: $(TARGET_DIR)/$(TARGET) $(TEST_OBJS)  $(wildcard $(
 
 run-unit-test: $(TARGET_DIR)/run_unit_test
 	$(TARGET_DIR)/run_unit_test
+
+eigen:
+	make eigen -C $(CURDIR)/..


### PR DESCRIPTION
now we are using Eigen library and ask a user to install it and set the path for eigen.
this PR added the Eigen library as a submodule and handle it in Makefile (quisp/makefrag) automatically.
So we don't need to tell eigen's path to OMNeT++IDE.
~~what a user has to do is just run `$ make eigen` first and then they can start development.~~


if your environment has Eigen library and `PKG_CONFIG_PATH` is configured properly, this PR doesn't do anything.

## TODO
- [x] add eigen as submodule
- [x] update documents
- [x] add `distclean` rule to delete googletest and eigen3's build artifacts.