### PR TITLE
Cleanup unit tests

### DIFF
--- a/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController_test.cc
@@ -17,20 +17,14 @@ using namespace quisp::utils;
 using namespace quisp::modules;
 using namespace quisp_test;
 
-class MockStationaryQubit : public StationaryQubit {
- public:
-  MOCK_METHOD(void, emitPhoton, (int pulse), (override));
-  MOCK_METHOD(void, setFree, (bool consumed), (override));
-};
-
 class Strategy : public quisp_test::TestComponentProviderStrategy {
  public:
   Strategy() : mockQubit(nullptr) {}
-  Strategy(MockStationaryQubit* _qubit) : mockQubit(_qubit) {}
+  Strategy(MockQubit* _qubit) : mockQubit(_qubit) {}
   ~Strategy() { delete mockQubit; }
-  MockStationaryQubit* mockQubit = nullptr;
-  StationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
-    if (mockQubit == nullptr) mockQubit = new MockStationaryQubit();
+  MockQubit* mockQubit = nullptr;
+  IStationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
+    if (mockQubit == nullptr) mockQubit = new MockQubit();
     return mockQubit;
   };
 };
@@ -39,7 +33,7 @@ class RTCTestTarget : public quisp::modules::RealTimeController {
  public:
   using quisp::modules::RealTimeController::initialize;
   using quisp::modules::RealTimeController::par;
-  RTCTestTarget(MockStationaryQubit* mockQubit) : RealTimeController() {
+  RTCTestTarget(MockQubit* mockQubit) : RealTimeController() {
     omnetpp::cParImpl* p = new omnetpp::cIntParImpl();
     const char* name = "address";
     p->setName(name);
@@ -57,7 +51,7 @@ TEST(RealTimeControllerTest, Init) {
 }
 TEST(RealTimeControllerTest, EmitPhoton) {
   prepareSimulation();
-  auto* qubit = new MockStationaryQubit{};
+  auto* qubit = new MockQubit{};
   RTCTestTarget c{qubit};
   c.initialize();
 
@@ -67,7 +61,7 @@ TEST(RealTimeControllerTest, EmitPhoton) {
 
 TEST(RealTimeControllerTest, ReInitializeStationaryQubit) {
   prepareSimulation();
-  auto* qubit = new MockStationaryQubit{};
+  auto* qubit = new MockQubit{};
   RTCTestTarget c{qubit};
   c.initialize();
 

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -907,7 +907,7 @@ void RuleEngine::updateResources_EntanglementSwapping(swapping_result swapr) {
   int qubit_index = swapr.measured_qubit_index;
 
   // qubit with address Addr was shot in nth time. This list is ordered from old to new.
-  StationaryQubit *qubit = provider.getStationaryQubit(qnic_index, qubit_index, qnic_type);
+  IStationaryQubit *qubit = provider.getStationaryQubit(qnic_index, qubit_index, qnic_type);
   // check
   if (operation_type == 0) {
     // do nothing
@@ -984,7 +984,7 @@ void RuleEngine::updateResources_SimultaneousEntanglementSwapping(swapping_resul
   int qnic_index = info->qnic.index;
   QNIC_type qnic_type = info->qnic.type;
   int qubit_index = swapr.measured_qubit_index;
-  StationaryQubit *qubit = provider.getStationaryQubit(qnic_index, qubit_index, qnic_type);
+  IStationaryQubit *qubit = provider.getStationaryQubit(qnic_index, qubit_index, qnic_type);
 
   if (operation_type == 0) {
     // nothing
@@ -1068,7 +1068,7 @@ void RuleEngine::freeFailedQubits_and_AddAsResource(int destAddr, int internal_q
       freeResource(it->second.qnic_index, it->second.qubit_index, qnic_type);
     } else {
       // Keep the entangled qubits
-      StationaryQubit *qubit = provider.getStationaryQubit(qnic_index, it->second.qubit_index, qnic_type);
+      IStationaryQubit *qubit = provider.getStationaryQubit(qnic_index, it->second.qubit_index, qnic_type);
 
       // if the partner is null, not correct
       if (qubit->entangled_partner != nullptr) {

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -172,6 +172,8 @@ TEST(RuleEngineTest, resourceAllocation) {
   rs->addRule(std::move(rule));
   rule_engine->rp.insert(rs);
 
+  EXPECT_CALL(*mockQubit1, Allocate()).WillRepeatedly(Return());
+  EXPECT_CALL(*mockQubit1, isAllocated()).WillRepeatedly(Return(false));
   rule_engine->ResourceAllocation(QNIC_E, 3);
 
   // resource allocation assigns a corresponding qubit to action's resource
@@ -183,6 +185,7 @@ TEST(RuleEngineTest, resourceAllocation) {
   EXPECT_EQ(_rule->resources.size(), 1);
   delete mockHardwareMonitor;
   delete routingdaemon;
+  delete mockQubit1;
 }
 
 TEST(RuleEngineTest, trackerUpdate) {

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -11,7 +11,7 @@
 #include "RuleEngine.h"
 
 #include "modules/QNIC.h"
-#include "modules/QNIC/StationaryQubit/StationaryQubit.h"
+#include "modules/QNIC/StationaryQubit/IStationaryQubit.h"
 #include "modules/QRSA/HardwareMonitor/HardwareMonitor.h"
 #include "modules/QRSA/HardwareMonitor/IHardwareMonitor.h"
 #include "modules/QRSA/RealTimeController/IRealTimeController.h"
@@ -30,23 +30,10 @@ using namespace quisp::modules;
 using namespace quisp_test;
 using namespace testing;
 
-class MockStationaryQubit : public StationaryQubit {
- public:
-  MockStationaryQubit(QNIC_type _type, QNicIndex index) {
-    qnic_type = _type;
-    qnic_index = index;
-  }
-
-  MOCK_METHOD(void, emitPhoton, (int pulse), (override));
-  MOCK_METHOD(void, setFree, (bool consumed), (override));
-  MOCK_METHOD(void, X_gate, (), (override));
-  MOCK_METHOD(void, Z_gate, (), (override));
-};
-
 class Strategy : public quisp_test::TestComponentProviderStrategy {
  public:
   Strategy() : mockQubit(nullptr), routingDaemon(nullptr), hardwareMonitor(nullptr) {}
-  Strategy(StationaryQubit* _qubit, MockRoutingDaemon* routing_daemon, MockHardwareMonitor* hardware_monitor, MockRealTimeController* realtime_controller)
+  Strategy(IStationaryQubit* _qubit, MockRoutingDaemon* routing_daemon, MockHardwareMonitor* hardware_monitor, MockRealTimeController* realtime_controller)
       : mockQubit(_qubit), routingDaemon(routing_daemon), hardwareMonitor(hardware_monitor), realtimeController(realtime_controller) {}
   ~Strategy() {
     delete mockQubit;
@@ -54,12 +41,12 @@ class Strategy : public quisp_test::TestComponentProviderStrategy {
     delete hardwareMonitor;
     delete realtimeController;
   }
-  StationaryQubit* mockQubit = nullptr;
+  IStationaryQubit* mockQubit = nullptr;
   MockRoutingDaemon* routingDaemon = nullptr;
   MockHardwareMonitor* hardwareMonitor = nullptr;
   MockRealTimeController* realtimeController = nullptr;
-  StationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
-    if (mockQubit == nullptr) mockQubit = new MockStationaryQubit(QNIC_E, 1);
+  IStationaryQubit* getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override {
+    if (mockQubit == nullptr) mockQubit = new MockQubit(QNIC_E, 1);
     return mockQubit;
   };
   IRoutingDaemon* getRoutingDaemon() override { return routingDaemon; };
@@ -79,7 +66,7 @@ class RuleEngineTestTarget : public quisp::modules::RuleEngine {
   using quisp::modules::RuleEngine::updateAppliedRule;
   using quisp::modules::RuleEngine::updateResources_EntanglementSwapping;
 
-  RuleEngineTestTarget(StationaryQubit* mockQubit, MockRoutingDaemon* routingdaemon, MockHardwareMonitor* hardware_monitor, MockRealTimeController* realtime_controller)
+  RuleEngineTestTarget(IStationaryQubit* mockQubit, MockRoutingDaemon* routingdaemon, MockHardwareMonitor* hardware_monitor, MockRealTimeController* realtime_controller)
       : quisp::modules::RuleEngine() {
     setParInt(this, "address", 123);
     setParInt(this, "number_of_qnics_rp", 0);
@@ -91,7 +78,7 @@ class RuleEngineTestTarget : public quisp::modules::RuleEngine {
     setComponentType(new TestModuleType("rule_engine_test"));
   }
   // setter function for allResorces[qnic_type][qnic_index]
-  void setAllResources(int partner_addr, StationaryQubit* qubit) { this->bell_pair_store.insertEntangledQubit(partner_addr, qubit); };
+  void setAllResources(int partner_addr, IStationaryQubit* qubit) { this->bell_pair_store.insertEntangledQubit(partner_addr, qubit); };
   void setTracker(int qnic_address, int shot_number, QubitAddr_cons qubit_address) { this->tracker[qnic_address].insert(std::make_pair(shot_number, qubit_address)); };
 
  private:
@@ -107,7 +94,7 @@ TEST(RuleEngineTest, ESResourceUpdate) {
   auto* sim = prepareSimulation();
   auto* routingdaemon = new MockRoutingDaemon;
   auto* mockHardwareMonitor = new MockHardwareMonitor;
-  auto* mockQubit1 = new MockStationaryQubit(QNIC_E, 0);
+  auto* mockQubit1 = new MockQubit(QNIC_E, 0);
   auto rule_engine = new RuleEngineTestTarget{mockQubit1, routingdaemon, mockHardwareMonitor, nullptr};
 
   auto info = std::make_unique<ConnectionSetupInfo>();
@@ -166,9 +153,9 @@ TEST(RuleEngineTest, resourceAllocation) {
   auto* mockHardwareMonitor = new MockHardwareMonitor;
   EXPECT_CALL(*mockHardwareMonitor, getQnicNumQubits(0, QNIC_E)).WillRepeatedly(Return(1));
   EXPECT_CALL(*mockHardwareMonitor, getQnicNumQubits(0, QNIC_R)).WillRepeatedly(Return(1));
-  auto mockQubit0 = new MockStationaryQubit(QNIC_E, 3);
-  auto mockQubit1 = new MockStationaryQubit(QNIC_E, 3);
-  auto mockQubit2 = new MockStationaryQubit(QNIC_E, 3);
+  auto mockQubit0 = new MockQubit(QNIC_E, 3);
+  auto mockQubit1 = new MockQubit(QNIC_E, 3);
+  auto mockQubit2 = new MockQubit(QNIC_E, 3);
   auto rule_engine = new RuleEngineTestTarget{mockQubit1, routingdaemon, mockHardwareMonitor, nullptr};
   sim->registerComponent(rule_engine);
   rule_engine->callInitialize();
@@ -511,7 +498,7 @@ TEST(RuleEngineTest, updateResourcesEntanglementSwappingWithoutRuleSet) {
   auto* routing_daemon = new MockRoutingDaemon;
   auto* hardware_monitor = new MockHardwareMonitor;
   auto* realtime_controller = new MockRealTimeController;
-  auto* qubit = new MockStationaryQubit(QNIC_E, 7);
+  auto* qubit = new MockQubit(QNIC_E, 7);
   auto* rule_engine = new RuleEngineTestTarget{qubit, routing_daemon, hardware_monitor, realtime_controller};
   EXPECT_CALL(*hardware_monitor, getQnicNumQubits(0, QNIC_E)).Times(3).WillRepeatedly(Return(2));
   EXPECT_CALL(*hardware_monitor, getQnicNumQubits(0, QNIC_R)).Times(3).WillRepeatedly(Return(2));
@@ -560,7 +547,7 @@ TEST(RuleEngineTest, updateResourcesEntanglementSwappingWithRuleSet) {
   auto* routing_daemon = new MockRoutingDaemon;
   auto* hardware_monitor = new MockHardwareMonitor;
   auto* realtime_controller = new MockRealTimeController;
-  auto* qubit = new MockStationaryQubit(QNIC_E, 7);
+  auto* qubit = new MockQubit(QNIC_E, 7);
   auto* rule_engine = new RuleEngineTestTarget{qubit, routing_daemon, hardware_monitor, realtime_controller};
   EXPECT_CALL(*hardware_monitor, getQnicNumQubits(0, QNIC_E)).Times(3).WillRepeatedly(Return(2));
   EXPECT_CALL(*hardware_monitor, getQnicNumQubits(0, QNIC_R)).Times(3).WillRepeatedly(Return(2));

--- a/quisp/rules/actions/SwappingAction_test.cc
+++ b/quisp/rules/actions/SwappingAction_test.cc
@@ -167,6 +167,10 @@ TEST(SwappingActionTest, runWithNoError) {
   left_qubit->entangled_partner = right_qubit;
 
   EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
+  EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, Hadamard_gate()).WillOnce(Return());
   EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
@@ -206,6 +210,10 @@ TEST(SwappingActionTest, runWithRightHasError) {
   left_qubit->entangled_partner = right_qubit;
 
   EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
+  EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, Hadamard_gate()).WillOnce(Return());
   EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
@@ -245,6 +253,10 @@ TEST(SwappingActionTest, runWithLeftHasError) {
   left_qubit->entangled_partner = right_qubit;
 
   EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
+  EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, Hadamard_gate()).WillOnce(Return());
   EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
@@ -284,6 +296,10 @@ TEST(SwappingActionTest, runWithBothErrors) {
   left_qubit->entangled_partner = right_qubit;
 
   EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
+  EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit)).WillOnce(Return());
+  EXPECT_CALL(*left_qubit, Hadamard_gate()).WillOnce(Return());
   EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));

--- a/quisp/test_utils/TestComponentProviderStrategy.h
+++ b/quisp/test_utils/TestComponentProviderStrategy.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <modules/QNIC.h>
-#include <modules/QNIC/StationaryQubit/StationaryQubit.h>
+#include <modules/QNIC/StationaryQubit/IStationaryQubit.h>
 #include <modules/QRSA/RealTimeController/IRealTimeController.h>
 #include <utils/IComponentProviderStrategy.h>
 #include "Simulation.h"
@@ -13,7 +13,7 @@ using quisp::modules::IHardwareMonitor;
 using quisp::modules::IRealTimeController;
 using quisp::modules::IRoutingDaemon;
 using quisp::modules::QNIC_type;
-using quisp::modules::StationaryQubit;
+using quisp::modules::IStationaryQubit;
 using quisp::utils::IComponentProviderStrategy;
 using quisp_test::simulation::TestSimulation;
 
@@ -26,7 +26,7 @@ class TestComponentProviderStrategy : public IComponentProviderStrategy {
   virtual bool isQNodeType(const cModuleType *const type) override { return false; };
   virtual bool isHoMNodeType(const cModuleType *const type) override { return false; };
   virtual bool isSPDCNodeType(const cModuleType *const type) override { return false; };
-  virtual StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override { return nullptr; };
+  virtual IStationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override { return nullptr; };
   virtual cModule *getQNIC(int qnic_index, QNIC_type qnic_type) override { return nullptr; };
   virtual IRoutingDaemon *getRoutingDaemon() override { return nullptr; };
   virtual IHardwareMonitor *getHardwareMonitor() override { return nullptr; };

--- a/quisp/test_utils/TestComponentProviderStrategy.h
+++ b/quisp/test_utils/TestComponentProviderStrategy.h
@@ -12,8 +12,8 @@ namespace strategy {
 using quisp::modules::IHardwareMonitor;
 using quisp::modules::IRealTimeController;
 using quisp::modules::IRoutingDaemon;
-using quisp::modules::QNIC_type;
 using quisp::modules::IStationaryQubit;
+using quisp::modules::QNIC_type;
 using quisp::utils::IComponentProviderStrategy;
 using quisp_test::simulation::TestSimulation;
 

--- a/quisp/utils/ComponentProvider.cc
+++ b/quisp/utils/ComponentProvider.cc
@@ -32,7 +32,7 @@ bool ComponentProvider::isQNodeType(const cModuleType *const type) {
   return strategy->isQNodeType(type);
 }
 
-StationaryQubit *ComponentProvider::getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) {
+IStationaryQubit *ComponentProvider::getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) {
   ensureStrategy();
   return strategy->getStationaryQubit(qnic_index, qubit_index, qnic_type);
 }

--- a/quisp/utils/ComponentProvider.h
+++ b/quisp/utils/ComponentProvider.h
@@ -26,7 +26,7 @@ class ComponentProvider {
   bool isQNodeType(const cModuleType *const type);
   bool isHoMNodeType(const cModuleType *const type);
   bool isSPDCNodeType(const cModuleType *const type);
-  StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type);
+  IStationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type);
   cModule *getQNIC(int qnic_index, QNIC_type qnic_type);
   IRoutingDaemon *getRoutingDaemon();
   IHardwareMonitor *getHardwareMonitor();

--- a/quisp/utils/DefaultComponentProviderStrategy.cc
+++ b/quisp/utils/DefaultComponentProviderStrategy.cc
@@ -28,13 +28,13 @@ cModule *DefaultComponentProviderStrategy::getNeighborNode(cModule *qnic) {
   return neighbor_node;
 }
 
-StationaryQubit *DefaultComponentProviderStrategy::getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) {
+IStationaryQubit *DefaultComponentProviderStrategy::getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) {
   auto *qnic = getQNIC(qnic_index, qnic_type);
   if (qnic == nullptr) {
     throw cRuntimeError("QNIC not found. index: %d, type: %d", qnic_index, qnic_type);
   }
   auto *qubit = qnic->getSubmodule("statQubit", qubit_index);
-  return check_and_cast<StationaryQubit *>(qubit);
+  return check_and_cast<IStationaryQubit *>(qubit);
 }
 
 cModule *DefaultComponentProviderStrategy::getQNIC(int qnic_index, QNIC_type qnic_type) {

--- a/quisp/utils/DefaultComponentProviderStrategy.h
+++ b/quisp/utils/DefaultComponentProviderStrategy.h
@@ -15,7 +15,7 @@ class DefaultComponentProviderStrategy : public IComponentProviderStrategy {
   bool isQNodeType(const cModuleType *const type) override;
   bool isHoMNodeType(const cModuleType *const type) override;
   bool isSPDCNodeType(const cModuleType *const type) override;
-  StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override;
+  IStationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) override;
   cModule *getQNIC(int qnic_index, QNIC_type qnic_type) override;
   IRoutingDaemon *getRoutingDaemon() override;
   IHardwareMonitor *getHardwareMonitor() override;

--- a/quisp/utils/IComponentProviderStrategy.h
+++ b/quisp/utils/IComponentProviderStrategy.h
@@ -16,7 +16,7 @@ class IComponentProviderStrategy {
   virtual bool isQNodeType(const cModuleType *const module) = 0;
   virtual bool isHoMNodeType(const cModuleType *const module) = 0;
   virtual bool isSPDCNodeType(const cModuleType *const module) = 0;
-  virtual StationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) = 0;
+  virtual IStationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type) = 0;
   virtual cModule *getQNIC(int qnic_index, QNIC_type qnic_type) = 0;
   virtual IRoutingDaemon *getRoutingDaemon() = 0;
   virtual IHardwareMonitor *getHardwareMonitor() = 0;

--- a/quisp/utils/utils.h
+++ b/quisp/utils/utils.h
@@ -14,10 +14,10 @@ namespace utils {
 using modules::IHardwareMonitor;
 using modules::IRealTimeController;
 using modules::IRoutingDaemon;
+using modules::IStationaryQubit;
 using modules::QNIC_N;
 using modules::QNIC_names;
 using modules::QNIC_type;
-using modules::IStationaryQubit;
 using omnetpp::cModule;
 
 }  // namespace utils

--- a/quisp/utils/utils.h
+++ b/quisp/utils/utils.h
@@ -2,7 +2,7 @@
 #define QUISP_UTILS_H_
 
 #include <modules/QNIC.h>
-#include <modules/QNIC/StationaryQubit/StationaryQubit.h>
+#include <modules/QNIC/StationaryQubit/IStationaryQubit.h>
 #include <modules/QRSA/HardwareMonitor/IHardwareMonitor.h>
 #include <modules/QRSA/RealTimeController/IRealTimeController.h>
 #include <modules/QRSA/RoutingDaemon/IRoutingDaemon.h>
@@ -17,7 +17,7 @@ using modules::IRoutingDaemon;
 using modules::QNIC_N;
 using modules::QNIC_names;
 using modules::QNIC_type;
-using modules::StationaryQubit;
+using modules::IStationaryQubit;
 using omnetpp::cModule;
 
 }  // namespace utils


### PR DESCRIPTION
after #315 , next: #317

* update googletest to the latest master because of the [C++ TestMate Extension issue](https://github.com/matepek/vscode-catch2-test-adapter/issues/304)
* use MockQubit instead of MockStationaryQubit in each test file.
* suppress warnings like the screenshot below.
<img width="765" alt="スクリーンショット 2021-12-03 20 58 35" src="https://user-images.githubusercontent.com/3610296/144598959-97c5dac4-5f4e-44b6-9ddb-8a680b1b26f3.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/316)
<!-- Reviewable:end -->
