### PR TITLE
Remove inheritances of std::list

### DIFF
--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -715,14 +715,14 @@ RuleSet *ConnectionManager::generateEntanglementSwappingRuleSet(int owner, Swapp
                                                     conf.rqnic_type, conf.rqnic_index, conf.rqnic_address, conf.rres, conf.self_left_qnic_index, conf.self_left_qnic_type,
                                                     conf.self_right_qnic_index, conf.self_right_qnic_type);
 
-  Rule *rule = new Rule(ruleset_id, rule_index, "entanglement swapping");
+  auto rule = std::make_unique<Rule>(ruleset_id, rule_index, "entanglement swapping");
   rule->setCondition(condition);
   rule->setAction(action);
 
   std::vector<int> partners = {conf.left_partner, conf.right_partner};
 
   RuleSet *ruleset = new RuleSet(ruleset_id, owner, partners);
-  ruleset->addRule(rule);
+  ruleset->addRule(std::move(rule));
 
   return ruleset;
 }
@@ -746,14 +746,14 @@ RuleSet *ConnectionManager::generateSimultaneousEntanglementSwappingRuleSet(int 
       conf.initiator_qnic_type, conf.initiator_qnic_index, conf.initiator_qnic_address, conf.initiator_res, conf.responder, conf.responder_qnic_type, conf.responder_qnic_index,
       conf.responder_qnic_address, conf.responder_res, index_in_path, path_length_exclude_IR);
 
-  Rule *rule = new Rule(ruleset_id, rule_index);
+  auto rule = std::make_unique<Rule>(ruleset_id, rule_index);
   rule->setCondition(condition);
   rule->setAction(action);
 
   std::vector<int> partners = {conf.left_partner, conf.right_partner};
 
   RuleSet *ruleset = new RuleSet(ruleset_id, owner, partners);
-  ruleset->addRule(rule);
+  ruleset->addRule(std::move(rule));
 
   return ruleset;
 }
@@ -763,7 +763,7 @@ RuleSet *ConnectionManager::generateTomographyRuleSet(int owner, int partner, in
 
   int rule_index = 0;
   RuleSet *tomography = new RuleSet(ruleset_id, owner, partner);
-  Rule *rule = new Rule(ruleset_id, rule_index, "tomography");
+  auto rule = std::make_unique<Rule>(ruleset_id, rule_index, "tomography");
 
   // 3000 measurements in total. There are 3*3 = 9 patterns of measurements. So each combination must perform 3000/9 measurements.
   Clause *count_clause = new MeasureCountClause(num_of_measure);
@@ -782,7 +782,7 @@ RuleSet *ConnectionManager::generateTomographyRuleSet(int owner, int partner, in
   rule->setAction(action);
 
   // Add the rule to the RuleSet
-  tomography->addRule(rule);
+  tomography->addRule(std::move(rule));
 
   return tomography;
 }

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -723,7 +723,6 @@ RuleSet *ConnectionManager::generateEntanglementSwappingRuleSet(int owner, Swapp
 
   RuleSet *ruleset = new RuleSet(ruleset_id, owner, partners);
   ruleset->addRule(rule);
-  ruleset->setRule_ptr(rule);
 
   return ruleset;
 }
@@ -755,7 +754,6 @@ RuleSet *ConnectionManager::generateSimultaneousEntanglementSwappingRuleSet(int 
 
   RuleSet *ruleset = new RuleSet(ruleset_id, owner, partners);
   ruleset->addRule(rule);
-  ruleset->setRule_ptr(rule);
 
   return ruleset;
 }

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -643,7 +643,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// ![](../img/PhysRevA.100.052320-Fig11.png)
       for (int i = 0; i < num_purification; i++) {
         // First stage X purification
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 2);
         Purification_condition->addClause(resource_clause);
@@ -651,10 +651,10 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
         Action *purify_action = new PurifyAction(RuleSet_id, rule_index, true, false, num_purification, partner_address, qnic_type, qnic_index, 0, 1);
         Purification->setAction(purify_action);
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
 
         // Second stage Z purification (Using X purified resources)
-        Purification = new Rule(RuleSet_id, rule_index);
+        Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Purification_condition = new Condition();
         resource_clause = new EnoughResourceClause(partner_address, 2);
         Purification_condition->addClause(resource_clause);
@@ -662,7 +662,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
         purify_action = new PurifyAction(RuleSet_id, rule_index, false, true, num_purification, partner_address, qnic_type, qnic_index, 0, 1);
         Purification->setAction(purify_action);
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 3003) {
       /// # Purification_type 3003: #
@@ -687,7 +687,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// ![](../img/PhysRevA.100.052320-Fig11.png)
       // First stage X purification
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 2);
         Purification_condition->addClause(resource_clause);
