### PR TITLE
fix signal type 

### DIFF
--- a/quisp/modules/Common/Queue.ned
+++ b/quisp/modules/Common/Queue.ned
@@ -12,12 +12,12 @@ simple Queue
         int frameCapacity = default(0); // max number of packets; 0 means no limit
         bool useCutThroughSwitching = default(false);  // use cut-through switching instead of store-and-forward
 	    //@display("i=block/queue;q=queue");
-        @signal[qlen](type="long");
-        @signal[busy](type="bool");
-        @signal[queueingTime](type="simtime_t");
-        @signal[drop](type="long");
-        @signal[txBytes](type="long");
-        @signal[rxBytes](type="long");
+        @signal[qlen](type=long);
+        @signal[busy](type=bool);
+        @signal[queueingTime](type=simtime_t);
+        @signal[drop](type=long);
+        @signal[txBytes](type=long);
+        @signal[rxBytes](type=long);
         // @statistic[qlen](title="queue length"; record=vector?,timeavg,max; interpolationmode=sample-hold);
         // @statistic[busy](title="server busy state"; record=vector?,timeavg; interpolationmode=sample-hold);
         // @statistic[queueingTime](title="queueing time at dequeue"; unit=s; interpolationmode=none);

--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
@@ -29,7 +29,7 @@ namespace modules {
 class BellStateAnalyzer : public cSimpleModule {
  private:
   // for performance analysis
-  int n_res = 0;
+  long n_res = 0;
   int trials = 0;
   simsignal_t GOD_num_resSignal;
   std::string BSA_perf_output_filename;

--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.ned
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.ned
@@ -10,10 +10,10 @@ simple BellStateAnalyzer
         double required_precision = default(1.5e-9);
         int photon_detection_per_sec = default(10000);
         int address;
-        @signal[Num_Bell_state](type="int");
+        @signal[Num_Bell_state](type=long);
         @statistic[Num_Bell_state](title="actual number of resource"; record=vector, max; interpolationmode=sample-hold);
 
-        @signal[num_trial](type="int");
+        @signal[num_trial](type=long);
         @statistic[num_trial](title="The average number of BSA trials to generate one Bell pair"; record=vector, mean; interpolationmode=sample-hold);
 
         int degree = 2;

--- a/quisp/modules/PhysicalConnection/BSA/HoMController.ned
+++ b/quisp/modules/PhysicalConnection/BSA/HoMController.ned
@@ -21,7 +21,7 @@ simple HoMController
         double bsa_notification_interval=default(1e-2);
 
         // performance
-        @signal[creation_time](type="float");
+        @signal[creation_time](type=double);
         @statistic[creation_time](title="Bell pair creation time"; record=vector; interpolationmode=sample-hold);
     gates:
         input fromRouter_port @loose;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -4,7 +4,7 @@ simple StationaryQubit
 {
     parameters:
         // performance analysis
-        // @signal[update_timing](type="float");
+        // @signal[update_timing](type=double);
         // @statistic[update_timing](title="actual number of resource"; record=vector, max; interpolationmode=sample-hold);
         // these are configured at boot time
         int stationaryQubit_address;

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.ned
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.ned
@@ -3,15 +3,15 @@
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Lesser General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 package modules.QRSA.RuleEngine;
 
@@ -27,11 +27,11 @@ simple RuleEngine
         // @signal[recog_res](type="int");
         // @statistic[recog_res](title="recognized number of resource"; record=vector, max; interpolationmode=sample-hold);
         // # of resources in the physically generated
-        @signal[actual_res](type="int");
+        @signal[actual_res](type=long);
         @statistic[actual_res](title="actual number of resource"; record=vector, max; interpolationmode=sample-hold);
 
         // creation time
-        @signal[creation_time](type="simtime_t");
+        @signal[creation_time](type=simtime_t);
         @statistic[creation_time](title="link established time"; record=vector; interpolationmode=sample-hold);
 
 


### PR DESCRIPTION
fixed the shown error in debug mode.
![スクリーンショット 2021-09-12 1 36 08](https://user-images.githubusercontent.com/3610296/133027410-5682c5ef-a690-421b-b020-2f94d2acb54b.png)

the document said
> The value can be of type bool, long, double, simtime_t, const char *, or (const) cObject *. Other types can be cast into one of these types, or wrapped into an object subclassed from cObject.

https://doc.omnetpp.org/omnetpp/manual/#sec:simple-modules:emitting-signals

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/289)
<!-- Reviewable:end -->
