### PR TITLE
Add test coverage and integrate Codacy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,15 +19,22 @@ jobs:
           ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
           ln -sf /usr/bin/clang-12 /usr/bin/clang
           ln -sf /usr/bin/clang++-12 /usr/bin/clang++
+          ln -sf /usr/bin/llvm-profdata-12 /usr/bin/llvm-profdata
+          ln -sf /usr/bin/llvm-cov-12 /usr/bin/llvm-cov
       - name: Check out repository
         uses: actions/checkout@v2
       - name: clang-format and clang-tidy
         run: make ci
-      - name: unit tests
+      - name: unit tests and generate coverage report
         run: |
           opp_makemake -f --deep -O out -i ./makefrag -M release --make-so
-          make run-unit-test
+          make lcov.info
         working-directory: quisp
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: quisp/lcov.info
       # - name: module tests
         # run: make run-module-test
       - name: Run Simulations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run codacy-coverage-reporter
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          api-token: ${{ secrets.CODACY_API_TOKEN }}
           coverage-reports: quisp/lcov.info
       # - name: module tests
         # run: make run-module-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run codacy-coverage-reporter
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
-          api-token: ${{ secrets.CODACY_API_TOKEN }}
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: quisp/lcov.info
       # - name: module tests
         # run: make run-module-test

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 .cache
 compile_commands.json
 
+### coverage files
+quisp/coverage*
+quisp/lcov.info
+quisp/default.profraw
+
 ### generated on docker
 org.eclipse*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update -y && apt install -y --no-install-recommends \
     ln -s /usr/bin/clang-format-12 /usr/bin/clang-format && \
     ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy && \
     ln -sf /usr/bin/clang-12 /usr/bin/clang && \
-    ln -sf /usr/bin/clang++-12 /usr/bin/clang++
+    ln -sf /usr/bin/clang++-12 /usr/bin/clang++ && \
+    ln -sf /usr/bin/llvm-profdata-12 /usr/bin/llvm-profdata && \
+    ln -sf /usr/bin/llvm-cov-12 /usr/bin/llvm-cov
 
 
 # first stage - build OMNeT++ with GUI

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,17 @@ makefile-lib: eigen
 clean:
 	$(RM) quisp/Makefile quisp/quisp quisp/quisp_dbg quisp/run_unit_test quisp/libquisp*
 	$(RM) -r quisp/out
+	$(RM) -rf quisp/coverage* quisp/default.profraw quisp/lcov.info
 
 distclean:
 	git submodule deinit --all -f
 	make clean
 
