### PR TITLE
add StationaryQubit MemoryTransitionMatrix unit test

### DIFF
--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -94,15 +94,16 @@ memory_err.completely_mixed_rate = memory_err.error_rate * (memory_completely_mi
   EV<<"Excitation error rate (mem) = "<<memory_err.excitation_error_rate<<"\n";
   EV<<"Relaxation error rate (mem) = "<<memory_err.relaxation_error_rate<<"\n";*/
   Memory_Transition_matrix = MatrixXd::Zero(7, 7);
-  Memory_Transition_matrix << 1 - memory_err.error_rate, memory_err.X_error_rate, memory_err.Z_error_rate, memory_err.Y_error_rate, memory_err.excitation_error_rate,
-      memory_err.relaxation_error_rate, memory_err.completely_mixed_rate, memory_err.X_error_rate, 1 - memory_err.error_rate, memory_err.Y_error_rate, memory_err.Z_error_rate,
-      memory_err.excitation_error_rate, memory_err.relaxation_error_rate, memory_err.completely_mixed_rate, memory_err.Z_error_rate, memory_err.Y_error_rate,
-      1 - memory_err.error_rate, memory_err.X_error_rate, memory_err.excitation_error_rate, memory_err.relaxation_error_rate, memory_err.completely_mixed_rate,
-      memory_err.Y_error_rate, memory_err.Z_error_rate, memory_err.X_error_rate, 1 - memory_err.error_rate, memory_err.excitation_error_rate, memory_err.relaxation_error_rate,
-      memory_err.completely_mixed_rate, 0, 0, 0, 0, 1 - memory_err.relaxation_error_rate - memory_err.completely_mixed_rate, memory_err.relaxation_error_rate,
-      memory_err.completely_mixed_rate, 0, 0, 0, 0, memory_err.excitation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.completely_mixed_rate,
-      memory_err.completely_mixed_rate, 0, 0, 0, 0, memory_err.excitation_error_rate, memory_err.relaxation_error_rate,
-      1 - memory_err.excitation_error_rate - memory_err.relaxation_error_rate;
+  // clang-format off
+  Memory_Transition_matrix <<
+    1 - memory_err.error_rate,  memory_err.X_error_rate,   memory_err.Z_error_rate,   memory_err.Y_error_rate,    memory_err.excitation_error_rate, memory_err.relaxation_error_rate, memory_err.completely_mixed_rate,
+    memory_err.X_error_rate,    1 - memory_err.error_rate, memory_err.Y_error_rate,   memory_err.Z_error_rate,    memory_err.excitation_error_rate, memory_err.relaxation_error_rate, memory_err.completely_mixed_rate,
+    memory_err.Z_error_rate,    memory_err.Y_error_rate,   1 - memory_err.error_rate, memory_err.X_error_rate,    memory_err.excitation_error_rate, memory_err.relaxation_error_rate, memory_err.completely_mixed_rate,
+    memory_err.Y_error_rate,    memory_err.Z_error_rate,   memory_err.X_error_rate,   1 - memory_err.error_rate,  memory_err.excitation_error_rate, memory_err.relaxation_error_rate, memory_err.completely_mixed_rate,
+    0,                          0,                         0,                         0,                          1 - memory_err.relaxation_error_rate - memory_err.completely_mixed_rate, memory_err.relaxation_error_rate, memory_err.completely_mixed_rate,
+    0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.completely_mixed_rate, memory_err.completely_mixed_rate,
+    0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, memory_err.relaxation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.relaxation_error_rate;
+  // clang-format on
   std::cout << "Memory_Transition_matrix = \n " << Memory_Transition_matrix << " done \n";
 
   Hgate_error = SetSingleQubitGateErrorCeilings("Hgate");

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -22,7 +22,8 @@ namespace modules {
 
 /** \class StationaryQubit StationaryQubit.h
  *
- *  \brief StationaryQubit
+ *  \brief StationaryQubit.
+ *  \ref https://arxiv.org/abs/1908.10758
  */
 
 typedef std::complex<double> Complex;
@@ -204,6 +205,7 @@ class StationaryQubit : public cSimpleModule {
 
   single_qubit_error Pauli;
   measurement_operators meas_op;
+  // https://arxiv.org/abs/1908.10758 Eq 5.2
   MatrixXd Memory_Transition_matrix; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in μs.*/
   MatrixXd Memory_Transition_matrix_ns; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/
   MatrixXd Memory_Transition_matrix_ms; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -1,0 +1,124 @@
+#include "StationaryQubit.h"
+#include <gtest/gtest.h>
+#include <test_utils/TestUtils.h>
+#include <unsupported/Eigen/MatrixFunctions>
+
+using namespace quisp::modules;
+using namespace quisp_test;
+namespace {
+
+class StatQubitTarget : public StationaryQubit {
+ public:
+  using StationaryQubit::initialize;
+  using StationaryQubit::par;
+  StatQubitTarget() : StationaryQubit() { setComponentType(new TestModuleType("test qubit")); }
+  void fillParams() {
+    // see networks/omnetpp.ini
+    setParDouble(this, "emission_success_probability", 0.5);
+    setParDouble(this, "memory_X_error_rate", 1.11111111e-7);
+    setParDouble(this, "memory_Y_error_rate", 1.11111111e-7);
+    setParDouble(this, "memory_Z_error_rate", 1.11111111e-7);
+    setParDouble(this, "memory_energy_excitation_rate", 0.000198);
+    setParDouble(this, "memory_energy_relaxation_rate", 0.00000198);
+    setParDouble(this, "memory_completely_mixed_rate", 0);
+
+    setParDouble(this, "Hgate_error_rate", 1 / 2000);
+    setParDouble(this, "Hgate_X_error_ratio", 0);
+    setParDouble(this, "Hgate_Z_error_ratio", 0);
+    setParDouble(this, "Hgate_Y_error_ratio", 0);
+
+    setParDouble(this, "Xgate_error_rate", 1 / 2000);
+    setParDouble(this, "Xgate_X_error_ratio", 0);
+    setParDouble(this, "Xgate_Z_error_ratio", 0);
+    setParDouble(this, "Xgate_Y_error_ratio", 0);
+
+    setParDouble(this, "Zgate_error_rate", 1 / 2000);
+    setParDouble(this, "Zgate_X_error_ratio", 0);
+    setParDouble(this, "Zgate_Z_error_ratio", 0);
+    setParDouble(this, "Zgate_Y_error_ratio", 0);
+
+    setParDouble(this, "Measurement_error_rate", 1 / 2000);
+    setParDouble(this, "Measurement_X_error_ratio", 1);
+    setParDouble(this, "Measurement_Y_error_ratio", 1);
+    setParDouble(this, "Measurement_Z_error_ratio", 1);
+
+    setParDouble(this, "CNOTgate_error_rate", 1 / 2000);
+    setParDouble(this, "CNOTgate_IX_error_ratio", 1);
+    setParDouble(this, "CNOTgate_XI_error_ratio", 1);
+    setParDouble(this, "CNOTgate_XX_error_ratio", 1);
+    setParDouble(this, "CNOTgate_IZ_error_ratio", 1);
+    setParDouble(this, "CNOTgate_ZI_error_ratio", 1);
+    setParDouble(this, "CNOTgate_ZZ_error_ratio", 1);
+    setParDouble(this, "CNOTgate_IY_error_ratio", 1);
+    setParDouble(this, "CNOTgate_YI_error_ratio", 1);
+    setParDouble(this, "CNOTgate_YY_error_ratio", 1);
+
+    setParInt(this, "stationaryQubit_address", 1);
+    setParInt(this, "node_address", 1);
+    setParInt(this, "qnic_address", 1);
+    setParInt(this, "qnic_type", 0);
+    setParInt(this, "qnic_index", 0);
+    setParDouble(this, "std", 0.5);
+
+    setParDouble(this, "photon_emitted_at", 0.0);
+    setParDouble(this, "last_updated_at", 0.0);
+    setParBool(this, "GOD_Xerror", false);
+    setParBool(this, "GOD_Zerror", false);
+    setParBool(this, "GOD_CMerror", false);
+    setParBool(this, "GOD_EXerror", false);
+    setParBool(this, "GOD_REerror", false);
+    setParBool(this, "isBusy", false);
+    setParInt(this, "GOD_entangled_stationaryQubit_address", 0);
+    setParInt(this, "GOD_entangled_node_address", 0);
+    setParInt(this, "GOD_entangled_qnic_address", 0);
+    setParInt(this, "GOD_entangled_qnic_type", 0);
+    setParDouble(this, "fidelity", -1.0);
+  }
+};
+
+TEST(StationaryQubitTest, initialize_memory_transition_matrix) {
+  auto *sim = prepareSimulation();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  setParDouble(qubit, "memory_X_error_rate", .011);
+  setParDouble(qubit, "memory_Y_error_rate", .012);
+  setParDouble(qubit, "memory_Z_error_rate", .013);
+  setParDouble(qubit, "memory_energy_excitation_rate", .014);
+  setParDouble(qubit, "memory_energy_relaxation_rate", .015);
+  setParDouble(qubit, "memory_completely_mixed_rate", 0);
+  sim->registerComponent(qubit);
+  qubit->callInitialize();
+
+  auto mat = qubit->Memory_Transition_matrix;
+
+  // each element means: "Clean Xerror Zerror Yerror Excited Relaxed Mixed"
+  Eigen::RowVectorXd row0(7);
+  double sigma = .011 + .013 + .012 + .014 + .015;
+  row0 << 1 - sigma, .011, .013, .012, .014, .015, .0;
+  ASSERT_EQ(mat.row(0), row0);
+
+  Eigen::RowVectorXd row1(7);
+  row1 << .011, 1 - sigma, .012, .013, .014, .015, .0;
+  ASSERT_EQ(mat.row(1), row1);
+
+  Eigen::RowVectorXd row2(7);
+  row2 << .013, .012, 1 - sigma, .011, .014, .015, .0;
+  ASSERT_EQ(mat.row(2), row2);
+
+  Eigen::RowVectorXd row3(7);
+  row3 << .012, .013, .011, 1 - sigma, .014, .015, .0;
+  ASSERT_EQ(mat.row(3), row3);
+
+  Eigen::RowVectorXd row4(7);
+  row4 << 0, 0, 0, 0, 1 - .015, .015, .0;
+  ASSERT_EQ(mat.row(4), row4);
+
+  Eigen::RowVectorXd row5(7);
+  row5 << 0, 0, 0, 0, .014, 1 - .014, .0;
+  ASSERT_EQ(mat.row(5), row5);
+
+  Eigen::RowVectorXd row6(7);
+  row6 << 0, 0, 0, 0, .014, .015, 1 - (.014 + .015);
+  ASSERT_EQ(mat.row(6), row6);
+}
+}  // namespace

--- a/quisp/test_utils/UtilFunctions.cc
+++ b/quisp/test_utils/UtilFunctions.cc
@@ -8,6 +8,10 @@ namespace quisp_test {
 namespace utils {
 
 void setParInt(cModule *module, const char *name, const int val) {
+  if (module->findPar(name) != -1) {
+    module->par(name) = val;
+    return;
+  }
   cParImpl *p = new cIntParImpl();
   p->setName(name);
   p->setIntValue(val);
@@ -15,6 +19,10 @@ void setParInt(cModule *module, const char *name, const int val) {
 }
 
 void setParDouble(cModule *module, const char *name, const double val) {
+  if (module->findPar(name) != -1) {
+    module->par(name) = val;
+    return;
+  }
   cParImpl *p = new cDoubleParImpl();
   p->setName(name);
   p->setDoubleValue(val);
@@ -22,6 +30,10 @@ void setParDouble(cModule *module, const char *name, const double val) {
 }
 
 void setParStr(cModule *module, const char *name, const char *val) {
+  if (module->findPar(name) != -1) {
+    module->par(name) = val;
+    return;
+  }
   cParImpl *p = new cStringParImpl();
   p->setName(name);
   p->setStringValue(val);
@@ -29,6 +41,10 @@ void setParStr(cModule *module, const char *name, const char *val) {
 }
 
 void setParBool(cModule *module, const char *name, const bool val) {
+  if (module->findPar(name) != -1) {
+    module->par(name) = val;
+    return;
+  }
   cParImpl *p = new cBoolParImpl();
   p->setName(name);
   p->setBoolValue(val);


### PR DESCRIPTION
I added a MemoryTransitionMatrix unit test and fix `setParFoo` test utility functions to overwrite parameters.
the matrix described in Eq 5.2 https://arxiv.org/abs/1908.10758


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/232)
<!-- Reviewable:end -->
