### PR TITLE
Add IStationaryQubit

### DIFF
--- a/quisp/modules/Application/Application.h
+++ b/quisp/modules/Application/Application.h
@@ -39,7 +39,7 @@ class Application : public IApplication {
   void storeEndNodeAddresses();
   int getOneRandomEndNodeAddress();
 
-  ConnectionSetupRequest *createConnectionSetupRequest(int dest_addr, int num_of_required_resources);
+  messages::ConnectionSetupRequest *createConnectionSetupRequest(int dest_addr, int num_of_required_resources);
   utils::ComponentProvider provider;
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -126,50 +126,11 @@ class IStationaryQubit : public cSimpleModule {
  public:
   IStationaryQubit(){};
   virtual ~IStationaryQubit(){};
-  /** Pointer to the entangled qubit*/
-  IStationaryQubit *entangled_partner = nullptr;
-  /** Photon emitted at*/
-  simtime_t emitted_time = -1;
-  /** Stationary qubit last updated at*/
-  simtime_t updated_time = -1;
-
-  /** Stationary Qubit is free or reserved. */
-  bool isBusy;
-  /** Standard deviation */
-  double std;
-
-  double emission_success_probability;
-  int numemitted;
-
-  SingleGateErrorModel Hgate_error;
-  SingleGateErrorModel Xgate_error;
-  SingleGateErrorModel Zgate_error;
-  TwoQubitGateErrorModel CNOTgate_error;
-  SingleGateErrorModel Measurement_error;
-
-  /** Error rate for idle stationary qubits */
-  memory_error_model memory_err;
-  double memory_error_rate;
-  double memory_No_error_ceil;
-  double memory_X_error_ceil;
-  double memory_Y_error_ceil;
-  double memory_Z_error_ceil;
-  double memory_Excitation_error_ceil;
-  double memory_Relaxation_error_ceil;
-
-  // single_qubit_error Pauli;
-  // measurement_operators meas_op;
-  Eigen::Matrix2cd Density_Matrix_Collapsed;  // Used when partner has been measured.
-  int num_purified;
-  bool partner_measured;
-  bool completely_mixed;
-  bool excited_or_relaxed;
-  bool GOD_dm_Xerror;
-  bool GOD_dm_Zerror;
 
   virtual bool checkBusy() = 0;
   virtual void setFree(bool consumed) = 0;
-  virtual void Lock(unsigned long rs_id, int rule_id, int action_id) = 0; /*In use. E.g. waiting for purification result.*/
+  /*In use. E.g. waiting for purification result.*/
+  virtual void Lock(unsigned long rs_id, int rule_id, int action_id) = 0;
   virtual void Unlock() = 0;
   virtual bool isLocked() = 0;
   virtual void Allocate() = 0;
@@ -181,29 +142,8 @@ class IStationaryQubit : public cSimpleModule {
    * \param pulse is 1 for the beginning of the burst, 2 for the end.
    */
   virtual void emitPhoton(int pulse) = 0;
-
-  /**
-   * \brief Single Qubit X measurement.
-   * \param This is only for simulating error propagations.
-   * New errors only occur when wrong measurement result is delivered for feed-forward
-   * (The error on the measured qubit propagates to the byproduct gate target qubit).
-   */
   virtual quisp::types::MeasureXResult measure_X() = 0;
-
-  /**
-   * \brief Single Qubit Y measurement.
-   * This is only for simulating error propagations.
-   * New errors only occur when wrong measurement result is delivered for feed-forward
-   * (The error on the measured qubit propagates to the byproduct gate target qubit).
-   */
   virtual types::MeasureYResult measure_Y() = 0;
-
-  /**
-   * \brief Single Qubit Z measurement.
-   * This is only for simulating error propagations.
-   * New errors only occur when wrong measurement result is delivered for feed-forward
-   * (The error on the measured qubit propagates to the byproduct gate target qubit).
-   */
   virtual types::MeasureZResult measure_Z() = 0;
 
   /**
@@ -232,6 +172,31 @@ class IStationaryQubit : public cSimpleModule {
 
   int action_index;
   bool no_density_matrix_nullptr_entangled_partner_ok;
+
+  /** Pointer to the entangled qubit*/
+  IStationaryQubit *entangled_partner = nullptr;
+  /** Photon emitted at*/
+  simtime_t emitted_time = -1;
+  /** Stationary qubit last updated at*/
+  simtime_t updated_time = -1;
+
+  /** Stationary Qubit is free or reserved. */
+  bool isBusy;
+  /** Standard deviation */
+  double std;
+
+  SingleGateErrorModel Hgate_error;
+  SingleGateErrorModel Xgate_error;
+  SingleGateErrorModel Zgate_error;
+  TwoQubitGateErrorModel CNOTgate_error;
+  SingleGateErrorModel Measurement_error;
+
+  Eigen::Matrix2cd Density_Matrix_Collapsed;  // Used when partner has been measured.
+  bool partner_measured;
+  bool completely_mixed;
+  bool excited_or_relaxed;
+  bool GOD_dm_Xerror;
+  bool GOD_dm_Zerror;
 };
 
 }  // namespace modules

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -157,8 +157,8 @@ class IStationaryQubit : public cSimpleModule {
   double memory_Excitation_error_ceil;
   double memory_Relaxation_error_ceil;
 
-  single_qubit_error Pauli;
-  measurement_operators meas_op;
+  // single_qubit_error Pauli;
+  // measurement_operators meas_op;
   Eigen::Matrix2cd Density_Matrix_Collapsed;  // Used when partner has been measured.
   int num_purified;
   bool partner_measured;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -124,6 +124,7 @@ struct measurement_outcome {
 
 class IStationaryQubit : public cSimpleModule {
  public:
+  IStationaryQubit(){};
   virtual ~IStationaryQubit(){};
   /** Pointer to the entangled qubit*/
   IStationaryQubit *entangled_partner = nullptr;
@@ -166,20 +167,20 @@ class IStationaryQubit : public cSimpleModule {
   bool GOD_dm_Xerror;
   bool GOD_dm_Zerror;
 
-  virtual bool checkBusy();
-  virtual void setFree(bool consumed);
-  virtual void Lock(unsigned long rs_id, int rule_id, int action_id); /*In use. E.g. waiting for purification result.*/
-  virtual void Unlock();
-  virtual bool isLocked();
-  virtual void Allocate();
-  virtual void Deallocate();
-  virtual bool isAllocated();
+  virtual bool checkBusy() = 0;
+  virtual void setFree(bool consumed) = 0;
+  virtual void Lock(unsigned long rs_id, int rule_id, int action_id) = 0; /*In use. E.g. waiting for purification result.*/
+  virtual void Unlock() = 0;
+  virtual bool isLocked() = 0;
+  virtual void Allocate() = 0;
+  virtual void Deallocate() = 0;
+  virtual bool isAllocated() = 0;
 
   /**
    * \brief Emit photon.
    * \param pulse is 1 for the beginning of the burst, 2 for the end.
    */
-  virtual void emitPhoton(int pulse);
+  virtual void emitPhoton(int pulse) = 0;
 
   /**
    * \brief Single Qubit X measurement.
@@ -187,7 +188,7 @@ class IStationaryQubit : public cSimpleModule {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual quisp::types::MeasureXResult measure_X();
+  virtual quisp::types::MeasureXResult measure_X() = 0;
 
   /**
    * \brief Single Qubit Y measurement.
@@ -195,7 +196,7 @@ class IStationaryQubit : public cSimpleModule {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual types::MeasureYResult measure_Y();
+  virtual types::MeasureYResult measure_Y() = 0;
 
   /**
    * \brief Single Qubit Z measurement.
@@ -203,25 +204,25 @@ class IStationaryQubit : public cSimpleModule {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual types::MeasureZResult measure_Z();
+  virtual types::MeasureZResult measure_Z() = 0;
 
   /**
    * Performs measurement and returns +(true) or -(false) based on the density matrix of the state. Used for tomography.
    * */
-  virtual measurement_outcome measure_density_independent(); /*Separate dm calculation*/
+  virtual measurement_outcome measure_density_independent() = 0; /*Separate dm calculation*/
 
-  virtual void CNOT_gate(IStationaryQubit *control_qubit);
-  virtual void Hadamard_gate();
-  virtual void Z_gate();
-  virtual void X_gate();
-  virtual bool Xpurify(IStationaryQubit *resource_qubit);
-  virtual bool Zpurify(IStationaryQubit *resource_qubit);
+  virtual void CNOT_gate(IStationaryQubit *control_qubit) = 0;
+  virtual void Hadamard_gate() = 0;
+  virtual void Z_gate() = 0;
+  virtual void X_gate() = 0;
+  virtual bool Xpurify(IStationaryQubit *resource_qubit) = 0;
+  virtual bool Zpurify(IStationaryQubit *resource_qubit) = 0;
 
   /*GOD parameters*/
-  virtual void setEntangledPartnerInfo(IStationaryQubit *partner);
-  virtual void setCompletelyMixedDensityMatrix();
-  virtual void addXerror();
-  virtual void addZerror();
+  virtual void setEntangledPartnerInfo(IStationaryQubit *partner) = 0;
+  virtual void setCompletelyMixedDensityMatrix() = 0;
+  virtual void addXerror() = 0;
+  virtual void addZerror() = 0;
 
   int stationaryQubit_address;
   int node_address;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -375,7 +375,7 @@ void StationaryQubit::X_gate() {
 
 void StationaryQubit::CNOT_gate(IStationaryQubit *control_qubit) {
   // Need to add noise here later
-  apply_two_qubit_gate_error(CNOTgate_error, check_and_cast<StationaryQubit *>(control_qubit));
+  apply_two_qubit_gate_error(CNOTgate_error, dynamic_cast<StationaryQubit *>(control_qubit));
   // std::cout<<"this X err = "<<this->par("GOD_Xerror").boolValue()<<"\n";
 
   if (control_qubit->par("GOD_Xerror")) {
@@ -653,7 +653,7 @@ bool StationaryQubit::Xpurify(IStationaryQubit *resource_qubit /*Controlled*/) {
   // std::cout<<"X puri\n";
   // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
   apply_memory_error(this);
-  apply_memory_error(check_and_cast<StationaryQubit *>(resource_qubit));
+  apply_memory_error(dynamic_cast<StationaryQubit *>(resource_qubit));
   /*Target qubit*/ this->CNOT_gate(resource_qubit /*controlled qubit*/);
   bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
   return meas;
@@ -662,7 +662,7 @@ bool StationaryQubit::Xpurify(IStationaryQubit *resource_qubit /*Controlled*/) {
 bool StationaryQubit::Zpurify(IStationaryQubit *resource_qubit /*Target*/) {
   // std::cout<<"Z puri\n";
   apply_memory_error(this);  // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
-  apply_memory_error(check_and_cast<StationaryQubit *>(resource_qubit));
+  apply_memory_error(dynamic_cast<StationaryQubit *>(resource_qubit));
   /*Target qubit*/ resource_qubit->CNOT_gate(this /*controlled qubit*/);
   this->Hadamard_gate();
   bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
@@ -862,7 +862,7 @@ quantum_state StationaryQubit::getQuantumState() {
   // std::cout<<"par re= "<<this->entangled_partner->par("GOD_REerror").boolValue()<<", par cm = "<<this->entangled_partner->par("GOD_EXerror").boolValue()<<", re/ex =
   // "<<this->entangled_partner->excited_or_relaxed<<"\n"; std::cout<<"!!!!!!!!!!!!!!!!!!\n";
 
-  Matrix4cd combined_errors = kroneckerProduct(getErrorMatrix(this), getErrorMatrix(check_and_cast<StationaryQubit *>(entangled_partner))).eval();
+  Matrix4cd combined_errors = kroneckerProduct(getErrorMatrix(this), getErrorMatrix(dynamic_cast<StationaryQubit *>(entangled_partner))).eval();
 
   // If Pauli errors
   Vector4cd ideal_Bell_state(1 / sqrt(2), 0, 0, 1 / sqrt(2));  // Assumes that the state is a 2 qubit state |00> + |11>
@@ -1006,7 +1006,7 @@ measurement_outcome StationaryQubit::measure_density_independent() {
       error("Entangled but completely mixed / Excited / Relaxed ? Probably wrong.");
     }
     // Also do the same on the partner if it is still entangled! This could break the entanglement due to relaxation/excitation error!
-    apply_memory_error(check_and_cast<StationaryQubit *>(this->entangled_partner));
+    apply_memory_error(dynamic_cast<StationaryQubit *>(this->entangled_partner));
   }
 
   /*-For debugging-*/

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -14,6 +14,9 @@
 #include <unsupported/Eigen/MatrixFunctions>
 #include <vector>
 
+using namespace Eigen;
+
+using quisp::messages::PhotonicQubit;
 using quisp::types::MeasureXResult;
 using quisp::types::MeasureYResult;
 using quisp::types::MeasureZResult;
@@ -370,9 +373,9 @@ void StationaryQubit::X_gate() {
   par("GOD_Xerror") = !par("GOD_Xerror");
 }
 
-void StationaryQubit::CNOT_gate(StationaryQubit *control_qubit) {
+void StationaryQubit::CNOT_gate(IStationaryQubit *control_qubit) {
   // Need to add noise here later
-  apply_two_qubit_gate_error(CNOTgate_error, control_qubit);
+  apply_two_qubit_gate_error(CNOTgate_error, check_and_cast<StationaryQubit *>(control_qubit));
   // std::cout<<"this X err = "<<this->par("GOD_Xerror").boolValue()<<"\n";
 
   if (control_qubit->par("GOD_Xerror")) {
@@ -618,7 +621,7 @@ void StationaryQubit::setRelaxedDensityMatrix() {
   }  // else it is already not entangled. e.g. excited -> relaxed.
 }
 
-void StationaryQubit::setEntangledPartnerInfo(StationaryQubit *partner) {
+void StationaryQubit::setEntangledPartnerInfo(IStationaryQubit *partner) {
   // When BSA succeeds, this method gets invoked to store entangled partner information.
   // This will also be sent classically to the partner node afterwards.
   entangled_partner = partner;
@@ -646,20 +649,20 @@ void StationaryQubit::addZerror() {
 }
 
 // Only tracks error propagation. If two booleans (Alice and Bob) agree (truetrue or falsefalse), keep the purified ebit.
-bool StationaryQubit::Xpurify(StationaryQubit *resource_qubit /*Controlled*/) {
+bool StationaryQubit::Xpurify(IStationaryQubit *resource_qubit /*Controlled*/) {
   // std::cout<<"X puri\n";
   // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
   apply_memory_error(this);
-  apply_memory_error(resource_qubit);
+  apply_memory_error(check_and_cast<StationaryQubit *>(resource_qubit));
   /*Target qubit*/ this->CNOT_gate(resource_qubit /*controlled qubit*/);
   bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
   return meas;
 }
 
-bool StationaryQubit::Zpurify(StationaryQubit *resource_qubit /*Target*/) {
+bool StationaryQubit::Zpurify(IStationaryQubit *resource_qubit /*Target*/) {
   // std::cout<<"Z puri\n";
   apply_memory_error(this);  // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
-  apply_memory_error(resource_qubit);
+  apply_memory_error(check_and_cast<StationaryQubit *>(resource_qubit));
   /*Target qubit*/ resource_qubit->CNOT_gate(this /*controlled qubit*/);
   this->Hadamard_gate();
   bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
@@ -859,7 +862,7 @@ quantum_state StationaryQubit::getQuantumState() {
   // std::cout<<"par re= "<<this->entangled_partner->par("GOD_REerror").boolValue()<<", par cm = "<<this->entangled_partner->par("GOD_EXerror").boolValue()<<", re/ex =
   // "<<this->entangled_partner->excited_or_relaxed<<"\n"; std::cout<<"!!!!!!!!!!!!!!!!!!\n";
 
-  Matrix4cd combined_errors = kroneckerProduct(getErrorMatrix(this), getErrorMatrix(entangled_partner)).eval();
+  Matrix4cd combined_errors = kroneckerProduct(getErrorMatrix(this), getErrorMatrix(check_and_cast<StationaryQubit *>(entangled_partner))).eval();
 
   // If Pauli errors
   Vector4cd ideal_Bell_state(1 / sqrt(2), 0, 0, 1 / sqrt(2));  // Assumes that the state is a 2 qubit state |00> + |11>
@@ -1003,7 +1006,7 @@ measurement_outcome StationaryQubit::measure_density_independent() {
       error("Entangled but completely mixed / Excited / Relaxed ? Probably wrong.");
     }
     // Also do the same on the partner if it is still entangled! This could break the entanglement due to relaxation/excitation error!
-    apply_memory_error(this->entangled_partner);
+    apply_memory_error(check_and_cast<StationaryQubit *>(this->entangled_partner));
   }
 
   /*-For debugging-*/

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -33,57 +33,7 @@ Define_Module(StationaryQubit);
  *
  */
 void StationaryQubit::initialize() {
-  double rand = dblrand();
-
-  /*Photon emission time error rates*/
-
-  /*
   emission_success_probability = par("emission_success_probability");
-  emission_error.X_error_rate = par("emission_Z_error_rate");//par("name") will be read from .ini or .ned file
-  emission_error.X_error_rate =  par("emission_X_error_rate");
-  emission_error.Z_error_rate = par("emission_Y_error_rate");
-  emission_error.pauli_error_rate = emission_error.Y_error_rate + emission_error.Z_error_rate + emission_error.X_error_rate;
-
-
-  emission_error.No_error_ceil =1-emission_error.pauli_error_rate;// if 0 <= dblrand < fidelity = No error
-  emission_error.X_error_ceil = emission_error.No_error_ceil + emission_error.X_error_rate; // if fidelity <= dblrand < fidelity+X error rate = X error
-  emission_error.Z_error_ceil = emission_error.X_error_ceil + emission_error.Z_error_rate;
-  emission_error.Y_error_ceil = 1;
-
-
-  std::cout<<"emission_error.No_error_ceil = "<<emission_error.No_error_ceil<<"\n";
-  std::cout<<"emission_error.X_error_ceil = "<<emission_error.X_error_ceil<<"\n";
-  std::cout<<"emission_error.Y_error_ceil = "<<emission_error.Y_error_ceil<<"\n";
-  std::cout<<"emission_error.Z_error_ceil = "<<emission_error.Z_error_ceil<<"\n";
-  */
-  emission_success_probability = par("emission_success_probability");
-  // numemitted = 0;
-  // setErrorCeilings();
-
-  /*Memory error rates*/
-
-  /*
-double memory_Z_error_ratio = par("memory_Z_error_ratio");//par("name") will be read from .ini or .ned file
-double memory_X_error_ratio = par("memory_X_error_ratio");
-double memory_Y_error_ratio = par("memory_Y_error_ratio");
-double memory_excitation_error_ratio = par("memory_energy_excitation_ratio");
-double memory_relaxation_error_ratio = par("memory_energy_relaxation_ratio");
-double memory_completely_mixed_ratio = par("memory_completely_mixed_ratio");
-
-if(memory_Z_error_ratio == 0 && memory_X_error_ratio == 0 && memory_Y_error_ratio == 0 && memory_excitation_error_ratio == 0 && memory_relaxation_error_ratio == 0 &&
-memory_completely_mixed_ratio ==0){ memory_Z_error_ratio = 1; memory_X_error_ratio = 1; memory_Y_error_ratio = 1; memory_excitation_error_ratio = 1; memory_relaxation_error_ratio =
-1; memory_completely_mixed_ratio = 1;
-}
-
-//EV<<"memory_excitation_error_ratio = "<<memory_excitation_error_ratio<<", memory_relaxation_error_ratio"<<memory_relaxation_error_ratio<<"\n";
-double memory_ratio_sum = memory_Z_error_ratio+memory_X_error_ratio+memory_Y_error_ratio + memory_excitation_error_ratio + memory_relaxation_error_ratio +
-memory_completely_mixed_ratio; memory_err.error_rate = par("memory_error_rate");//This is per μs. memory_err.X_error_rate = memory_err.error_rate *
-(memory_X_error_ratio/memory_ratio_sum); memory_err.Y_error_rate = memory_err.error_rate * (memory_Y_error_ratio/memory_ratio_sum); memory_err.Z_error_rate = memory_err.error_rate
-* (memory_Z_error_ratio/memory_ratio_sum); memory_err.excitation_error_rate = memory_err.error_rate * (memory_excitation_error_ratio/memory_ratio_sum);
-memory_err.relaxation_error_rate = memory_err.error_rate * (memory_relaxation_error_ratio/memory_ratio_sum);
-memory_err.completely_mixed_rate = memory_err.error_rate * (memory_completely_mixed_ratio/memory_ratio_sum);
-  */
-
   memory_err.X_error_rate = (double)par("memory_X_error_rate").doubleValue();
   memory_err.Y_error_rate = (double)par("memory_Y_error_rate").doubleValue();
   memory_err.Z_error_rate = (double)par("memory_Z_error_rate").doubleValue();
@@ -92,14 +42,6 @@ memory_err.completely_mixed_rate = memory_err.error_rate * (memory_completely_mi
   memory_err.completely_mixed_rate = (double)par("memory_completely_mixed_rate").doubleValue();
   memory_err.error_rate = memory_err.X_error_rate + memory_err.Y_error_rate + memory_err.Z_error_rate + memory_err.excitation_error_rate + memory_err.relaxation_error_rate +
                           memory_err.completely_mixed_rate;  // This is per μs.
-  /*EV<<"Err rate = "<<memory_err.pauli_error_rate<<"\n";
-  EV<<"Ratio sum = "<<memory_ratio_sum<<"\n";
-  EV<<"I error rate (mem) = "<<1-memory_err.pauli_error_rate<<"\n";
-  EV<<"X error rate (mem) = "<<memory_err.X_error_rate<<"\n";
-  EV<<"Y error rate (mem) = "<<memory_err.Y_error_rate<<"\n";
-  EV<<"Z error rate (mem) = "<<memory_err.Z_error_rate<<"\n";
-  EV<<"Excitation error rate (mem) = "<<memory_err.excitation_error_rate<<"\n";
-  EV<<"Relaxation error rate (mem) = "<<memory_err.relaxation_error_rate<<"\n";*/
   Memory_Transition_matrix = MatrixXd::Zero(7, 7);
   // clang-format off
   Memory_Transition_matrix <<
@@ -120,7 +62,6 @@ memory_err.completely_mixed_rate = memory_err.error_rate * (memory_completely_mi
   setTwoQubitGateErrorCeilings(CNOTgate_error, "CNOTgate");
 
   std::cout << Memory_Transition_matrix << "\n";
-  // endSimulation();
 
   // Set error matrices. This is used in the process of simulating tomography.
   Pauli.X << 0, 1, 1, 0;
@@ -162,9 +103,7 @@ memory_err.completely_mixed_rate = memory_err.error_rate * (memory_completely_mi
   /* e^(t/T1) energy relaxation, e^(t/T2) phase relaxation. Want to use only 1/10 of T1 and T2 in general.*/
 }
 
-void StationaryQubit::finish() {
-  // std::cout<<"emitted "<<numemitted<<"¥n";
-}
+void StationaryQubit::finish() {}
 
 /**
  * \brief cSimpleModule handleMessage function
@@ -174,8 +113,6 @@ void StationaryQubit::finish() {
 void StationaryQubit::handleMessage(cMessage *msg) {
   bubble("Got a photon!!");
   setBusy();
-  // numemitted++;
-  // setEmissionPauliError();
   double rand = dblrand();
   if (rand < (1 - emission_success_probability)) {
     PhotonicQubit *pk = check_and_cast<PhotonicQubit *>(msg);
@@ -282,40 +219,6 @@ void StationaryQubit::setTwoQubitGateErrorCeilings(TwoQubitGateErrorModel &model
   model.YI_error_ceil = model.IY_error_ceil + model.YI_error_rate;
   model.YY_error_ceil = model.YI_error_ceil + model.YY_error_rate;
 }
-
-/*
-void StationaryQubit::setEmissionPauliError(){
-    if(par("GOD_Xerror") || par("GOD_Zerror")){
-        //std::cout<<"node["<<node_address<<"] qnic["<<qnic_address<<"] Emitting from "<<this<<"X="<<par("GOD_Xerror").str()<<"Z="<<par("GOD_Zerror").str()<<"\n";
-        error("There shouldn't be an error existing before photon emission. This error may have not been reinitialized since last use. Better check!");
-    }
-    double rand = dblrand();//Gives a random double between 0.0 ~ 1.0
-    if(rand < emission_error.No_error_ceil){
-               //Qubit will end up with no error
-               //EV<<"No error :"<<rand<<" < "<<No_error_ceil<<"\n";
-    }else if(emission_error.No_error_ceil <= rand && rand < emission_error.X_error_ceil && (emission_error.No_error_ceil!=emission_error.X_error_ceil)){
-               //X error
-                par("GOD_Xerror") = true;
-                //EV<<"Xerror :"<<No_error_ceil<<"<="<<rand<<" < "<<X_error_ceil<<"\n";
-    }else if(emission_error.X_error_ceil <= rand && rand < emission_error.Z_error_ceil && (emission_error.X_error_ceil!=emission_error.Z_error_ceil)){
-               //Z error
-                par("GOD_Zerror") = true;
-               // EV<<"Zerror :"<<X_error_ceil<<"<="<<rand<<" < "<<Z_error_ceil<<"\n";
-    }else if(emission_error.Z_error_ceil <= rand && rand < emission_error.Y_error_ceil && (emission_error.Z_error_ceil!=emission_error.Y_error_ceil)){
-               //Y error
-                par("GOD_Xerror") = true;
-                par("GOD_Zerror") = true;
-                //EV<<"Yerror :"<<Z_error_ceil<<"<="<<rand<<" < "<<Y_error_ceil<<"\n";
-   }else{
-       std::cout<<rand<<"\n";
-       std::cout<<"emission_error.No_error_ceil = "<<emission_error.No_error_ceil<<"\n";
-       std::cout<<"emission_error.X_error_ceil = "<<emission_error.X_error_ceil<<"\n";
-       std::cout<<"emission_error.Y_error_ceil = "<<emission_error.Y_error_ceil<<"\n";
-       std::cout<<"emission_error.Z_error_ceil = "<<emission_error.Z_error_ceil<<"\n";
-       error("Either the error ceilings or the random double generator is wrong.");
-   }
-}
-*/
 
 MeasureXResult StationaryQubit::measure_X() {
   apply_single_qubit_gate_error(Measurement_error);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -154,7 +154,6 @@ memory_err.completely_mixed_rate = memory_err.error_rate * (memory_completely_mi
   qnic_index = par("qnic_index");
   std = par("std");
   setFree(false);
-  setFidelity(-1.);
 
   DEBUG_memory_X_count = 0;
   DEBUG_memory_Y_count = 0;
@@ -505,7 +504,7 @@ bool StationaryQubit::isAllocated() { return allocated; }
  */
 PhotonicQubit *StationaryQubit::generateEntangledPhoton() {
   Enter_Method("generateEntangledPhoton()");
-  photon = new PhotonicQubit("Photon");
+  auto *photon = new PhotonicQubit("Photon");
   // To simulate the actual physical entangled partner, not what the system thinks!!! we need this.
 
   // This photon is entangled with.... node_address = node's index

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -277,7 +277,7 @@ void StationaryQubit::X_gate() {
 
 void StationaryQubit::CNOT_gate(IStationaryQubit *control_qubit) {
   // Need to add noise here later
-  apply_two_qubit_gate_error(CNOTgate_error, dynamic_cast<StationaryQubit *>(control_qubit));
+  apply_two_qubit_gate_error(CNOTgate_error, check_and_cast<StationaryQubit *>(control_qubit));
   // std::cout<<"this X err = "<<this->par("GOD_Xerror").boolValue()<<"\n";
 
   if (control_qubit->par("GOD_Xerror")) {
@@ -555,7 +555,7 @@ bool StationaryQubit::Xpurify(IStationaryQubit *resource_qubit /*Controlled*/) {
   // std::cout<<"X puri\n";
   // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
   apply_memory_error(this);
-  apply_memory_error(dynamic_cast<StationaryQubit *>(resource_qubit));
+  apply_memory_error(check_and_cast<StationaryQubit *>(resource_qubit));
   /*Target qubit*/ this->CNOT_gate(resource_qubit /*controlled qubit*/);
   bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
   return meas;
@@ -564,7 +564,7 @@ bool StationaryQubit::Xpurify(IStationaryQubit *resource_qubit /*Controlled*/) {
 bool StationaryQubit::Zpurify(IStationaryQubit *resource_qubit /*Target*/) {
   // std::cout<<"Z puri\n";
   apply_memory_error(this);  // This could result in completelty mixed, excited, relaxed, which also affects the entangled partner.
-  apply_memory_error(dynamic_cast<StationaryQubit *>(resource_qubit));
+  apply_memory_error(check_and_cast<StationaryQubit *>(resource_qubit));
   /*Target qubit*/ resource_qubit->CNOT_gate(this /*controlled qubit*/);
   this->Hadamard_gate();
   bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
@@ -764,7 +764,7 @@ quantum_state StationaryQubit::getQuantumState() {
   // std::cout<<"par re= "<<this->entangled_partner->par("GOD_REerror").boolValue()<<", par cm = "<<this->entangled_partner->par("GOD_EXerror").boolValue()<<", re/ex =
   // "<<this->entangled_partner->excited_or_relaxed<<"\n"; std::cout<<"!!!!!!!!!!!!!!!!!!\n";
 
-  Matrix4cd combined_errors = kroneckerProduct(getErrorMatrix(this), getErrorMatrix(dynamic_cast<StationaryQubit *>(entangled_partner))).eval();
+  Matrix4cd combined_errors = kroneckerProduct(getErrorMatrix(this), getErrorMatrix(check_and_cast<StationaryQubit *>(entangled_partner))).eval();
 
   // If Pauli errors
   Vector4cd ideal_Bell_state(1 / sqrt(2), 0, 0, 1 / sqrt(2));  // Assumes that the state is a 2 qubit state |00> + |11>
@@ -908,7 +908,7 @@ measurement_outcome StationaryQubit::measure_density_independent() {
       error("Entangled but completely mixed / Excited / Relaxed ? Probably wrong.");
     }
     // Also do the same on the partner if it is still entangled! This could break the entanglement due to relaxation/excitation error!
-    apply_memory_error(dynamic_cast<StationaryQubit *>(this->entangled_partner));
+    apply_memory_error(check_and_cast<StationaryQubit *>(this->entangled_partner));
   }
 
   /*-For debugging-*/

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -27,50 +27,15 @@ typedef std::complex<double> Complex;
 
 class StationaryQubit : public IStationaryQubit {
  public:
-  double emission_success_probability;
-  int numemitted;
-
-  SingleGateErrorModel Hgate_error;
-  SingleGateErrorModel Xgate_error;
-  SingleGateErrorModel Zgate_error;
-  TwoQubitGateErrorModel CNOTgate_error;
-  SingleGateErrorModel Measurement_error;
-  memory_error_model memory_err;
-  double memory_error_rate;
-  double memory_No_error_ceil;
-  double memory_X_error_ceil;
-  double memory_Y_error_ceil;
-  double memory_Z_error_ceil;
-  double memory_Excitation_error_ceil;
-  double memory_Relaxation_error_ceil;
-
-  single_qubit_error Pauli;
-  measurement_operators meas_op;
-  // https://arxiv.org/abs/1908.10758 Eq 5.2
-  Eigen::MatrixXd Memory_Transition_matrix; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in μs.*/
-  Eigen::MatrixXd Memory_Transition_matrix_ns; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/
-  Eigen::MatrixXd Memory_Transition_matrix_ms; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/
-  int num_purified;
-  bool partner_measured;
-  bool completely_mixed;
-  bool excited_or_relaxed;
-  bool GOD_dm_Xerror;
-  bool GOD_dm_Zerror;
-
-  bool checkBusy();
-  void setFree(bool consumed);
-  void Lock(unsigned long rs_id, int rule_id, int action_id); /*In use. E.g. waiting for purification result.*/
-  void Unlock();
-  bool isLocked();
-  void Allocate();
-  void Deallocate();
-  bool isAllocated();
-
-  double getFidelity() { return fidelity; };
-  void setFidelity(const double f) {
-    fidelity = f;
-    par("fidelity") = f;
-  };
+  bool checkBusy() override;
+  void setFree(bool consumed) override;
+  /*In use. E.g. waiting for purification result.*/
+  void Lock(unsigned long rs_id, int rule_id, int action_id) override;
+  void Unlock() override;
+  bool isLocked() override;
+  void Allocate() override;
+  void Deallocate() override;
+  bool isAllocated() override;
 
   /**
    * \brief Emit photon.
@@ -113,14 +78,13 @@ class StationaryQubit : public IStationaryQubit {
    * \param Need to specify the control qubit as an argument.
    */
   void CNOT_gate(IStationaryQubit *control_qubit) override;
+
   /**
    * \brief Single qubit Hadamard gate
    * \param X error transforms to Z, and vise-versa.
    */
   void Hadamard_gate() override;
-
   void Z_gate() override;
-
   void X_gate() override;
   bool Xpurify(IStationaryQubit *resource_qubit) override;
   bool Zpurify(IStationaryQubit *resource_qubit) override;
@@ -133,12 +97,36 @@ class StationaryQubit : public IStationaryQubit {
   void addXerror() override;
   void addZerror() override;
 
+  double emission_success_probability;
+  int numemitted;
+
+  SingleGateErrorModel Hgate_error;
+  SingleGateErrorModel Xgate_error;
+  SingleGateErrorModel Zgate_error;
+  TwoQubitGateErrorModel CNOTgate_error;
+  SingleGateErrorModel Measurement_error;
+  memory_error_model memory_err;
+  double memory_error_rate;
+  double memory_No_error_ceil;
+  double memory_X_error_ceil;
+  double memory_Y_error_ceil;
+  double memory_Z_error_ceil;
+  double memory_Excitation_error_ceil;
+  double memory_Relaxation_error_ceil;
+
+  single_qubit_error Pauli;
+  measurement_operators meas_op;
+  // https://arxiv.org/abs/1908.10758 Eq 5.2
+  Eigen::MatrixXd Memory_Transition_matrix; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in μs.*/
+  Eigen::MatrixXd Memory_Transition_matrix_ns; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/
+  Eigen::MatrixXd Memory_Transition_matrix_ms; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/
+  int num_purified;
+
   bool locked;
   unsigned long locked_ruleset_id;
   int locked_rule_id;
 
  private:
-  messages::PhotonicQubit *photon;
   double fidelity;
   bool allocated;
   int DEBUG_memory_X_count;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -50,7 +50,6 @@ class StationaryQubit : public IStationaryQubit {
   Eigen::MatrixXd Memory_Transition_matrix; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in μs.*/
   Eigen::MatrixXd Memory_Transition_matrix_ns; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/
   Eigen::MatrixXd Memory_Transition_matrix_ms; /*I,X,Y,Z,Ex,Rl for single qubit. Unit in ns.*/
-  Eigen::Matrix2cd Density_Matrix_Collapsed;  // Used when partner has been measured.
   int num_purified;
   bool partner_measured;
   bool completely_mixed;
@@ -137,8 +136,6 @@ class StationaryQubit : public IStationaryQubit {
   bool locked;
   unsigned long locked_ruleset_id;
   int locked_rule_id;
-  int action_index;
-  bool no_density_matrix_nullptr_entangled_partner_ok;
 
  private:
   messages::PhotonicQubit *photon;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -98,7 +98,6 @@ class StationaryQubit : public IStationaryQubit {
   void addZerror() override;
 
   double emission_success_probability;
-  int numemitted;
 
   SingleGateErrorModel Hgate_error;
   SingleGateErrorModel Xgate_error;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -134,12 +134,6 @@ class StationaryQubit : public IStationaryQubit {
   void addXerror() override;
   void addZerror() override;
 
-  int stationaryQubit_address;
-  int node_address;
-  int qnic_address;
-  int qnic_type;
-  int qnic_index;
-
   bool locked;
   unsigned long locked_ruleset_id;
   int locked_rule_id;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -10,6 +10,8 @@ namespace {
 
 class StatQubitTarget : public StationaryQubit {
  public:
+  using StationaryQubit::apply_single_qubit_gate_error;
+  using StationaryQubit::apply_two_qubit_gate_error;
   using StationaryQubit::initialize;
   using StationaryQubit::par;
   using StationaryQubit::setSingleQubitGateErrorModel;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -10,6 +10,7 @@ namespace {
 
 class StatQubitTarget : public StationaryQubit {
  public:
+  using StationaryQubit::apply_memory_error;
   using StationaryQubit::initialize;
   using StationaryQubit::par;
   StatQubitTarget() : StationaryQubit() { setComponentType(new TestModuleType("test qubit")); }

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -19,10 +19,13 @@
 #include "omnetpp/cexception.h"
 #include "utils/ComponentProvider.h"
 
+using namespace quisp::messages;
+using namespace quisp::rules;
+using Eigen::Matrix4cd;
+using Eigen::Vector4cd;
+
 namespace quisp {
 namespace modules {
-
-using namespace rules;
 
 HardwareMonitor::HardwareMonitor() : provider(utils::ComponentProvider{this}) {}
 HardwareMonitor::~HardwareMonitor() {}

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
@@ -83,7 +83,7 @@ class HardwareMonitor : public IHardwareMonitor {
   virtual InterfaceInfo getQnicInterfaceByQnicAddr(int qnic_index, QNIC_type qnic_type);
   virtual void sendLinkTomographyRuleSet(int my_address, int partner_address, QNIC_type qnic_type, int qnic_index, unsigned long rule_id);
   virtual QNIC search_QNIC_from_Neighbor_QNode_address(int neighbor_address);
-  virtual Matrix4cd reconstruct_density_matrix(int qnic_id, int partner);
+  virtual Eigen::Matrix4cd reconstruct_density_matrix(int qnic_id, int partner);
   virtual unsigned long createUniqueId();
   virtual void writeToFile_Topology_with_LinkCost(int qnic_id, double link_cost, double fidelity, double bellpair_per_sec);
 

--- a/quisp/modules/QRSA/RuleEngine/BellPairStore.cc
+++ b/quisp/modules/QRSA/RuleEngine/BellPairStore.cc
@@ -7,18 +7,18 @@ namespace modules {
 BellPairStore::BellPairStore() {}
 BellPairStore::~BellPairStore() {}
 
-void BellPairStore::insertEntangledQubit(QNodeAddr partner_addr, StationaryQubit *const qubit) {
+void BellPairStore::insertEntangledQubit(QNodeAddr partner_addr, IStationaryQubit *const qubit) {
   auto qnic_type = (QNIC_type)qubit->qnic_type;
   auto qnic_index = qubit->qnic_index;
   auto key = std::make_pair(qnic_type, qnic_index);
   if (_resources.find(key) == _resources.cend()) {
-    _resources.emplace(key, std::multimap<int, StationaryQubit *>{std::make_pair(partner_addr, qubit)});
+    _resources.emplace(key, std::multimap<int, IStationaryQubit *>{std::make_pair(partner_addr, qubit)});
   } else {
     _resources[key].emplace(partner_addr, qubit);
   }
 }
 
-void BellPairStore::eraseQubit(StationaryQubit *const qubit) {
+void BellPairStore::eraseQubit(IStationaryQubit *const qubit) {
   auto qnic_type = (QNIC_type)qubit->qnic_type;
   auto qnic_index = qubit->qnic_index;
   if (_resources.find(std::make_pair(qnic_type, qnic_index)) == _resources.cend()) {
@@ -35,7 +35,7 @@ void BellPairStore::eraseQubit(StationaryQubit *const qubit) {
   }
 }
 
-StationaryQubit *BellPairStore::findQubit(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr addr) {
+IStationaryQubit *BellPairStore::findQubit(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr addr) {
   auto key = std::make_pair(qnic_type, qnic_index);
   if (_resources.find(key) == _resources.cend()) {
     return nullptr;
@@ -50,7 +50,7 @@ StationaryQubit *BellPairStore::findQubit(QNIC_type qnic_type, QNicIndex qnic_in
 PartnerAddrQubitMapRange BellPairStore::getBellPairsRange(QNIC_type qnic_type, int qnic_index, int partner_addr) {
   auto key = std::make_pair(qnic_type, qnic_index);
   if (_resources.find(key) == _resources.cend()) {
-    _resources.emplace(key, std::multimap<int, StationaryQubit *>{});
+    _resources.emplace(key, std::multimap<int, IStationaryQubit *>{});
   }
   return _resources[key].equal_range(partner_addr);
 }

--- a/quisp/modules/QRSA/RuleEngine/BellPairStore.h
+++ b/quisp/modules/QRSA/RuleEngine/BellPairStore.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <modules/QNIC.h>
-#include <modules/QNIC/StationaryQubit/StationaryQubit.h>
+#include <modules/QNIC/StationaryQubit/IStationaryQubit.h>
 namespace quisp {
 namespace modules {
 
 using QNodeAddr = int;
 using QNicIndex = int;
 // entangled partner qnode address -> qubit
-using PartnerAddrQubitMap = std::multimap<QNodeAddr, StationaryQubit*>;
+using PartnerAddrQubitMap = std::multimap<QNodeAddr, IStationaryQubit*>;
 using ResourceKey = std::pair<QNIC_type, QNicIndex>;
 using PartnerAddrQubitMapRange = std::pair<PartnerAddrQubitMap::iterator, PartnerAddrQubitMap::iterator>;
 
@@ -22,9 +22,9 @@ class BellPairStore {
  public:
   BellPairStore();
   ~BellPairStore();
-  void eraseQubit(StationaryQubit* const qubit);
-  void insertEntangledQubit(QNodeAddr partner_addr, StationaryQubit* const qubit);
-  StationaryQubit* findQubit(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr addr);
+  void eraseQubit(IStationaryQubit* const qubit);
+  void insertEntangledQubit(QNodeAddr partner_addr, IStationaryQubit* const qubit);
+  IStationaryQubit* findQubit(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr addr);
   PartnerAddrQubitMapRange getBellPairsRange(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr partner_addr);
 
  protected:

--- a/quisp/modules/QRSA/RuleEngine/BellPairStore_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/BellPairStore_test.cc
@@ -34,7 +34,10 @@ TEST(BellPairStoreTest, insert) {
   auto key = std::make_pair(QNIC_E, 3);
   // check the PartnerAddrQubitMap is created for the key
   ASSERT_EQ(store._resources.size(), 1);
-  ASSERT_NE(store._resources.find(key), store._resources.end());
+  for (auto &i : store._resources) {
+    std::cout << key.first << "," << key.second << ": " << i.first.first << ", " << i.first.second << std::endl;
+  }
+  ASSERT_NE(store._resources.find(key), store._resources.end()) << "bell pair not found";
   auto it = store._resources[key].find(7);
   ASSERT_FALSE(it == store._resources[key].end());
   EXPECT_EQ(it->second, dynamic_cast<StationaryQubit *>(qubit1));

--- a/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
+++ b/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
@@ -91,7 +91,7 @@ class IRuleEngine : public cSimpleModule {
  public:
   ~IRuleEngine() {}
   virtual void freeResource(int qnic_index, int qubit_index, QNIC_type qnic_type) = 0;
-  virtual void freeConsumedResource(int qnic_index, StationaryQubit *qubit, QNIC_type qnic_type) = 0;
+  virtual void freeConsumedResource(int qnic_index, IStationaryQubit *qubit, QNIC_type qnic_type) = 0;
   virtual void dynamic_ResourceAllocation(int qnic_type, int qnic_index) = 0;
   virtual void ResourceAllocation(int qnic_type, int qnic_index) = 0;
 };

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -571,7 +571,7 @@ void RuleEngine::Unlock_resource_and_upgrade_stage(unsigned long ruleset_id, int
                 // Correct resource found! Need to unlock and stage up the resource to the next rule.
                 qubit->second->Unlock();
                 // std::cout<<"[Upgrade Unlock] "<<qubit->second<<" in node["<<qubit->second->node_address<<"]\n";
-                StationaryQubit *q = qubit->second;
+                IStationaryQubit *q = qubit->second;
                 (*rule)->resources.erase(qubit);  // Erase this from resource list
                 rule++;
                 if (rule == end) {
@@ -1371,7 +1371,7 @@ void RuleEngine::traverseThroughAllProcesses2() {
   }  // For loop
 }
 
-void RuleEngine::freeConsumedResource(int qnic_index /*Not the address!!!*/, StationaryQubit *qubit, QNIC_type qnic_type) {
+void RuleEngine::freeConsumedResource(int qnic_index /*Not the address!!!*/, IStationaryQubit *qubit, QNIC_type qnic_type) {
   realtime_controller->ReInitialize_StationaryQubit(qnic_index, qubit->par("stationaryQubit_address"), qnic_type, true);
   Busy_OR_Free_QubitState_table[qnic_type] = setQubitFree_inQnic(Busy_OR_Free_QubitState_table[qnic_type], qnic_index, qubit->par("stationaryQubit_address"));
   bell_pair_store.eraseQubit(qubit);

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.h
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.h
@@ -17,7 +17,7 @@
 #include "BellPairStore.h"
 #include "IRuleEngine.h"
 #include "classical_messages_m.h"
-#include "modules/QNIC/StationaryQubit/StationaryQubit.h"
+#include "modules/QNIC/StationaryQubit/IStationaryQubit.h"
 #include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
 #include "modules/QRSA/RealTimeController/IRealTimeController.h"
 #include "modules/QRSA/RoutingDaemon/RoutingDaemon.h"
@@ -80,7 +80,7 @@ class RuleEngine : public IRuleEngine {
   std::vector<bool> tracker_accessible;
 
   void freeResource(int qnic_index, int qubit_index, QNIC_type qnic_type) override;
-  void freeConsumedResource(int qnic_index, StationaryQubit *qubit, QNIC_type qnic_type) override;
+  void freeConsumedResource(int qnic_index, IStationaryQubit *qubit, QNIC_type qnic_type) override;
   void dynamic_ResourceAllocation(int qnic_type, int qnic_index) override;
   void ResourceAllocation(int qnic_type, int qnic_index) override;
 

--- a/quisp/rules/Condition.cc
+++ b/quisp/rules/Condition.cc
@@ -13,7 +13,7 @@ namespace rules {
 
 void Condition::addClause(Clause *c) { clauses.push_back(c); }
 
-bool Condition::check(std::multimap<int, StationaryQubit *> resources) const {
+bool Condition::check(std::multimap<int, IStationaryQubit *> resources) const {
   bool satisfying = true;
   for (auto &clause : clauses) {
     if (!clause->check(resources)) {
@@ -24,7 +24,7 @@ bool Condition::check(std::multimap<int, StationaryQubit *> resources) const {
   return satisfying;
 }
 
-bool Condition::checkTerminate(std::multimap<int, StationaryQubit *> resources) const {
+bool Condition::checkTerminate(std::multimap<int, IStationaryQubit *> resources) const {
   bool satisfying = false;
   for (auto &clause : clauses) {
     if (clause->checkTerminate(resources)) {

--- a/quisp/rules/Condition.h
+++ b/quisp/rules/Condition.h
@@ -21,8 +21,8 @@ namespace rules {
 class Condition {
  public:
   void addClause(Clause* c);
-  bool check(std::multimap<int, StationaryQubit*> resources) const;
-  bool checkTerminate(std::multimap<int, StationaryQubit*> resources) const;
+  bool check(std::multimap<int, IStationaryQubit*> resources) const;
+  bool checkTerminate(std::multimap<int, IStationaryQubit*> resources) const;
 
  protected:
   std::vector<Clause*> clauses;

--- a/quisp/rules/Rule.cc
+++ b/quisp/rules/Rule.cc
@@ -9,12 +9,12 @@
 #include "Rule.h"
 #include "classical_messages_m.h"
 
-//#include <modules/RuleEngine.h>
+using quisp::messages::ConditionNotSatisfied;
 
 namespace quisp {
 namespace rules {
 
-void Rule::addResource(int address_entangled_with, StationaryQubit *qubit) {
+void Rule::addResource(int address_entangled_with, IStationaryQubit *qubit) {
   // int index = number_of_resources_allocated_in_total;
   // this index must be entangled partner (this must be updated)
   resources.insert(std::make_pair(address_entangled_with, qubit));  // Assign resource to the 1st Rule.

--- a/quisp/rules/Rule.h
+++ b/quisp/rules/Rule.h
@@ -28,7 +28,7 @@ class Rule {
   std::string name;
   std::unique_ptr<Condition> condition;
   std::unique_ptr<Action> action;
-  std::multimap<int, StationaryQubit *> resources;
+  std::multimap<int, IStationaryQubit *> resources;
   int mutable number_of_resources_allocated_in_total = 0;
   // std::unique_ptr<Rule> next_rule;
   Rule(){};
@@ -43,10 +43,10 @@ class Rule {
     name = r_name;
   };
 
-  void addResource(int address_entangled_with, StationaryQubit *qubit);
+  void addResource(int address_entangled_with, IStationaryQubit *qubit);
   void setCondition(Condition *c);
   void setAction(Action *a);
-  void eraseResource(StationaryQubit *qubit){
+  void eraseResource(IStationaryQubit *qubit){
       /*bool erased = false;
       for (auto it =  rc.cbegin(), next_it =  rc.cbegin(); it !=  rc.cend(); it = next_it){
           next_it = it; ++next_it;

--- a/quisp/rules/actions/Action.cc
+++ b/quisp/rules/actions/Action.cc
@@ -16,9 +16,9 @@ namespace actions {
 int Action::checkNumResource() { return (*rule_resources).size(); }
 
 // required_index: 0 is the top one, 1 is the 2nd top one, and so on.
-StationaryQubit *Action::getResource_fromTop(int required_index) {
+IStationaryQubit *Action::getResource_fromTop(int required_index) {
   int resource_index = 0;
-  StationaryQubit *pt = nullptr;
+  IStationaryQubit *pt = nullptr;
 
   for (auto it = (*rule_resources).begin(); it != (*rule_resources).end(); ++it) {
     if (it->second->isLocked()) {
@@ -33,10 +33,10 @@ StationaryQubit *Action::getResource_fromTop(int required_index) {
   return pt;
 }
 
-StationaryQubit *Action::getResource_fromTop_with_partner(int required_index, int partner) {
+IStationaryQubit *Action::getResource_fromTop_with_partner(int required_index, int partner) {
   // here
   int resource_index = 0;
-  StationaryQubit *pt = nullptr;
+  IStationaryQubit *pt = nullptr;
 
   for (auto it = (*rule_resources).begin(); it != (*rule_resources).end(); ++it) {
     if (it->second->isLocked()) {
@@ -51,7 +51,7 @@ StationaryQubit *Action::getResource_fromTop_with_partner(int required_index, in
   return pt;
 }
 
-void Action::removeResource_fromRule(StationaryQubit *qubit) {
+void Action::removeResource_fromRule(IStationaryQubit *qubit) {
   for (auto it = (*rule_resources).begin(), next_it = (*rule_resources).begin(); it != (*rule_resources).end(); it = next_it) {
     next_it = it;
     ++next_it;

--- a/quisp/rules/actions/BaseAction.h
+++ b/quisp/rules/actions/BaseAction.h
@@ -16,22 +16,22 @@ namespace quisp {
 namespace rules {
 namespace actions {
 
+using quisp::modules::IStationaryQubit;
 using quisp::modules::QNIC_type;
-using quisp::modules::StationaryQubit;
 
 class Action {
  public:
   virtual ~Action(){};
-  std::multimap<int, StationaryQubit*>* rule_resources;
+  std::multimap<int, IStationaryQubit*>* rule_resources;
   unsigned long ruleset_id;
   int rule_id;  // Used to make the lock_id unique, together with purification_count.
   // int resource_index = 0;// for check the index of resource.
   // virtual cPacket* run(cModule *re, qnicResources *resources) = 0;
   virtual cPacket* run(cModule* re) = 0;
-  virtual StationaryQubit* getResource_fromTop(int required_index);
-  virtual StationaryQubit* getResource_fromTop_with_partner(int required_index, int partner);
+  virtual IStationaryQubit* getResource_fromTop(int required_index);
+  virtual IStationaryQubit* getResource_fromTop_with_partner(int required_index, int partner);
   virtual int checkNumResource();
-  virtual void removeResource_fromRule(StationaryQubit* qubit);
+  virtual void removeResource_fromRule(IStationaryQubit* qubit);
   // virtual StationaryQubit* getQubit(qnicResources* resources, QNIC_type qtype, int qid, int partner, int res_id);
 };
 }  // namespace actions

--- a/quisp/rules/actions/DoublePurifyAction.cc
+++ b/quisp/rules/actions/DoublePurifyAction.cc
@@ -22,8 +22,8 @@ DoublePurifyAction::DoublePurifyAction(unsigned long RuleSet_id, int rule_index,
 
 // Double error purification
 cPacket *DoublePurifyAction::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -88,8 +88,8 @@ cPacket *DoublePurifyAction::run(cModule *re) {
 
 // Inveerted double error purification.
 cPacket *DoublePurifyActionInv::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);

--- a/quisp/rules/actions/DoubleSelectionAction.cc
+++ b/quisp/rules/actions/DoubleSelectionAction.cc
@@ -22,8 +22,8 @@ DoubleSelectionAction::DoubleSelectionAction(unsigned long RuleSet_id, int rule_
 
 // Double selection single error (X error) purification.
 cPacket *DoubleSelectionAction::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -102,8 +102,8 @@ DoubleSelectionActionInv::DoubleSelectionActionInv(unsigned long RuleSet_id, int
 
 // Double selection single error (Z error) purification
 cPacket *DoubleSelectionActionInv::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);

--- a/quisp/rules/actions/DoubleSelectionDualAction.cc
+++ b/quisp/rules/actions/DoubleSelectionDualAction.cc
@@ -8,8 +8,8 @@ namespace actions {
 
 // X purification, Z purification to trash_qubit_X Bell pair.
 cPacket *DoubleSelectionDualAction::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -118,8 +118,8 @@ DoubleSelectionDualActionInv::DoubleSelectionDualActionInv(unsigned long RuleSet
 
 // Double selection double error (ZX error) purification
 cPacket *DoubleSelectionDualActionInv::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z, *ds_trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);

--- a/quisp/rules/actions/DoubleSelectionDualActionSecond.cc
+++ b/quisp/rules/actions/DoubleSelectionDualActionSecond.cc
@@ -24,8 +24,8 @@ DoubleSelectionDualActionSecond::DoubleSelectionDualActionSecond(unsigned long R
 
 // X purification, Z purification to trash_qubit_X Bell pair.
 cPacket *DoubleSelectionDualActionSecond::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_X = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_X = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);
@@ -116,8 +116,8 @@ DoubleSelectionDualActionSecondInv::DoubleSelectionDualActionSecondInv(unsigned 
 
 // Double selection double error (ZX error) purification
 cPacket *DoubleSelectionDualActionSecondInv::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit_Z, *trash_qubit_X, *ds_trash_qubit_Z = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit_X = getResource_fromTop(trash_resource_X);

--- a/quisp/rules/actions/PurifyAction.cc
+++ b/quisp/rules/actions/PurifyAction.cc
@@ -38,8 +38,8 @@ PurifyAction::PurifyAction(unsigned long RuleSet_id, int rule_index, bool X_puri
 
 // Either Z or X purification.
 cPacket *PurifyAction::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
-  StationaryQubit *trash_qubit = nullptr;
+  IStationaryQubit *qubit = nullptr;
+  IStationaryQubit *trash_qubit = nullptr;
 
   qubit = getResource_fromTop(resource);
   trash_qubit = getResource_fromTop(trash_resource);

--- a/quisp/rules/actions/RandomMeasureAction.cc
+++ b/quisp/rules/actions/RandomMeasureAction.cc
@@ -19,7 +19,7 @@ RandomMeasureAction::RandomMeasureAction(int part, QNIC_type qt, int qi, int res
 };
 
 cPacket *RandomMeasureAction::run(cModule *re) {
-  StationaryQubit *qubit = nullptr;
+  IStationaryQubit *qubit = nullptr;
 
   qubit = getResource_fromTop_with_partner(resource, partner);
 

--- a/quisp/rules/actions/SimultaneousSwappingAction.cc
+++ b/quisp/rules/actions/SimultaneousSwappingAction.cc
@@ -48,8 +48,8 @@ SimultaneousSwappingAction::SimultaneousSwappingAction(unsigned long RuleSet_id,
 cPacket *SimultaneousSwappingAction::run(cModule *re) {
   float success_probability = 1.0;
 
-  StationaryQubit *left_qubit = nullptr;
-  StationaryQubit *right_qubit = nullptr;
+  IStationaryQubit *left_qubit = nullptr;
+  IStationaryQubit *right_qubit = nullptr;
 
   left_qubit = getResource_fromTop_with_partner(left_resource, left_partner);
   right_qubit = getResource_fromTop_with_partner(right_resource, right_partner);
@@ -65,8 +65,8 @@ cPacket *SimultaneousSwappingAction::run(cModule *re) {
     return pk;
   }
 
-  StationaryQubit *right_partner_qubit = right_qubit->entangled_partner;
-  StationaryQubit *left_partner_qubit = left_qubit->entangled_partner;
+  auto *right_partner_qubit = right_qubit->entangled_partner;
+  auto *left_partner_qubit = left_qubit->entangled_partner;
 
   right_qubit->CNOT_gate(left_qubit);
   left_qubit->Hadamard_gate();

--- a/quisp/rules/actions/SwappingAction.cc
+++ b/quisp/rules/actions/SwappingAction.cc
@@ -34,8 +34,8 @@ SwappingAction::SwappingAction(unsigned long RuleSet_id, int rule_index, int lp,
 cPacket *SwappingAction::run(cModule *re) {
   float success_probability = 1.0;
 
-  StationaryQubit *left_qubit = nullptr;
-  StationaryQubit *right_qubit = nullptr;
+  IStationaryQubit *left_qubit = nullptr;
+  IStationaryQubit *right_qubit = nullptr;
 
   left_qubit = getResource_fromTop_with_partner(left_resource, left_partner);
   right_qubit = getResource_fromTop_with_partner(right_resource, right_partner);
@@ -52,8 +52,8 @@ cPacket *SwappingAction::run(cModule *re) {
   }
 
   // actual swapping operations
-  StationaryQubit *right_partner_qubit = right_qubit->entangled_partner;
-  StationaryQubit *left_partner_qubit = left_qubit->entangled_partner;
+  auto *right_partner_qubit = right_qubit->entangled_partner;
+  auto *left_partner_qubit = left_qubit->entangled_partner;
   // just swapping pointer.
   // swapper have no way to know this swapping is success or not.
   // bell measurement

--- a/quisp/rules/actions/SwappingAction_test.cc
+++ b/quisp/rules/actions/SwappingAction_test.cc
@@ -15,6 +15,7 @@ using namespace quisp::messages;
 using namespace quisp_test;
 
 using quisp::modules::IRuleEngine;
+using quisp::modules::IStationaryQubit;
 using quisp::modules::QNIC_E;
 using quisp::modules::QNIC_type;
 using quisp::modules::StationaryQubit;
@@ -64,7 +65,7 @@ class SwappingAction : public OriginalSwappingAction {
   }
 
   MOCK_METHOD(StationaryQubit *, getResource_fromTop_with_partner, (int required_index, int partner), (override));
-  MOCK_METHOD(void, removeResource_fromRule, (StationaryQubit *), (override));
+  MOCK_METHOD(void, removeResource_fromRule, (IStationaryQubit *), (override));
 };
 
 TEST(SwappingActionTest, init) {

--- a/quisp/rules/clauses/Clause.h
+++ b/quisp/rules/clauses/Clause.h
@@ -30,8 +30,8 @@ class Clause {
   };
   virtual ~Clause() {}
   // if the condition is satisfied, return true, otherwise return false.
-  virtual bool check(std::multimap<int, StationaryQubit*>) = 0;
-  virtual bool checkTerminate(std::multimap<int, StationaryQubit*>) const = 0;
+  virtual bool check(std::multimap<int, IStationaryQubit*>) = 0;
+  virtual bool checkTerminate(std::multimap<int, IStationaryQubit*>) const = 0;
 };
 
 }  // namespace clauses

--- a/quisp/rules/clauses/EnoughResourceClause.cc
+++ b/quisp/rules/clauses/EnoughResourceClause.cc
@@ -4,7 +4,7 @@ namespace quisp {
 namespace rules {
 namespace clauses {
 
-bool EnoughResourceClause::check(std::multimap<int, StationaryQubit*> resource) {
+bool EnoughResourceClause::check(std::multimap<int, IStationaryQubit*> resource) {
   bool enough = false;
   int num_free = 0;
 

--- a/quisp/rules/clauses/EnoughResourceClause.h
+++ b/quisp/rules/clauses/EnoughResourceClause.h
@@ -17,8 +17,8 @@ class EnoughResourceClause : public Clause {
     num_resource_required = num_res;
     partner = partner_addr;
   };
-  bool check(std::multimap<int, StationaryQubit*>) override;
-  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override { return false; };
+  bool check(std::multimap<int, IStationaryQubit*>) override;
+  bool checkTerminate(std::multimap<int, IStationaryQubit*>) const override { return false; };
 };
 }  // namespace clauses
 

--- a/quisp/rules/clauses/FidelityClause.cc
+++ b/quisp/rules/clauses/FidelityClause.cc
@@ -4,9 +4,9 @@
 namespace quisp {
 namespace rules {
 namespace clauses {
-[[noreturn]] bool FidelityClause::check(std::multimap<int, StationaryQubit*> resource) { throw omnetpp::cRuntimeError("FidelityClause class has not been implemented yet"); }
+[[noreturn]] bool FidelityClause::check(std::multimap<int, IStationaryQubit*> resource) { throw omnetpp::cRuntimeError("FidelityClause class has not been implemented yet"); }
 
-bool FidelityClause::checkTerminate(std::multimap<int, StationaryQubit*>) const { return false; };
+bool FidelityClause::checkTerminate(std::multimap<int, IStationaryQubit*>) const { return false; };
 }  // namespace clauses
 }  // namespace rules
 }  // namespace quisp

--- a/quisp/rules/clauses/FidelityClause.h
+++ b/quisp/rules/clauses/FidelityClause.h
@@ -13,8 +13,8 @@ class FidelityClause : public Clause {
  public:
   FidelityClause(int partner, int resource, double fidelity) : Clause(partner, resource) { threshold = fidelity; };
   FidelityClause(int part, QNIC_type qt, int qi, int res, double fidelity) : Clause(part, qt, qi, res) { threshold = fidelity; };
-  [[noreturn]] bool check(std::multimap<int, StationaryQubit*>) override;
-  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override;
+  [[noreturn]] bool check(std::multimap<int, IStationaryQubit*>) override;
+  bool checkTerminate(std::multimap<int, IStationaryQubit*>) const override;
 };
 }  // namespace clauses
 }  // namespace rules

--- a/quisp/rules/clauses/MeasureCountClause.cc
+++ b/quisp/rules/clauses/MeasureCountClause.cc
@@ -3,7 +3,7 @@
 namespace quisp {
 namespace rules {
 namespace clauses {
-bool MeasureCountClause::check(std::multimap<int, StationaryQubit*> resources) {
+bool MeasureCountClause::check(std::multimap<int, IStationaryQubit*> resources) {
   if (current_count < max_count) {
     current_count++;
     return true;
@@ -11,7 +11,7 @@ bool MeasureCountClause::check(std::multimap<int, StationaryQubit*> resources) {
   return false;
 }
 
-bool MeasureCountClause::checkTerminate(std::multimap<int, StationaryQubit*> resources) const {
+bool MeasureCountClause::checkTerminate(std::multimap<int, IStationaryQubit*> resources) const {
   bool done = false;
   if (current_count >= max_count) {
     done = true;

--- a/quisp/rules/clauses/MeasureCountClause.h
+++ b/quisp/rules/clauses/MeasureCountClause.h
@@ -14,8 +14,8 @@ class MeasureCountClause : public Clause {
     max_count = _max_count;
   };
   MeasureCountClause(int _max_count) : Clause() { max_count = _max_count; };
-  bool check(std::multimap<int, StationaryQubit*>) override;
-  bool checkTerminate(std::multimap<int, StationaryQubit*>) const override;
+  bool check(std::multimap<int, IStationaryQubit*>) override;
+  bool checkTerminate(std::multimap<int, IStationaryQubit*>) const override;
 };
 
 }  // namespace clauses

--- a/quisp/rules/clauses/PurificationCountClause.cc
+++ b/quisp/rules/clauses/PurificationCountClause.cc
@@ -3,7 +3,7 @@
 namespace quisp {
 namespace rules {
 namespace clauses {
-bool PurificationCountClause::check(std::multimap<int, StationaryQubit*> resource) { throw omnetpp::cRuntimeError("PurificationCountClause class has not been implemented yet"); }
+bool PurificationCountClause::check(std::multimap<int, IStationaryQubit*> resource) { throw omnetpp::cRuntimeError("PurificationCountClause class has not been implemented yet"); }
 }  // namespace clauses
 }  // namespace rules
 }  // namespace quisp

--- a/quisp/rules/clauses/PurificationCountClause.h
+++ b/quisp/rules/clauses/PurificationCountClause.h
@@ -11,7 +11,7 @@ class PurificationCountClause : public Clause {
   int num_purify_must;
   PurificationCountClause(int partner_addr, QNIC_type qnic_type, int qnic_id, int n_purify) : Clause(partner_addr, qnic_type, qnic_id) { num_purify_must = n_purify; };
 
-  [[noreturn]] bool check(std::multimap<int, StationaryQubit*>) override;
+  [[noreturn]] bool check(std::multimap<int, IStationaryQubit*>) override;
 };
 
 }  // namespace clauses

--- a/quisp/test_utils/mock_modules/MockRuleEngine.h
+++ b/quisp/test_utils/mock_modules/MockRuleEngine.h
@@ -4,6 +4,7 @@
 #include <modules/QRSA/RuleEngine/IRuleEngine.h>
 
 using quisp::modules::IRuleEngine;
+using quisp::modules::IStationaryQubit;
 
 namespace quisp_test {
 namespace mock_modules {
@@ -11,7 +12,7 @@ namespace rule_engine {
 class MockRuleEngine : public IRuleEngine {
  public:
   MOCK_METHOD(void, freeResource, (int, int, QNIC_type), (override));
-  MOCK_METHOD(void, freeConsumedResource, (int, StationaryQubit*, QNIC_type), (override));
+  MOCK_METHOD(void, freeConsumedResource, (int, IStationaryQubit*, QNIC_type), (override));
   MOCK_METHOD(void, dynamic_ResourceAllocation, (int, int), (override));
   MOCK_METHOD(void, ResourceAllocation, (int, int), (override));
 };


### PR DESCRIPTION
after #255

now it's hard to write tests using StationaryQubit because it needs a lot of parameters and set measure results what we want.
So I separated the interface class for StationaryQubit and make it easy to write tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/256)
<!-- Reviewable:end -->