@@ -703,7 +703,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Purification->setAction(purify_action);
         }
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 1001) {
       /// # Purification_type 1001: #
@@ -722,7 +722,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// Similar to 1221.
       /// ![](../img/PhysRevA.100.052320-Fig12.png)
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
         Purification_condition->addClause(resource_clause);
@@ -730,7 +730,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
         Action *purify_action = new DoublePurifyAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
         Purification->setAction(purify_action);
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 1221) {
       /// # Purification_type 1221: #
@@ -748,7 +748,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// ![](../img/PhysRevA.100.052320-Fig12.png)
       for (int i = 0; i < num_purification; i++) {
         if (i % 2 == 0) {
-          Rule *Purification = new Rule(RuleSet_id, rule_index);
+          auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
           Condition *Purification_condition = new Condition();
           Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
           Purification_condition->addClause(resource_clause);
@@ -756,9 +756,9 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Action *purify_action = new DoublePurifyAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
           Purification->setAction(purify_action);
           rule_index++;
-          tomography_RuleSet->addRule(Purification);
+          tomography_RuleSet->addRule(std::move(Purification));
         } else {
-          Rule *Purification = new Rule(RuleSet_id, rule_index);
+          auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
           Condition *Purification_condition = new Condition();
           Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
           Purification_condition->addClause(resource_clause);
@@ -766,7 +766,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Action *purify_action = new DoublePurifyActionInv(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
           Purification->setAction(purify_action);
           rule_index++;
-          tomography_RuleSet->addRule(Purification);
+          tomography_RuleSet->addRule(std::move(Purification));
         }
       }
     } else if (Purification_type == 1011) {
@@ -785,7 +785,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// Note there is no basis change between rounds.
       /// ![](../img/arxiv.1904.08605-Fig13.png)
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
         Purification_condition->addClause(resource_clause);
@@ -793,7 +793,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
         Action *purify_action = new DoubleSelectionAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
         Purification->setAction(purify_action);
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 1021) {  // Fujii-san's Double selection purification
       /// # Purification_type 1021: #
@@ -810,7 +810,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// first round is XZ, second is ZX.
       /// ![](../img/arxiv.1904.08605-Fig13.png)
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
         Purification_condition->addClause(resource_clause);
@@ -823,7 +823,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Purification->setAction(purify_action);
         }
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 1031) {
       /// # Purification_type 1031: #
@@ -841,7 +841,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// be impractical.
       /// ![](../img/arxiv.1904.08605-Fig14.png)
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 5);
         Purification_condition->addClause(resource_clause);
@@ -854,7 +854,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Purification->setAction(purify_action);
         }
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 1061) {
       /// # Purification_type 1061: #
@@ -871,7 +871,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// Bell pairs. Initial results weren't very promised, not extensively
       /// used.
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 4);
         Purification_condition->addClause(resource_clause);
@@ -884,7 +884,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Purification->setAction(purify_action);
         }
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 5555) {  // Predefined purification method
       /// # Purification_type 5555: #
@@ -899,7 +899,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// The point of this was to show that you don't have to stick with one
       /// scheme, but can use different schemes in different rounds.
       for (int i = 0; i < 2; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
         Purification_condition->addClause(resource_clause);
@@ -912,11 +912,11 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Purification->setAction(purify_action);
         }
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
 
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 2);
         Purification_condition->addClause(resource_clause);
