### PR TITLE
update OMNeT++ msgc version to 6

### DIFF
--- a/quisp/PhotonicQubit.msg
+++ b/quisp/PhotonicQubit.msg
@@ -1,16 +1,3 @@
-
-cplusplus {{ 
-    #include <vector>
-    #include <unsupported/Eigen/MatrixFunctions>
-
-	using namespace omnetpp;
-    typedef cModule *GOD_statQubitPtr; 
-    
-}} // C++ typedef
-class noncobject GOD_statQubitPtr; // For tracking the truely entangled ones (Only God knows!). The system may think the qubit is entangled but it may not (darkcount)!
-
-
-
 namespace quisp::messages;
 
 message PhotonicQubit
@@ -27,7 +14,7 @@ message PhotonicQubit
     int NodeEntangledWith = -1;//Which node it is entangled with. -1 if not entangled. Equivalent to SrcAddress.
     int QNICEntangledWith = -1;//Which QNIC it is entangled with
     int StationaryQubitEntangledWith = -1;//Which buffer it is entangled with
-    GOD_statQubitPtr entangled_with;
+    omnetpp::cModule* entangled_with;
     int QNICtypeEntangledWith = -1;
     //cModulePtr qnic_pointer;
     //EntangledWith entangledWith;
@@ -49,6 +36,6 @@ cplusplus{{
     			virtual PhotonicQubit *dup() const {return new PhotonicQubit(*this);}
 
 	};Register_Class(PhotonicQubit);
-	
+
 }}
 

--- a/quisp/makefrag
+++ b/quisp/makefrag
@@ -2,6 +2,7 @@ CXXFLAGS = -std=c++17
 
 OBJS := $(filter-out test_util/% %_test.o,$(OBJS))
 OBJS := $(filter-out %unit_test_main.o,$(OBJS))
+MSGC:=$(MSGC) --msg6
 
 # you can pass the file path you want to check as SRCS environment variable. see the example below.
 # $ SRCS=./quisp/modules/Application.cc make tidy # checks only Application.cc

--- a/quisp/messages/HoM_ipc_messages.msg
+++ b/quisp/messages/HoM_ipc_messages.msg
@@ -1,10 +1,7 @@
-cplusplus {{
-#include "base_messages_m.h"
-}}
+import base_messages;
 
 namespace quisp::messages;
 
-packet Header;
 
 packet HoMNotificationTimer extends Header{}
 

--- a/quisp/messages/QNode_ipc_messages.msg
+++ b/quisp/messages/QNode_ipc_messages.msg
@@ -1,16 +1,6 @@
-cplusplus {{
-#include "base_messages_m.h"
-#include <rules/RuleSet.h>
-}}
-
-cplusplus {{
-    typedef quisp::rules::RuleSet * RuleSetField;
-}}
-class noncobject RuleSetField;
+import base_messages;
 
 namespace quisp::messages;
-
-packet Header;
 
 packet deleteThisModule{}
 
