### PR TITLE
fix the number of required resource in swapping rule

### DIFF
--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -932,8 +932,8 @@ std::unique_ptr<Rule> ConnectionManager::swappingRule(SwappingConfig conf, unsig
   std::string rule_name = "Entanglement Swapping with " + std::to_string(conf.left_partner) + " : " + std::to_string(conf.right_partner);
   auto rule_entanglement_swapping = std::make_unique<Rule>(ruleset_id, rule_id, rule_name, partners);
   Condition *condition = new Condition();
-  Clause *resource_clause_left = new EnoughResourceClause(conf.left_partner, conf.lres);
-  Clause *resource_clause_right = new EnoughResourceClause(conf.right_partner, conf.rres);
+  Clause *resource_clause_left = new EnoughResourceClause(conf.left_partner, 1);
+  Clause *resource_clause_right = new EnoughResourceClause(conf.right_partner, 1);
   condition->addClause(resource_clause_left);
   condition->addClause(resource_clause_right);
   rule_entanglement_swapping->setCondition(condition);
@@ -953,8 +953,8 @@ std::unique_ptr<Rule> ConnectionManager::simultaneousSwappingRule(SwappingConfig
 
   auto rule_simultaneous_entanglement_swapping = std::make_unique<Rule>(ruleset_id, rule_id, rule_name, partners);
   Condition *condition = new Condition();
-  Clause *resource_clause_left = new EnoughResourceClause(conf.left_partner, conf.lres);
-  Clause *resource_clause_right = new EnoughResourceClause(conf.right_partner, conf.rres);
+  Clause *resource_clause_left = new EnoughResourceClause(conf.left_partner, 1);
+  Clause *resource_clause_right = new EnoughResourceClause(conf.right_partner, 1);
   condition->addClause(resource_clause_left);
   condition->addClause(resource_clause_right);
 

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_rule_generator_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_rule_generator_test.cc
@@ -162,11 +162,11 @@ TEST(ConnectionManagerRuleGenTest, SwappingRule) {
   EXPECT_EQ(rule->condition->clauses.size(), 2);
   auto *left_clause = dynamic_cast<EnoughResourceClause *>(rule->condition->clauses.at(0));
   EXPECT_EQ(access_private::partner(*left_clause), conf.left_partner);
-  EXPECT_EQ(access_private::num_resource_required(*left_clause), conf.lres);
+  EXPECT_EQ(access_private::num_resource_required(*left_clause), 1);
 
   auto *right_clause = dynamic_cast<EnoughResourceClause *>(rule->condition->clauses.at(1));
   EXPECT_EQ(access_private::partner(*right_clause), conf.right_partner);
-  EXPECT_EQ(access_private::num_resource_required(*right_clause), conf.rres);
+  EXPECT_EQ(access_private::num_resource_required(*right_clause), 1);
 
   auto *action = dynamic_cast<SwappingAction *>(rule->action.get());
   ASSERT_NE(action, nullptr);

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
@@ -437,11 +437,11 @@ TEST(ConnectionManagerTest, RespondToRequest) {
       auto *clause1 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(0));
       ASSERT_NE(clause1, nullptr);
       EXPECT_EQ(access_private::partner(*clause1), 2);
-      EXPECT_EQ(access_private::num_resource_required(*clause1), 0);  // XXX: should be 1?
+      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);  // XXX: should be 1?
       auto *clause2 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(1));
       ASSERT_NE(clause2, nullptr);
       EXPECT_EQ(access_private::partner(*clause2), 5);
-      EXPECT_EQ(access_private::num_resource_required(*clause2), 0);  // XXX: should be 1?
+      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);  // XXX: should be 1?
     }
 
     EXPECT_EQ(ruleset->rules.at(0)->next_rule_id, ruleset->rules.at(4)->rule_index);
@@ -557,11 +557,11 @@ TEST(ConnectionManagerTest, RespondToRequest) {
       auto *clause1 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(0));
       ASSERT_NE(clause1, nullptr);
       EXPECT_EQ(access_private::partner(*clause1), 3);
-      EXPECT_EQ(access_private::num_resource_required(*clause1), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);
       auto *clause2 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(1));
       ASSERT_NE(clause2, nullptr);
       EXPECT_EQ(access_private::partner(*clause2), 5);
