### PR TITLE
fix the logic of finding next rule in RuleEngine::Unlock_resource_and_upgrade_stage

### DIFF
--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -553,7 +553,6 @@ void RuleEngine::Unlock_resource_and_upgrade_stage(unsigned long ruleset_id, uns
   // 0. this resorce update only update just one entanglement
   int partner_address;
   IStationaryQubit *qubit;
-  unsigned long next_rule_id;
   if (rp.size() == 0) {
     return;
   }
@@ -574,13 +573,16 @@ void RuleEngine::Unlock_resource_and_upgrade_stage(unsigned long ruleset_id, uns
               qubit->Unlock();
               // remove qubit from resource list in the rule
               (*rule)->resources.erase(qubit_record);
-              next_rule_id = (*rule)->next_rule_id;
-              break;
+              unsigned long next_rule_id = (*rule)->next_rule_id;
+              for (; rule != process->cend(); ++rule) {
+                if ((*rule)->rule_index == next_rule_id) {
+                  (*rule)->addResource(partner_address, qubit);
+                  return;
+                }
+              }
+              error("next rule not found: RuleSetID: %l, RuleId: %l, index: %d", ruleset_id, rule_id, index);
             }
           }
-        } else if ((*rule)->rule_index == next_rule_id) {
-          (*rule)->addResource(partner_address, qubit);
-          return;
         }
       }
     }


### PR DESCRIPTION
it accesses uninitialized local variable `next_rule_id`.
this PR fixed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/298)
<!-- Reviewable:end -->