+generate-coverage: makefile-lib
+	$(MAKE) -C quisp lcov.info
+
+generate-coverage-report: makefile-lib
+	$(MAKE) -C quisp/ coverage/index.html
 
 checkmakefile:
 	@if [ ! -f $(QUISP_MAKEFILE) ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all tidy format ci makefile-exe makefile-lib checkmakefile googletest clean test
+.PHONY: all tidy format ci makefile-exe makefile-lib checkmakefile googletest clean test coverage coverage-report help
 
 all: makefile-exe
 	$(MAKE) -C quisp -j$(nproc)
@@ -58,10 +58,10 @@ distclean:
 	git submodule deinit --all -f
 	make clean
 
-generate-coverage: makefile-lib
+coverage: makefile-lib
 	$(MAKE) -C quisp lcov.info
 
-generate-coverage-report: makefile-lib
+coverage-report: makefile-lib
 	$(MAKE) -C quisp/ coverage/index.html
 
 checkmakefile:
@@ -73,4 +73,22 @@ checkmakefile:
 	echo; \
 	exit 1; \
 	fi
+
+help:
+	@echo; \
+	echo '===================================================================================================='; \
+	echo 'Usage: make [target]'; \
+	echo '===================================================================================================='; \
+	echo; \
+	echo 'Available targets:'; \
+	echo '  exe                 build the executable quisp/quisp'; \
+	echo '  lib                 build the library quisp/libquisp{_dbg}.{dylib,so}'; \
+	echo '  clean               remove objcet files, executables and libraries'; \
+	echo '  distclean           remove everything includes submoduled components'; \
+	echo '  run-unit-test       build unit tests and run it'; \
+	echo '  run-module-test     build modele tests(opp_test) and run it'; \
+	echo '  coverage            generate coverage as quisp/lcov.info'; \
+	echo '  coverage-report     generate html coverage report at quisp/coverage/index.html'; \
+	echo '  format              run clang-format on the source files'; \
+	echo '  tidy                run clang-tidy on the source files to do static analysis'; \
 

--- a/quisp/makefrag
+++ b/quisp/makefrag
@@ -25,6 +25,10 @@ INCLUDE_PATH+=-I. $(shell pkg-config eigen3 --cflags)
 endif
 
 INCLUDE_PATH+=-I.
+ifneq (,$(ENABLE_COVERAGE))
+CXXFLAGS+=-ftest-coverage -fprofile-instr-generate -fcoverage-mapping
+LDFLAGS+=-ftest-coverage -fprofile-instr-generate -fcoverage-mapping
+endif
 
 default: eigen all
 
@@ -50,6 +54,23 @@ $(TARGET_DIR)/run_unit_test: $(TARGET_DIR)/$(TARGET) $(TEST_OBJS)  $(wildcard $(
 
 run-unit-test: $(TARGET_DIR)/run_unit_test
 	$(TARGET_DIR)/run_unit_test
+
+$(TARGET_DIR)/coverage.profraw:
+	rm -rf coverage*
+	ENABLE_COVERAGE=true make run-unit-test
+	LLVM_PROFILE_FILE=$(TARGET_DIR)/coverage.profraw $(TARGET_DIR)/run_unit_test
+
+$(TARGET_DIR)/coverage.profdata: $(TARGET_DIR)/coverage.profraw
+	ls -la
+	llvm-profdata -h
+	ls -la $(TARGET_DIR)
+	llvm-profdata merge -sparse -o $(TARGET_DIR)/coverage.profdata $(TARGET_DIR)/coverage.profraw
+
+$(TARGET_DIR)/lcov.info: $(TARGET_DIR)/coverage.profdata
+	llvm-cov export -instr-profile=./coverage.profdata ./run_unit_test -format=lcov ../ > lcov.info
+
+$(TARGET_DIR)/coverage/index.html: $(TARGET_DIR)/lcov.info
+	genhtml lcov.info -o $(TARGET_DIR)/coverage
 
 .PHONY: eigen
 # check eigen exists and setup eigen if needed.

--- a/quisp/makefrag
+++ b/quisp/makefrag
@@ -61,13 +61,10 @@ $(TARGET_DIR)/coverage.profraw:
 	LLVM_PROFILE_FILE=$(TARGET_DIR)/coverage.profraw $(TARGET_DIR)/run_unit_test
 
 $(TARGET_DIR)/coverage.profdata: $(TARGET_DIR)/coverage.profraw
-	ls -la
-	llvm-profdata -h
-	ls -la $(TARGET_DIR)
 	llvm-profdata merge -sparse -o $(TARGET_DIR)/coverage.profdata $(TARGET_DIR)/coverage.profraw
 
 $(TARGET_DIR)/lcov.info: $(TARGET_DIR)/coverage.profdata
-	llvm-cov export -instr-profile=./coverage.profdata ./run_unit_test -format=lcov ../ > lcov.info
+	llvm-cov export -instr-profile=./coverage.profdata ./run_unit_test -format=lcov ../ -ignore-filename-regex=".*_test.cc|eigen/.*|test_utils/.*|.*_m.h|.*_m.cc" > lcov.info
 
 $(TARGET_DIR)/coverage/index.html: $(TARGET_DIR)/lcov.info
 	genhtml lcov.info -o $(TARGET_DIR)/coverage

--- a/quisp/makefrag
+++ b/quisp/makefrag
@@ -64,7 +64,7 @@ $(TARGET_DIR)/coverage.profdata: $(TARGET_DIR)/coverage.profraw
 	llvm-profdata merge -sparse -o $(TARGET_DIR)/coverage.profdata $(TARGET_DIR)/coverage.profraw
 
 $(TARGET_DIR)/lcov.info: $(TARGET_DIR)/coverage.profdata
-	llvm-cov export -instr-profile=./coverage.profdata ./run_unit_test -format=lcov ../ -ignore-filename-regex=".*_test.cc|eigen/.*|test_utils/.*|.*_m.h|.*_m.cc" > lcov.info
+	llvm-cov export -instr-profile=./coverage.profdata ./run_unit_test -format=lcov ../ -ignore-filename-regex=".*_test.cc|eigen/.*|.*test_utils/.*|.*_m.h|.*_m.cc" > lcov.info
 
 $(TARGET_DIR)/coverage/index.html: $(TARGET_DIR)/lcov.info
 	genhtml lcov.info -o $(TARGET_DIR)/coverage


### PR DESCRIPTION
you can see the coverage here https://app.codacy.com/gh/sfc-aqua/quisp/files?bid=26682065
and also you can generate coverage by `$ make coverage-report` and then you can browse the report under `quisp/coverage/index.html`.

I integrated Codacy to check the coverage. in anther PR, I'll integrate clang-tidy to Codacy.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/313)
<!-- Reviewable:end -->