@@ -48,7 +38,7 @@ packet InternalRuleSetForwarding extends Header{
     unsigned long RuleSet_id;
     unsigned long Rule_id;
 
-    RuleSetField RuleSet;
+    RuleSet* ruleSet;
 }
 
 packet InternalRuleSetForwarding_Application extends Header{
@@ -56,5 +46,5 @@ packet InternalRuleSetForwarding_Application extends Header{
     unsigned long Rule_id;
     int application_type;
 
-    RuleSetField RuleSet;
+    RuleSet* ruleSet;
 }

--- a/quisp/messages/base_messages.msg
+++ b/quisp/messages/base_messages.msg
@@ -1,3 +1,26 @@
+cplusplus  {{
+    #include "base_messages_m.h"
+    #include <modules/QNIC.h>
+    #include <rules/RuleSet.h>
+    using quisp::rules::RuleSet;
+    using quisp::modules::QNIC_pair_info;
+}}
+
+class QNIC_type {
+    @existingClass;
+    @opaque;
+};
+
+class QNIC_pair_info {
+    @existingClass;
+    @opaque;
+};
+
+class RuleSet {
+    @existingClass;
+    @opaque;
+};
+
 namespace quisp::messages;
 
 packet Header

--- a/quisp/messages/connection_setup_messages.msg
+++ b/quisp/messages/connection_setup_messages.msg
@@ -1,19 +1,7 @@
-cplusplus {{
-#include "base_messages_m.h"
-#include <modules/QNIC.h>
-#include <rules/RuleSet.h>
-}}
-
-cplusplus {{
-    typedef quisp::rules::RuleSet * RuleSetField;
-}}
-class noncobject RuleSetField;
-
-struct QNIC_pair_info;
-
+import base_messages;
 namespace quisp::messages;
 
-packet Header;
+
 
 packet ConnectionSetupRequest extends Header
 {
@@ -38,7 +26,7 @@ packet ConnectionSetupResponse extends Header
     int actual_srcAddr;
     int actual_destAddr;
     unsigned long RuleSet_id;
-    RuleSetField RuleSet;
+    RuleSet* ruleSet;
     int application_type;
     int stack_of_QNodeIndexes[];
 }

--- a/quisp/messages/entanglement_swapping_messages.msg
+++ b/quisp/messages/entanglement_swapping_messages.msg
@@ -1,15 +1,6 @@
-cplusplus {{
-#include "base_messages_m.h"
-#include <modules/QNIC.h>
-
-using namespace quisp::modules;
-}}
-
-struct QNIC_type;
+import base_messages;
 
 namespace quisp::messages;
-
-packet Header;
 
 packet SwappingResult extends Header{
     unsigned long RuleSet_id;

--- a/quisp/messages/link_generation_messages.msg
+++ b/quisp/messages/link_generation_messages.msg
@@ -1,10 +1,5 @@
-cplusplus {{
-#include "base_messages_m.h"
-}}
-
+import base_messages;
 namespace quisp::messages;
-
-packet Header;
 
 packet BSMtimingNotifier extends Header
 {

--- a/quisp/messages/purification_messages.msg
+++ b/quisp/messages/purification_messages.msg
@@ -1,14 +1,5 @@
-cplusplus {{
-#include "base_messages_m.h"
-
-using namespace omnetpp;
-typedef cModule *GOD_statQubitPtr;
-}} // C++ typedef
-class noncobject GOD_statQubitPtr; // For tracking the truely entangled ones (Only God knows!). The system may think the qubit is entangled but it may not (darkcount)!
-
+import base_messages;
 namespace quisp::messages;
-
-packet Header;
 
 packet PurificationResult extends Header
 {
@@ -16,7 +7,8 @@ packet PurificationResult extends Header
     unsigned long ruleset_id;
     unsigned long rule_id;
     int action_index;
-    GOD_statQubitPtr entangled_with;//For Debugging purposes.
+    //For Debugging
+    omnetpp::cModule* entangled_with;
 }
 
 packet DoublePurificationResult extends Header
@@ -26,7 +18,8 @@ packet DoublePurificationResult extends Header
     unsigned long ruleset_id;
     unsigned long rule_id;
     int action_index;
-    GOD_statQubitPtr entangled_with;//For Debugging purposes.
+     //For Debugging
+    omnetpp::cModule* entangled_with;
 }
 
 packet DS_DoublePurificationResult extends Header
@@ -38,7 +31,8 @@ packet DS_DoublePurificationResult extends Header
     unsigned long ruleset_id;
     unsigned long rule_id;
     int action_index;
-    GOD_statQubitPtr entangled_with;//For Debugging purposes.
+    //For Debugging
+    omnetpp::cModule* entangled_with;
 }
 
 packet DS_DoublePurificationSecondResult extends Header
@@ -49,5 +43,6 @@ packet DS_DoublePurificationSecondResult extends Header
     unsigned long ruleset_id;
     unsigned long rule_id;
     int action_index;
-    GOD_statQubitPtr entangled_with;//For Debugging purposes.
+    //For Debugging
+    omnetpp::cModule* entangled_with;
 }

--- a/quisp/messages/tomography_messages.msg
+++ b/quisp/messages/tomography_messages.msg
@@ -1,25 +1,12 @@
-cplusplus {{
-#include "base_messages_m.h"
-#include <rules/RuleSet.h>
-#include <modules/QNIC.h>
-}}
-
-cplusplus {{
-    typedef quisp::rules::RuleSet * RuleSetField;
-}}
-
-struct QNIC_type;
-class noncobject RuleSetField;
+import base_messages;
 
 namespace quisp::messages;
