### PR TITLE
fix NO_ERROR conflicts with winerror.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ googletest/CMakeLists.txt:
 	git submodule update --init
 
 googletest/build: googletest/CMakeLists.txt
-	mkdir -p googletest/build && cd googletest/build && cmake ..
+	mkdir -p googletest/build && cd googletest/build && cmake .. -G "Unix Makefiles"
 
 googletest/build/lib: googletest/build
 	make -C googletest/build

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -6,15 +6,15 @@ namespace quisp {
 
 namespace types {
 enum class MeasureXResult : int {
-  NO_ERROR,
+  NO_Z_ERROR,
   HAS_Z_ERROR,
 };
 enum class MeasureYResult : int {
-  NO_ERROR,
+  NO_XZ_ERROR,
   HAS_XZ_ERROR,
 };
 enum class MeasureZResult : int {
-  NO_ERROR,
+  NO_X_ERROR,
   HAS_X_ERROR,
 };
 }  // namespace types

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -221,7 +221,7 @@ MeasureXResult StationaryQubit::measure_X() {
   if (par("GOD_Zerror").boolValue()) {
     return MeasureXResult::HAS_Z_ERROR;
   }
-  return MeasureXResult::NO_ERROR;
+  return MeasureXResult::NO_Z_ERROR;
 }
 
 MeasureYResult StationaryQubit::measure_Y() {
@@ -236,7 +236,7 @@ MeasureYResult StationaryQubit::measure_Y() {
   if (error) {
     return MeasureYResult::HAS_XZ_ERROR;
   }
-  return MeasureYResult::NO_ERROR;
+  return MeasureYResult::NO_XZ_ERROR;
 }
 
 MeasureZResult StationaryQubit::measure_Z() {
@@ -244,7 +244,7 @@ MeasureZResult StationaryQubit::measure_Z() {
   if (par("GOD_Xerror")) {
     return MeasureZResult::HAS_X_ERROR;
   }
-  return MeasureZResult::NO_ERROR;
+  return MeasureZResult::NO_X_ERROR;
 }
 
 // Convert X to Z, and Z to X error. Therefore, Y error stays as Y.
@@ -539,7 +539,7 @@ bool StationaryQubit::Xpurify(IStationaryQubit *resource_qubit /*Controlled*/) {
   applyMemoryError();
   check_and_cast<StationaryQubit *>(resource_qubit)->applyMemoryError();
   /*Target qubit*/ this->CNOT_gate(resource_qubit /*controlled qubit*/);
-  bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
+  bool meas = this->measure_Z() == MeasureZResult::NO_X_ERROR;
   return meas;
 }
 
@@ -549,7 +549,7 @@ bool StationaryQubit::Zpurify(IStationaryQubit *resource_qubit /*Target*/) {
   check_and_cast<StationaryQubit *>(resource_qubit)->applyMemoryError();
   /*Target qubit*/ resource_qubit->CNOT_gate(this /*controlled qubit*/);
   this->Hadamard_gate();
-  bool meas = this->measure_Z() == MeasureZResult::NO_ERROR;
+  bool meas = this->measure_Z() == MeasureZResult::NO_X_ERROR;
   return meas;
 }
 

--- a/quisp/rules/actions/SimultaneousSwappingAction.cc
+++ b/quisp/rules/actions/SimultaneousSwappingAction.cc
@@ -76,15 +76,15 @@ cPacket *SimultaneousSwappingAction::run(cModule *re) {
 
   int operation_type_left, operation_type_right;
 
-  if (left_measure == MeasureZResult::NO_ERROR && right_measure == MeasureZResult::NO_ERROR) {  // 0 0
+  if (left_measure == MeasureZResult::NO_X_ERROR && right_measure == MeasureZResult::NO_X_ERROR) {  // 0 0
     EV << "operation type 0, operation left I, operation right I\n";
     operation_type_left = 0;
     operation_type_right = 0;
-  } else if (left_measure == MeasureZResult::NO_ERROR && right_measure == MeasureZResult::HAS_X_ERROR) {  // 0 1
+  } else if (left_measure == MeasureZResult::NO_X_ERROR && right_measure == MeasureZResult::HAS_X_ERROR) {  // 0 1
     EV << "operation type 1, operation left I, operation right X\n";
     operation_type_left = 0;
     operation_type_right = 1;
-  } else if (left_measure == MeasureZResult::HAS_X_ERROR && right_measure == MeasureZResult::NO_ERROR) {  // 1 0
+  } else if (left_measure == MeasureZResult::HAS_X_ERROR && right_measure == MeasureZResult::NO_X_ERROR) {  // 1 0
     EV << "operation type 2, operation left Z, operation right I\n";
     operation_type_left = 0;
     operation_type_right = 2;

--- a/quisp/rules/actions/SwappingAction.cc
+++ b/quisp/rules/actions/SwappingAction.cc
@@ -82,15 +82,15 @@ cPacket *SwappingAction::run(cModule *re) {
   // RuleEngine::updateResources_EntanglementSwapping handles the operation type.
   int operation_type_left, operation_type_right;
   // operation_type: 0 = I, 1 = X, 2 = Z
-  if (left_measure == MeasureZResult::NO_ERROR && right_measure == MeasureZResult::NO_ERROR) {
+  if (left_measure == MeasureZResult::NO_X_ERROR && right_measure == MeasureZResult::NO_X_ERROR) {
     EV << "operation type 0, operation left I, operation right I\n";
     operation_type_left = 0;
     operation_type_right = 0;
-  } else if (left_measure == MeasureZResult::NO_ERROR && right_measure == MeasureZResult::HAS_X_ERROR) {
+  } else if (left_measure == MeasureZResult::NO_X_ERROR && right_measure == MeasureZResult::HAS_X_ERROR) {
     EV << "operation type 1, operation left I, operation right X\n";
     operation_type_left = 0;
     operation_type_right = 1;
-  } else if (left_measure == MeasureZResult::HAS_X_ERROR && right_measure == MeasureZResult::NO_ERROR) {
+  } else if (left_measure == MeasureZResult::HAS_X_ERROR && right_measure == MeasureZResult::NO_X_ERROR) {
     EV << "operation type 2, operation left Z, operation right I\n";
     operation_type_left = 2;
     operation_type_right = 0;

--- a/quisp/rules/actions/SwappingAction_test.cc
+++ b/quisp/rules/actions/SwappingAction_test.cc
@@ -166,8 +166,8 @@ TEST(SwappingActionTest, runWithNoError) {
   right_qubit->entangled_partner = left_qubit;
   left_qubit->entangled_partner = right_qubit;
 
-  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_ERROR));
-  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_ERROR));
+  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
+  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
   EXPECT_CALL(*action, getResource(23, 24)).WillOnce(Return(left_qubit));
@@ -206,7 +206,7 @@ TEST(SwappingActionTest, runWithRightHasError) {
   left_qubit->entangled_partner = right_qubit;
 
   EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
-  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_ERROR));
+  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
   EXPECT_CALL(*action, getResource(23, 24)).WillOnce(Return(left_qubit));
@@ -244,7 +244,7 @@ TEST(SwappingActionTest, runWithLeftHasError) {
   right_qubit->entangled_partner = left_qubit;
   left_qubit->entangled_partner = right_qubit;
 
-  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_ERROR));
+  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
   EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));


### PR DESCRIPTION
unfortunately `winerror.h` defines NO_ERROR macro and it overrides
NO_ERROR as integers. so we should avoid using NO_ERROR.

this PR fixed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/302)
<!-- Reviewable:end -->
