### PR TITLE
update CI's toolchain to clang 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,16 @@ jobs:
       - name: Install the latest git and dependencies
         run: |
           apt-get update -y
-          apt-get install -y --no-install-recommends software-properties-common cmake g++ clang-format clang-tidy
+          apt-get install -y --no-install-recommends software-properties-common gpg-agent cmake g++
           add-apt-repository ppa:git-core/ppa
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+          apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main"
           apt-get update -y
-          apt-get install git -y
+          apt install clang-format-12 clang-tidy-12 lldb-12 git -y
+          ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
+          ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
+          ln -sf /usr/bin/clang-12 /usr/bin/clang
+          ln -sf /usr/bin/clang++-12 /usr/bin/clang++
       - name: Check out repository
         uses: actions/checkout@v2
       - name: clang-format and clang-tidy


### PR DESCRIPTION
I forgot to update clang toolchain on GitHub Actions... so this PR updated it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/253)
<!-- Reviewable:end -->