-
-packet Header;
 
 packet LinkTomographyRuleSet extends Header
 {
     int process_id;
     int number_of_measuring_resources;
-    RuleSetField RuleSet;
+    RuleSet* ruleSet;
 }
 
 packet LinkTomographyRequest extends Header {}

--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
@@ -159,7 +159,7 @@ void BellStateAnalyzer::handleMessage(cMessage *msg) {
     left_photon_origin_qnic_address = photon->getQNICEntangledWith();
     left_photon_origin_qubit_address = photon->getStationaryQubitEntangledWith();
     left_photon_origin_qnic_type = photon->getQNICtypeEntangledWith();
-    left_statQubit_ptr = check_and_cast<StationaryQubit *>(photon->getEntangled_with());
+    left_statQubit_ptr = const_cast<StationaryQubit *>(check_and_cast<const StationaryQubit *>(photon->getEntangled_with()));
     left_photon_Xerr = photon->getPauliXerr();
     left_photon_Zerr = photon->getPauliZerr();
     left_photon_lost = photon->getPhotonLost();
@@ -181,7 +181,7 @@ void BellStateAnalyzer::handleMessage(cMessage *msg) {
     right_photon_origin_qubit_address = photon->getStationaryQubitEntangledWith();
     right_photon_origin_qnic_type = photon->getQNICtypeEntangledWith();
     // right_statQubit_ptr = photon->getEntangled_with();
-    right_statQubit_ptr = check_and_cast<StationaryQubit *>(photon->getEntangled_with());
+    right_statQubit_ptr = const_cast<StationaryQubit *>(check_and_cast<const StationaryQubit *>(photon->getEntangled_with()));
     right_photon_Xerr = photon->getPauliXerr();
     right_photon_Zerr = photon->getPauliZerr();
     right_photon_lost = photon->getPhotonLost();

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <PhotonicQubit_m.h>
-
+#include <Eigen/Eigen>
 namespace quisp {
 
 namespace types {
@@ -122,7 +122,7 @@ struct measurement_outcome {
   char GOD_clean;
 };
 
-class IStationaryQubit : public cSimpleModule {
+class IStationaryQubit : public omnetpp::cSimpleModule {
  public:
   IStationaryQubit(){};
   virtual ~IStationaryQubit(){};
@@ -176,9 +176,9 @@ class IStationaryQubit : public cSimpleModule {
   /** Pointer to the entangled qubit*/
   IStationaryQubit *entangled_partner = nullptr;
   /** Photon emitted at*/
-  simtime_t emitted_time = -1;
+  omnetpp::simtime_t emitted_time = -1;
   /** Stationary qubit last updated at*/
-  simtime_t updated_time = -1;
+  omnetpp::simtime_t updated_time = -1;
 
   /** Stationary Qubit is free or reserved. */
   bool isBusy;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -131,7 +131,7 @@ class StationaryQubit : public IStationaryQubit {
  protected:
   void initialize() override;
   void finish() override;
-  void handleMessage(cMessage *msg) override;
+  void handleMessage(omnetpp::cMessage *msg) override;
   messages::PhotonicQubit *generateEntangledPhoton();
   void setBusy();
   // returns the matrix that represents the errors on the Bell pair. (e.g. XY, XZ and ZI...)

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -162,7 +162,7 @@ void ConnectionManager::storeRuleSet(ConnectionSetupResponse *pk) {
   pk_internal->setSrcAddr(pk->getDestAddr());
   pk_internal->setKind(4);
   pk_internal->setRuleSet_id(pk->getRuleSet_id());
-  pk_internal->setRuleSet(pk->getRuleSet());
+  pk_internal->setRuleSet(const_cast<RuleSet *>(pk->getRuleSet()));
   send(pk_internal, "RouterPort$o");
 }
 
@@ -178,7 +178,7 @@ void ConnectionManager::storeRuleSetForApplication(ConnectionSetupResponse *pk) 
   pk_internal->setSrcAddr(pk->getDestAddr());  // Should be original Src here?
   pk_internal->setKind(4);
   pk_internal->setRuleSet_id(pk->getRuleSet_id());
-  pk_internal->setRuleSet(pk->getRuleSet());
+  pk_internal->setRuleSet(const_cast<RuleSet *>(pk->getRuleSet()));
   pk_internal->setApplication_type(pk->getApplication_type());
   send(pk_internal, "RouterPort$o");
 }

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -174,7 +174,7 @@ void RuleEngine::handleMessage(cMessage *msg) {
     // Received a tomography rule set.
     LinkTomographyRuleSet *pk = check_and_cast<LinkTomographyRuleSet *>(msg);
     // std::cout<<"node["<<parentAddress<<"] !!!!!!!!!!Ruleset reveid!!!!!!!!! ruleset id = "<<pk->getRuleSet()->ruleset_id<<"\n";
-    auto ruleset = pk->getRuleSet();
+    auto *ruleset = const_cast<RuleSet *>(pk->getRuleSet());
     int process_id = rp.size();  // This is temporary because it will not be unique when processes have been deleted.
     std::cout << "Process size is ...." << ruleset->size() << " node[" << parentAddress << "\n";
     // todo:We also need to allocate resources. e.g. if all qubits were entangled already, and got a new ruleset.
@@ -290,7 +290,7 @@ void RuleEngine::handleMessage(cMessage *msg) {
   else if (dynamic_cast<InternalRuleSetForwarding *>(msg) != nullptr) {
     InternalRuleSetForwarding *pkt = check_and_cast<InternalRuleSetForwarding *>(msg);
     // add actual process
-    auto &ruleset = pkt->getRuleSet();
+    auto *ruleset = const_cast<RuleSet *>(pkt->getRuleSet());
     // here swappers got swapping ruleset with internal packet
     // todo:We also need to allocate resources. e.g. if all qubits were entangled already, and got a new ruleset.
     // ResourceAllocation();
@@ -306,7 +306,7 @@ void RuleEngine::handleMessage(cMessage *msg) {
     if (pkt->getApplication_type() == 0) {
       // Received a tomography rule set.
 
-      auto ruleset = pkt->getRuleSet();
+      auto ruleset = const_cast<RuleSet *>(pkt->getRuleSet());
       std::cout << "Process size is ...." << ruleset->size() << " node[" << parentAddress << "\n";
       if (ruleset->size() > 0) {
         rp.insert(ruleset);

--- a/quisp/rules/Rule.h
+++ b/quisp/rules/Rule.h
@@ -54,7 +54,7 @@ class Rule {
     action_partners = _action_partners;
   };
 
-  int num_partners() { return action_partners.size(); };
+  int num_partners() const { return action_partners.size(); };
   void addResource(int address_entangled_with, IStationaryQubit *qubit);
   void setCondition(Condition *c);
   void setAction(Action *a);

--- a/quisp/rules/RuleSet.cc
+++ b/quisp/rules/RuleSet.cc
@@ -26,8 +26,8 @@ RuleSet::RuleSet(long _ruleset_id, int _owner_addr, int partner_addr) {
 
 void RuleSet::addRule(std::unique_ptr<Rule> r) { rules.emplace_back(std::move(r)); };
 std::unique_ptr<Rule>& RuleSet::getRule(int i) { return rules[i]; };
-int RuleSet::size() { return rules.size(); };
-bool RuleSet::empty() { return rules.empty(); }
+int RuleSet::size() const { return rules.size(); };
+bool RuleSet::empty() const { return rules.empty(); }
 std::vector<std::unique_ptr<Rule>>::const_iterator RuleSet::cbegin() { return rules.cbegin(); }
 std::vector<std::unique_ptr<Rule>>::const_iterator RuleSet::cend() { return rules.cend(); }
 

--- a/quisp/rules/RuleSet.h
+++ b/quisp/rules/RuleSet.h
@@ -23,8 +23,8 @@ class RuleSet {
   RuleSet(long _ruleset_id, int _owner_addr, std::vector<int> partner_addrs);
   void addRule(std::unique_ptr<Rule> r);
   std::unique_ptr<Rule>& getRule(int i);
-  int size();
-  bool empty();
+  int size() const;
+  bool empty() const;
   void finalize() {}
   std::vector<std::unique_ptr<Rule>>::const_iterator cbegin();
   std::vector<std::unique_ptr<Rule>>::const_iterator cend();


### PR DESCRIPTION
update `.msg` files notation to version 6 in order to upgrade OMNeT++6 from 5.x.
there's a lot of `const_cast` to remove the `const` qualifier of the packet getter. but we can remove these `const_cast` after the RuleSet segregation.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/321)
<!-- Reviewable:end -->
