### PR TITLE
fix unit test error when run it one by one

### DIFF
--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor_test.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor_test.cc
@@ -74,6 +74,7 @@ class HardwareMonitorTestTarget : public quisp::modules::HardwareMonitor {
 };
 
 TEST(HardwareMonitorTestTarget, Init) {
+  prepareSimulation();
   auto* mock_routing_daemon = new MockRoutingDaemon;
   auto* mock_qubit = new MockStationaryQubit;
   EXPECT_CALL(*mock_routing_daemon, returnNumEndNodes()).WillOnce(Return(1));

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
@@ -15,6 +15,7 @@ namespace {
 using namespace omnetpp;
 using namespace quisp::utils;
 using namespace quisp::modules;
+using namespace quisp_test;
 
 class MockStationaryQubit : public StationaryQubit {
  public:
@@ -55,6 +56,7 @@ TEST(RealTimeControllerTest, Init) {
   ASSERT_EQ(c.par("address").intValue(), 123);
 }
 TEST(RealTimeControllerTest, EmitPhoton) {
+  prepareSimulation();
   auto* qubit = new MockStationaryQubit{};
   RTCTestTarget c{qubit};
   c.initialize();
@@ -64,6 +66,7 @@ TEST(RealTimeControllerTest, EmitPhoton) {
 }
 
 TEST(RealTimeControllerTest, ReInitializeStationaryQubit) {
+  prepareSimulation();
   auto* qubit = new MockStationaryQubit{};
   RTCTestTarget c{qubit};
   c.initialize();

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -83,6 +83,7 @@ class RuleEngineTestTarget : public quisp::modules::RuleEngine {
 };
 
 TEST(RuleEngineTest, ESResourceUpdate) {
+  prepareSimulation();
   auto routingdaemon = new MockRoutingDaemon;
   auto mockHardwareMonitor = new MockHardwareMonitor;
   auto mockQubit0 = new MockStationaryQubit;


### PR DESCRIPTION
fix the error of unit tests when running only one test like this.
```
./run_unit_test  --gtest_filter="RuleEngineTest*"
Note: Google Test filter = RuleEngineTest*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from RuleEngineTest
[ RUN      ] RuleEngineTest.ESResourceUpdate
unknown file: Failure
C++ exception with description "Global simtime_t variable found, with value -1. Global simtime_t variables are forbidden, because scale exponent is not yet known at the time they are initialized. Please use double or const_simtime_t instead" thrown in the test body.
[  FAILED  ] RuleEngineTest.ESResourceUpdate (0 ms)
[----------] 1 test from RuleEngineTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] RuleEngineTest.ESResourceUpdate

 1 FAILED TEST
<!> WARNING: global object variable (DISCOURAGED) detected: (_GLOBAL__N_1::MockRoutingDaemon)'' at 0x7f9c10509b00
<!> WARNING: global object variable (DISCOURAGED) detected: (_GLOBAL__N_1::MockHardwareMonitor)'' at 0x7f9c10509c40
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/230)
<!-- Reviewable:end -->
