### PR TITLE
Fix the typo for simultaneous option

### DIFF
--- a/quisp/modules/QNode.ned
+++ b/quisp/modules/QNode.ned
@@ -17,6 +17,7 @@ module QNode
         string includeInTopo = "yes";
         string nodeType = default("none");
         double emission_timing_std = default(0);//in seconds
+        bool simultaneous_es_enabled = default(false);
 
     gates:
         inout port[];//size will be determined by the number of connections defined at the end of this file
@@ -58,6 +59,7 @@ module QNode
                 number_of_qnics = sizeof(quantum_port);
                 number_of_qnics_r = sizeof(quantum_port_receiver);
                 number_of_qnics_rp = sizeof(quantum_port_receiver_passive);
+                simultaneous_es_enabled = simultaneous_es_enabled;
         }
         qnic[sizeof(quantum_port)]: QNIC {//number of QNIC is the same as number of classical queue/NIC
             parameters:

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -25,7 +25,7 @@ void ConnectionManager::initialize() {
   hardware_monitor = provider.getHardwareMonitor();
   my_address = par("address");
   num_of_qnics = par("total_number_of_qnics");
-  simultaneous_es_enabled = par("simultaneousES");
+  simultaneous_es_enabled = par("simultaneous_es_enabled");
 
   for (int i = 0; i < num_of_qnics; i++) {
     // qnode address

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.ned
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.ned
@@ -7,7 +7,7 @@ simple ConnectionManager
         int number_of_qnics_r;
         int number_of_qnics_rp;
         int total_number_of_qnics;
-        bool simultaneousES = default(false);
+        bool simultaneous_es_enabled = default(false);
 
     gates:
         inout RouterPort;

--- a/quisp/modules/QRSA/QRSA.ned
+++ b/quisp/modules/QRSA/QRSA.ned
@@ -13,6 +13,7 @@ module quantumRoutingSoft
         int number_of_qnics;
         int number_of_qnics_r;
         int number_of_qnics_rp;
+        bool simultaneous_es_enabled;
     gates:
         //inout rdPort;//size will be determined by the number of connections defined at the end of this file
         inout cmPort;
@@ -43,6 +44,7 @@ module quantumRoutingSoft
                 number_of_qnics_r = number_of_qnics_r;
                 number_of_qnics_rp = number_of_qnics_rp;
                 total_number_of_qnics = number_of_qnics +  number_of_qnics_r + number_of_qnics_rp;
+                simultaneous_es_enabled = simultaneous_es_enabled;
                 @display("p=227,148");
         }
         rt: RealTimeController {

--- a/quisp/networks/omnetpp.ini
+++ b/quisp/networks/omnetpp.ini
@@ -363,7 +363,7 @@ seed-set = 4 #2
 # 2 = every node selects a random partner
 #**.TrafficPattern = 2
 **.link_tomography = false
-**.simultaneousES = true
+**.simultaneous_es_enabled = true
 #**.initial_purification = 1
 
 


### PR DESCRIPTION
Fix the typo for simultaneous entanglement swapping option. Change every parameter name related to the option to be simultaneous_es_enabled and parameter in ned file, otherwise, it cause an error.