@@ -930,7 +930,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Purification->setAction(purify_action);
         }
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
     } else if (Purification_type == 5556) {  // Predefined purification method
       /// # Purification_type 5556: #
@@ -944,7 +944,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// One round of Ds-Sp, then Ss-Sp.
       /// The point of this was to show that you don't have to stick with one
       /// scheme, but can use different schemes in different rounds.
-      Rule *Purification = new Rule(RuleSet_id, rule_index);
+      auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
       Condition *Purification_condition = new Condition();
       Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
       Purification_condition->addClause(resource_clause);
@@ -952,10 +952,10 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       Action *purify_action = new DoubleSelectionAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
       Purification->setAction(purify_action);
       rule_index++;
-      tomography_RuleSet->addRule(Purification);
+      tomography_RuleSet->addRule(std::move(Purification));
 
       for (int i = 0; i < num_purification; i++) {
-        Rule *Purification = new Rule(RuleSet_id, rule_index);
+        auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
         Condition *Purification_condition = new Condition();
         Clause *resource_clause = new EnoughResourceClause(partner_address, 2);
         Purification_condition->addClause(resource_clause);
@@ -971,7 +971,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           Purification->setAction(purify_action);
         }
         rule_index++;
-        tomography_RuleSet->addRule(Purification);
+        tomography_RuleSet->addRule(std::move(Purification));
       }
 
     } else if ((X_Purification && !Z_Purification) || (!X_Purification && Z_Purification)) {  // X or Z purification. Out-dated syntax.
@@ -986,7 +986,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// uses X_Purification and Z_purification booleans, but is obsolete.
       /// Creates a single purification only, or a single round of double
       /// purification. Use of this for new work is deprecated.
-      Rule *Purification = new Rule(RuleSet_id, rule_index);
+      auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
       Condition *Purification_condition = new Condition();
       Clause *resource_clause = new EnoughResourceClause(partner_address, 2);
       Purification_condition->addClause(resource_clause);
@@ -994,10 +994,10 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       Action *purify_action = new PurifyAction(RuleSet_id, rule_index, X_Purification, Z_Purification, num_purification, partner_address, qnic_type, qnic_index, 0, 1);
       Purification->setAction(purify_action);
       rule_index++;
-      tomography_RuleSet->addRule(Purification);
+      tomography_RuleSet->addRule(std::move(Purification));
     } else {  // X, Z double purification
       error("syntax outdate or purification id not recognized.");
-      Rule *Purification = new Rule(RuleSet_id, rule_index);
+      auto Purification = std::make_unique<Rule>(RuleSet_id, rule_index);
       Condition *Purification_condition = new Condition();
       Clause *resource_clause = new EnoughResourceClause(partner_address, 3);
       Purification_condition->addClause(resource_clause);
@@ -1005,11 +1005,11 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       Action *purify_action = new DoublePurifyAction(RuleSet_id, rule_index, partner_address, qnic_type, qnic_index, 0, 1, 2);
       Purification->setAction(purify_action);
       rule_index++;
-      tomography_RuleSet->addRule(Purification);
+      tomography_RuleSet->addRule(std::move(Purification));
     }
 
     // Let's make nodes select measurement basis randomly, because it it easier.
-    Rule *Random_measure_tomo = new Rule(RuleSet_id, rule_index);
+    auto Random_measure_tomo = std::make_unique<Rule>(RuleSet_id, rule_index);
 
     // Technically, there is no condition because an available resource is
     // guaranteed whenever the rule is ran.
@@ -1026,7 +1026,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
     Random_measure_tomo->setAction(measure);
     //---------
     // Add the rule to the RuleSet
-    tomography_RuleSet->addRule(Random_measure_tomo);
+    tomography_RuleSet->addRule(std::move(Random_measure_tomo));
     //---------------------------
     pk->setRuleSet(tomography_RuleSet);
     send(pk, "RouterPort$o");
@@ -1037,7 +1037,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
     //-First rule-
 
     // Let's make nodes select measurement basis randomly, because it it easier.
-    Rule *Random_measure_tomo = new Rule(RuleSet_id, 0);
+    auto Random_measure_tomo = std::make_unique<Rule>(RuleSet_id, 0);
     // Technically, there is no condition because an available resource is guaranteed whenever the rule is ran.
     Condition *total_measurements = new Condition();
 
@@ -1054,7 +1054,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
     Random_measure_tomo->setAction(measure);
     //---------
     // Add the rule to the RuleSet
-    tomography_RuleSet->addRule(Random_measure_tomo);
+    tomography_RuleSet->addRule(std::move(Random_measure_tomo));
     tomography_RuleSet->finalize();
     //---------------------------
     pk->setRuleSet(tomography_RuleSet);

--- a/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
+++ b/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
@@ -70,12 +70,12 @@ struct PhotonTransmissionConfig {
   double interval;
 };
 
-// Process = RuleSet
-typedef struct {
+// Process contains RuleSet
+struct Process {
+  // is this different from RuleSet::owner_addr?
   int ownner_addr;
-  // int process_ID;
   RuleSet *Rs;
-} process;
+};
 
 typedef std::map<int, QubitState> QubitStateTable;
 typedef std::multimap<int, purification_result> PurificationTable;