-      EXPECT_EQ(access_private::num_resource_required(*clause2), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);
     }
 
     EXPECT_EQ(ruleset->rules.at(0)->next_rule_id, ruleset->rules.at(2)->rule_index);
@@ -1155,11 +1155,11 @@ TEST(ConnectionManagerTest, RespondToRequestExtend) {
       auto *clause1 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(0));
       ASSERT_NE(clause1, nullptr);
       EXPECT_EQ(access_private::partner(*clause1), 1);
-      EXPECT_EQ(access_private::num_resource_required(*clause1), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);
       auto *clause2 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(1));
       ASSERT_NE(clause2, nullptr);
       EXPECT_EQ(access_private::partner(*clause2), 3);
-      EXPECT_EQ(access_private::num_resource_required(*clause2), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);
     }
     EXPECT_EQ(ruleset->rules.at(0)->next_rule_id, ruleset->rules.at(2)->rule_index);
     EXPECT_EQ(ruleset->rules.at(1)->next_rule_id, ruleset->rules.at(2)->rule_index);
@@ -1373,11 +1373,11 @@ TEST(ConnectionManagerTest, RespondToRequestExtend) {
       auto *clause1 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(0));
       ASSERT_NE(clause1, nullptr);
       EXPECT_EQ(access_private::partner(*clause1), 1);
-      EXPECT_EQ(access_private::num_resource_required(*clause1), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);
       auto *clause2 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(1));
       ASSERT_NE(clause2, nullptr);
       EXPECT_EQ(access_private::partner(*clause2), 5);
-      EXPECT_EQ(access_private::num_resource_required(*clause2), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);
     }
 
     EXPECT_EQ(ruleset->rules.at(0)->next_rule_id, ruleset->rules.at(2)->rule_index);
@@ -1498,11 +1498,11 @@ TEST(ConnectionManagerTest, RespondToRequestExtend) {
       auto *clause1 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(0));
       ASSERT_NE(clause1, nullptr);
       EXPECT_EQ(access_private::partner(*clause1), 3);
-      EXPECT_EQ(access_private::num_resource_required(*clause1), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);
       auto *clause2 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(1));
       ASSERT_NE(clause2, nullptr);
       EXPECT_EQ(access_private::partner(*clause2), 5);
-      EXPECT_EQ(access_private::num_resource_required(*clause2), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);
     }
     EXPECT_EQ(ruleset->rules.at(0)->next_rule_id, ruleset->rules.at(2)->rule_index);
     EXPECT_EQ(ruleset->rules.at(1)->next_rule_id, ruleset->rules.at(2)->rule_index);
@@ -1816,11 +1816,11 @@ TEST(ConnectionManagerTest, RespondToRequestExtend) {
       auto *clause1 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(0));
       ASSERT_NE(clause1, nullptr);
       EXPECT_EQ(access_private::partner(*clause1), 1);
-      EXPECT_EQ(access_private::num_resource_required(*clause1), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);
       auto *clause2 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(1));
       ASSERT_NE(clause2, nullptr);
       EXPECT_EQ(access_private::partner(*clause2), 9);
-      EXPECT_EQ(access_private::num_resource_required(*clause2), 0);
+      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);
     }
 
     EXPECT_EQ(ruleset->rules.at(0)->next_rule_id, ruleset->rules.at(2)->rule_index);

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
@@ -437,11 +437,11 @@ TEST(ConnectionManagerTest, RespondToRequest) {
       auto *clause1 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(0));
       ASSERT_NE(clause1, nullptr);
       EXPECT_EQ(access_private::partner(*clause1), 2);
-      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);  // XXX: should be 1?
+      EXPECT_EQ(access_private::num_resource_required(*clause1), 1);  
       auto *clause2 = dynamic_cast<EnoughResourceClause *>(rule->condition.get()->clauses.at(1));
       ASSERT_NE(clause2, nullptr);
       EXPECT_EQ(access_private::partner(*clause2), 5);
-      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);  // XXX: should be 1?
+      EXPECT_EQ(access_private::num_resource_required(*clause2), 1);
     }
 
     EXPECT_EQ(ruleset->rules.at(0)->next_rule_id, ruleset->rules.at(4)->rule_index);


### PR DESCRIPTION
Closes #10

# Problem
In the Swapping rule, the number of required resources must take the num resource, but currently, it takes the index of rule. 

# Solution
Fixed the number of required resources to 1 for now because we assume the existence of just a single BSA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/280)
<!-- Reviewable:end -->
