### PR TITLE
add codacy badges and fix workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
           make lcov.info
         working-directory: quisp
       - name: Run codacy-coverage-reporter
+        if: ${{ github.event_name == 'push' && github.repository == 'sfc-aqua/quisp' }}
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # QUISP
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/83c96c45f2684211a8cef800b1d07f81)](https://www.codacy.com/gh/sfc-aqua/quisp/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=sfc-aqua/quisp&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/83c96c45f2684211a8cef800b1d07f81)](https://www.codacy.com/gh/sfc-aqua/quisp/dashboard?utm_source=github.com&utm_medium=referral&utm_content=sfc-aqua/quisp&utm_campaign=Badge_Coverage)
 ![github workflow](https://github.com/sfc-aqua/quisp/actions/workflows/main.yml/badge.svg)
 <a href="https://aqua-quisp.slack.com/" rel="nofollow"><img src="https://img.shields.io/badge/join-us%20on%20slack-gray.svg?colorB=red&amp;logo=slack&amp;longCache=true" alt="Slack Widget"></a>
 The Quantum Internet Simulation Package (QuISP) is an event-driven


### PR DESCRIPTION
add badges on readme.
<img width="544" alt="スクリーンショット 2021-12-03 17 55 09" src="https://user-images.githubusercontent.com/3610296/144574171-cf346f40-a7a7-47e3-8c1a-d84009ef9ba6.png">

and fixed the GitHub actions workflow to disable to report to codacy if the PR from another forked repository.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/315)
<!-- Reviewable:end -->