@@ -84,7 +84,7 @@ typedef std::multimap<int, Quatropurification_result> QuatroPurificationTable;
 typedef std::multimap<int, Triplepurification_result> TriplePurificationTable;
 typedef std::map<int, QubitAddr_cons> sentQubitIndexTracker;  // nth shot -> node/qnic/qubit index (node addr not needed actually)
 typedef std::map<int, bool> trial_tracker;  // trial index, false or true (that trial is over or not)
-typedef std::map<int, process> running_processes;  // index -> process
+typedef std::map<int, Process> running_processes;  // index -> process
 typedef std::map<int, Rule *> rule_ptr;
 
 class IRuleEngine : public cSimpleModule {

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -150,11 +150,11 @@ TEST(RuleEngineTest, resourceAllocation) {
   rule_engine->setAllResources(1, mockQubit1);
   rule_engine->setAllResources(2, mockQubit2);
   auto* rs = new RuleSet(0, 0, 1);
-  auto* rule = new Rule();
+  auto rule = std::make_unique<Rule>();
   auto* action = new RandomMeasureAction(1, QNIC_E, 3, 1, 0, 1);
 
   rule->setAction(action);
-  rs->addRule(rule);
+  rs->addRule(std::move(rule));
   Process proc;
   proc.ownner_addr = 0;
   proc.Rs = rs;
@@ -166,7 +166,7 @@ TEST(RuleEngineTest, resourceAllocation) {
   auto* _rs = rule_engine->rp.at(0).Rs;
   EXPECT_NE(_rs, nullptr);
   EXPECT_EQ(_rs->size(), 1);
-  auto* _rule = _rs->getRule(0);
+  auto& _rule = _rs->getRule(0);
   EXPECT_FALSE(_rule == nullptr);
   EXPECT_EQ(_rule->resources.size(), 1);
   delete mockHardwareMonitor;

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -155,7 +155,7 @@ TEST(RuleEngineTest, resourceAllocation) {
 
   rule->setAction(action);
   rs->addRule(rule);
-  process proc;
+  Process proc;
   proc.ownner_addr = 0;
   proc.Rs = rs;
   rule_engine->rp.insert(std::make_pair(0, proc));
@@ -163,10 +163,10 @@ TEST(RuleEngineTest, resourceAllocation) {
   rule_engine->ResourceAllocation(QNIC_E, 3);
 
   // resource allocation assigns a corresponding qubit to action's resource
-  auto _rs = rule_engine->rp.at(0).Rs;
+  auto* _rs = rule_engine->rp.at(0).Rs;
   EXPECT_NE(_rs, nullptr);
   EXPECT_EQ(_rs->size(), 1);
-  auto _rule = _rs->front().get();
+  auto* _rule = _rs->getRule(0);
   EXPECT_FALSE(_rule == nullptr);
   EXPECT_EQ(_rule->resources.size(), 1);
   delete mockHardwareMonitor;

--- a/quisp/rules/Condition.cc
+++ b/quisp/rules/Condition.cc
@@ -11,49 +11,23 @@
 namespace quisp {
 namespace rules {
 
-/*
-bool Condition::check(qnicResources *resources) const {
-    EV<<"In condition...\n";
-    bool satisfying = true;
-    for (auto clause = cbegin(), end = cend(); clause != end; clause++){
-        if (!(*clause)->check(resources)){
-            satisfying = false;
-            break;
-        }
-    }
-    return satisfying;
-}
-*/
+void Condition::addClause(Clause *c) { clauses.push_back(c); }
 
-bool Condition::check(std::multimap<int, StationaryQubit*> resources) const {
-  EV << "In condition...\n";
+bool Condition::check(std::multimap<int, StationaryQubit *> resources) const {
   bool satisfying = true;
-  for (auto clause = cbegin(), end = cend(); clause != end; clause++) {
-    if (!(*clause)->check(resources)) {
+  for (auto &clause : clauses) {
+    if (!clause->check(resources)) {
       satisfying = false;
       break;
     }
   }
-  // std::cout<<"satisfying? = "<<satisfying<<" false = "<<false<<" true = "<<true<<"\n";
   return satisfying;
 }
 
-/*
-bool Condition::checkTerminate(qnicResources *resources) const {
-    bool satisfying = true;
-    for (auto clause = cbegin(), end = cend(); clause != end; clause++){
-        if (!(*clause)->checkTerminate(resources)){
-            satisfying = false;
-            break;
-        }
-    }
-    return satisfying;
-}*/
-
-bool Condition::checkTerminate(std::multimap<int, StationaryQubit*> resources) const {
+bool Condition::checkTerminate(std::multimap<int, StationaryQubit *> resources) const {
   bool satisfying = false;
-  for (auto clause = cbegin(), end = cend(); clause != end; clause++) {
-    if ((*clause)->checkTerminate(resources)) {
+  for (auto &clause : clauses) {
+    if (clause->checkTerminate(resources)) {
       satisfying = true;
       break;
     }

--- a/quisp/rules/Condition.h
+++ b/quisp/rules/Condition.h
@@ -18,16 +18,15 @@ namespace rules {
  *
  *  \brief Condition
  */
-class Condition : std::list<pClause> {
+class Condition {
  public:
-  void addClause(Clause* c) { push_back(pClause(c)); };
-  void addClause(pClause& c) { push_back(pClause(std::move(c))); };
-  // bool check(qnicResources * resources) const;
+  void addClause(Clause* c);
   bool check(std::multimap<int, StationaryQubit*> resources) const;
-  // bool checkTerminate(qnicResources * resources) const;
   bool checkTerminate(std::multimap<int, StationaryQubit*> resources) const;
+
+ protected:
+  std::vector<Clause*> clauses;
 };
-typedef std::unique_ptr<Condition> pCondition;
 
 }  // namespace rules
 }  // namespace quisp

--- a/quisp/rules/Rule.h
+++ b/quisp/rules/Rule.h
@@ -26,7 +26,7 @@ class Rule {
   int ruleset_id;
   int rule_index;
   std::string name;
-  pCondition condition;
+  std::unique_ptr<Condition> condition;
   std::unique_ptr<Action> action;
   std::multimap<int, StationaryQubit *> resources;
   int mutable number_of_resources_allocated_in_total = 0;
@@ -66,8 +66,6 @@ class Rule {
   bool checkTerminate();
   // bool checkTerminate(qnicResources * resources,int qnic_type, int qnic_index,  int resource_entangled_with_address);
 };
-
-typedef std::unique_ptr<Rule> pRule;
 
 }  // namespace rules
 }  // namespace quisp

--- a/quisp/rules/RuleSet.cc
+++ b/quisp/rules/RuleSet.cc
@@ -10,10 +10,26 @@
 namespace quisp {
 namespace rules {
 
-void RuleSet::finalize() {
-  for (auto rule = this->cbegin(), end = this->cend(); rule != end; rule++) {
-  }
+RuleSet::RuleSet(long _ruleset_id, int _owner_addr, std::vector<int> partner_addrs) {
+  ruleset_id = _ruleset_id;
+  owner_addr = _owner_addr;
+  entangled_partners = partner_addrs;
+  started_at = simTime();
 }
+
+RuleSet::RuleSet(long _ruleset_id, int _owner_addr, int partner_addr) {
+  ruleset_id = _ruleset_id;
+  owner_addr = _owner_addr;
+  entangled_partners.push_back(partner_addr);
+  started_at = simTime();
+}
+
+void RuleSet::addRule(Rule* r) { rules.push_back(r); };
+Rule* RuleSet::getRule(int i) { return rules.at(i); };
+int RuleSet::size() { return rules.size(); };
+bool RuleSet::empty() { return rules.empty(); }
+std::vector<Rule* const>::iterator RuleSet::cbegin() { return rules.cbegin(); }
+std::vector<Rule* const>::iterator RuleSet::cend() { return rules.cend(); }
 
 }  // namespace rules
 }  // namespace quisp

--- a/quisp/rules/RuleSet.cc
+++ b/quisp/rules/RuleSet.cc
@@ -28,8 +28,8 @@ void RuleSet::addRule(Rule* r) { rules.push_back(r); };
 Rule* RuleSet::getRule(int i) { return rules.at(i); };
 int RuleSet::size() { return rules.size(); };
 bool RuleSet::empty() { return rules.empty(); }
-std::vector<Rule* const>::iterator RuleSet::cbegin() { return rules.cbegin(); }
-std::vector<Rule* const>::iterator RuleSet::cend() { return rules.cend(); }
+std::vector<Rule*>::const_iterator RuleSet::cbegin() { return rules.cbegin(); }
+std::vector<Rule*>::const_iterator RuleSet::cend() { return rules.cend(); }
 
 }  // namespace rules
 }  // namespace quisp

--- a/quisp/rules/RuleSet.cc
+++ b/quisp/rules/RuleSet.cc
@@ -24,12 +24,12 @@ RuleSet::RuleSet(long _ruleset_id, int _owner_addr, int partner_addr) {
   started_at = simTime();
 }
 
-void RuleSet::addRule(Rule* r) { rules.push_back(r); };
-Rule* RuleSet::getRule(int i) { return rules.at(i); };
+void RuleSet::addRule(std::unique_ptr<Rule> r) { rules.emplace_back(std::move(r)); };
+std::unique_ptr<Rule>& RuleSet::getRule(int i) { return rules[i]; };
 int RuleSet::size() { return rules.size(); };
 bool RuleSet::empty() { return rules.empty(); }
-std::vector<Rule*>::const_iterator RuleSet::cbegin() { return rules.cbegin(); }
-std::vector<Rule*>::const_iterator RuleSet::cend() { return rules.cend(); }
+std::vector<std::unique_ptr<Rule>>::const_iterator RuleSet::cbegin() { return rules.cbegin(); }
+std::vector<std::unique_ptr<Rule>>::const_iterator RuleSet::cend() { return rules.cend(); }
 
 }  // namespace rules
 }  // namespace quisp

--- a/quisp/rules/RuleSet.h
+++ b/quisp/rules/RuleSet.h
@@ -26,8 +26,8 @@ class RuleSet {
   int size();
   bool empty();
   void finalize() {}
-  std::vector<Rule* const>::iterator cbegin();
-  std::vector<Rule* const>::iterator cend();
+  std::vector<Rule*>::const_iterator cbegin();
+  std::vector<Rule*>::const_iterator cend();
 
   int owner_addr;
   std::vector<int> entangled_partners;

--- a/quisp/rules/RuleSet.h
+++ b/quisp/rules/RuleSet.h
@@ -17,61 +17,23 @@ namespace rules {
  *
  * \brief Set of rules for the RuleEngine.
  */
-
-class RuleSet : public std::list<pRule> {
+class RuleSet {
  public:
-  int owner;
-  std::vector<int> entangled_partner;
+  RuleSet(long _ruleset_id, int _owner_addr, int partner_addr);
+  RuleSet(long _ruleset_id, int _owner_addr, std::vector<int> partner_addrs);
+  void addRule(Rule* r);
+  Rule* getRule(int i);
+  int size();
+  bool empty();
+  void finalize() {}
+  std::vector<Rule* const>::iterator cbegin();
+  std::vector<Rule* const>::iterator cend();
+
+  int owner_addr;
+  std::vector<int> entangled_partners;
   std::vector<Rule*> rules;
-  // int entangled_partner_left;
-  // int entangled_partner_right;
   simtime_t started_at;
   unsigned long ruleset_id;
-  // AvailableResourceForEachStage rc;//Defined in tools.h
-  RuleSet(long id, int o, std::vector<int> e) : std::list<pRule>() {
-    ruleset_id = id;
-    owner = o;
-    entangled_partner = e;
-    started_at = simTime();
-  }
-
-  RuleSet(long id, int o, int e) : std::list<pRule>() {
-    ruleset_id = id;
-    owner = o;
-    entangled_partner.push_back(e);
-    started_at = simTime();
-  }
-
-  // RuleSet(long id, int o, int l,int r) : std::list<pRule> () {
-  //     ruleset_id = id; owner = o; entangled_partner_left = l; entangled_partner_right = r; started_at = simTime();
-  // }
-
-  // RuleSet(int o, int e) : std::list<pRule> () {
-  //     ruleset_id = createUniqueId(owner); owner = o; entangled_partner = e; started_at = simTime();
-  // }
-
-  void addRule(Rule* r) { push_back(pRule(r)); };
-  void addRule(pRule& r) { push_back(pRule(std::move(r))); };
-  void setRule_ptr(Rule* r_ptr) { this->rules.push_back(r_ptr); };
-  Rule* getRule_ptr(int i) { return this->rules.at(i); };
-  int numRules() { return this->rules.size(); };
-  void finalize();
-  int getSize() { return this->size(); };
-  void destroyThis() {
-    EV << "Destroying this RuleSet. \n ";
-    delete this;
-  };
-  unsigned long createUniqueId(int myAddress) {
-    std::string time = SimTime().str();
-    std::string address = std::to_string(myAddress);
-    std::string random = std::to_string(intuniform(0, 0, 10000000));
-    std::string hash_seed = address + time + random;
-    std::hash<std::string> hash_fn;
-    size_t t = hash_fn(hash_seed);
-    unsigned long RuleSet_id = t;
-    std::cout << "Hash is " << hash_seed << ", = " << t << ", int = " << RuleSet_id << "\n";
-    return RuleSet_id;
-  }
 };
 
 }  // namespace rules

--- a/quisp/rules/RuleSet.h
+++ b/quisp/rules/RuleSet.h
@@ -21,17 +21,17 @@ class RuleSet {
  public:
   RuleSet(long _ruleset_id, int _owner_addr, int partner_addr);
   RuleSet(long _ruleset_id, int _owner_addr, std::vector<int> partner_addrs);
-  void addRule(Rule* r);
-  Rule* getRule(int i);
+  void addRule(std::unique_ptr<Rule> r);
+  std::unique_ptr<Rule>& getRule(int i);
   int size();
   bool empty();
   void finalize() {}
-  std::vector<Rule*>::const_iterator cbegin();
-  std::vector<Rule*>::const_iterator cend();
+  std::vector<std::unique_ptr<Rule>>::const_iterator cbegin();
+  std::vector<std::unique_ptr<Rule>>::const_iterator cend();
 
   int owner_addr;
   std::vector<int> entangled_partners;
-  std::vector<Rule*> rules;
+  std::vector<std::unique_ptr<Rule>> rules;
   simtime_t started_at;
   unsigned long ruleset_id;
 };

--- a/quisp/rules/RuleSet_test.cc
+++ b/quisp/rules/RuleSet_test.cc
@@ -22,8 +22,8 @@ TEST(RuleSetTest, Init) {
 TEST(RuleSetTest, AddRule) {
   prepareSimulation();
   RuleSet rule_set(1, 2, 3);
-  Rule* rule = new Rule();
-  rule_set.addRule(rule);
+  auto rule = std::make_unique<Rule>();
+  rule_set.addRule(std::move(rule));
   EXPECT_EQ(1, rule_set.size());
 }
 }  // namespace

--- a/quisp/rules/RuleSet_test.cc
+++ b/quisp/rules/RuleSet_test.cc
@@ -1,0 +1,29 @@
+#include "RuleSet.h"
+#include <gtest/gtest.h>
+#include <test_utils/TestUtils.h>
+
+namespace {
+using namespace quisp::rules;
+using namespace quisp_test;
+TEST(RuleSetTest, Init) {
+  prepareSimulation();
+  RuleSet rule_set(1, 2, std::vector<int>{3, 4, 5});
+  EXPECT_EQ(1, rule_set.ruleset_id);
+  EXPECT_EQ(2, rule_set.owner_addr);
+  EXPECT_EQ(3, rule_set.entangled_partners.size());
+
+  RuleSet rule_set2(1, 2, 3);
+  EXPECT_EQ(1, rule_set2.ruleset_id);
+  EXPECT_EQ(2, rule_set2.owner_addr);
+  EXPECT_EQ(1, rule_set2.entangled_partners.size());
+  EXPECT_EQ(3, rule_set2.entangled_partners.at(0));
+}
+
+TEST(RuleSetTest, AddRule) {
+  prepareSimulation();
+  RuleSet rule_set(1, 2, 3);
+  Rule* rule = new Rule();
+  rule_set.addRule(rule);
+  EXPECT_EQ(1, rule_set.size());
+}
+}  // namespace


### PR DESCRIPTION
after #241 
basically RuleSet class has two containers for Rule. one is RuleSet itself is a std::list and another is the `rules` member. 
[PLEASE DO NOT inherit `std::list`.](https://stackoverflow.com/questions/1647298/why-dont-stl-containers-have-virtual-destructors)
 it must cause serious bugs and we must avoid this. 
So I cleaned up this class. 
* remove inheritance of `std::list`
* fix methods to manage Rules in `RuleSet::rules` member.
* remove `pRule`. it is a unique_ptr of `Rule` but there was some dangerous operations. I fixed it.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/244)
<!-- Reviewable:end -->
