### PR TITLE
Use qubit record

### DIFF
--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -132,9 +132,6 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   virtual void Lock(unsigned long rs_id, unsigned long rule_id, int action_id) = 0;
   virtual void Unlock() = 0;
   virtual bool isLocked() = 0;
-  virtual void Allocate() = 0;
-  virtual void Deallocate() = 0;
-  virtual bool isAllocated() = 0;
 
   /**
    * \brief Emit photon.

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -127,7 +127,6 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   IStationaryQubit(){};
   virtual ~IStationaryQubit(){};
 
-  virtual bool checkBusy() = 0;
   virtual void setFree(bool consumed) = 0;
   /*In use. E.g. waiting for purification result.*/
   virtual void Lock(unsigned long rs_id, unsigned long rule_id, int action_id) = 0;
@@ -180,8 +179,6 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   /** Stationary qubit last updated at*/
   omnetpp::simtime_t updated_time = -1;
 
-  /** Stationary Qubit is free or reserved. */
-  bool isBusy;
   /** Standard deviation */
   double std;
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -307,7 +307,6 @@ void StationaryQubit::setFree(bool consumed) {
   locked_rule_id = -1;
   action_index = -1;
 
-  allocated = false;
   is_busy = false;
   emitted_time = -1;
   updated_time = simTime();
@@ -376,18 +375,6 @@ void StationaryQubit::Unlock() {
 }
 
 bool StationaryQubit::isLocked() { return locked; }
-
-void StationaryQubit::Allocate() {
-  allocated = true;
-  if (hasGUI()) {
-    bubble("Allocated!");
-    getDisplayString().setTagArg("i", 1, "purple");
-  }
-}
-
-void StationaryQubit::Deallocate() { allocated = false; }
-
-bool StationaryQubit::isAllocated() { return allocated; }
 
 /**
  * \brief Generate photon entangled with the memory

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -286,7 +286,7 @@ void StationaryQubit::CNOT_gate(IStationaryQubit *control_qubit) {
 
 // This is invoked whenever a photon is emitted out from this particular qubit.
 void StationaryQubit::setBusy() {
-  isBusy = true;
+  is_busy = true;
   emitted_time = simTime();
   updated_time = simTime();  // Should be no error at this time.
   par("photon_emitted_at") = emitted_time.dbl();
@@ -307,8 +307,8 @@ void StationaryQubit::setFree(bool consumed) {
   locked_rule_id = -1;
   action_index = -1;
 
-  isBusy = false;
   allocated = false;
+  is_busy = false;
   emitted_time = -1;
   updated_time = simTime();
 
@@ -344,11 +344,6 @@ void StationaryQubit::setFree(bool consumed) {
       getDisplayString().setTagArg("i", 1, "blue");
     }
   }
-}
-
-bool StationaryQubit::checkBusy() {
-  Enter_Method("checkBusy()");
-  return isBusy;
 }
 
 /*To avoid disturbing this qubit.*/
@@ -425,7 +420,7 @@ PhotonicQubit *StationaryQubit::generateEntangledPhoton() {
  */
 void StationaryQubit::emitPhoton(int pulse) {
   Enter_Method("emitPhoton()");
-  if (checkBusy()) {
+  if (is_busy) {
     error("Requested a photon emission to a busy qubit... this should not happen!");
     return;
   }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -27,7 +27,6 @@ typedef std::complex<double> Complex;
 
 class StationaryQubit : public IStationaryQubit {
  public:
-  bool checkBusy() override;
   void setFree(bool consumed) override;
   /*In use. E.g. waiting for purification result.*/
   void Lock(unsigned long rs_id, unsigned long rule_id, int action_id) override;
@@ -146,6 +145,10 @@ class StationaryQubit : public IStationaryQubit {
 
   void applySingleQubitGateError(SingleGateErrorModel const &err);
   void applyTwoQubitGateError(TwoQubitGateErrorModel const &err, StationaryQubit *another_qubit);
+
+  // this is for debugging. class internal use only.
+  // and it's different from QubitRecord's one.
+  bool is_busy;
 };
 
 }  // namespace modules

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -32,9 +32,6 @@ class StationaryQubit : public IStationaryQubit {
   void Lock(unsigned long rs_id, unsigned long rule_id, int action_id) override;
   void Unlock() override;
   bool isLocked() override;
-  void Allocate() override;
-  void Deallocate() override;
-  bool isAllocated() override;
 
   /**
    * \brief Emit photon.
@@ -123,9 +120,6 @@ class StationaryQubit : public IStationaryQubit {
   bool locked;
   unsigned long locked_ruleset_id;
   unsigned long locked_rule_id;
-
- private:
-  bool allocated;
 
  protected:
   void initialize() override;

--- a/quisp/modules/QRSA/QRSA.h
+++ b/quisp/modules/QRSA/QRSA.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <memory>
+#include "RuleEngine/QubitRecord/IQubitRecord.h"
+#include "modules/QNIC.h"
+
+namespace quisp::modules::qrsa {
+
+using UniqueQubitRecord = std::unique_ptr<quisp::modules::qubit_record::IQubitRecord>;
+// points qnode local qubit
+struct LocalQubitRef {
+  LocalQubitRef(QNIC_type qnic_type, int qnic_index, int qubit_index) : qnic_type(qnic_type), qnic_index(qnic_index), qubit_index(qubit_index) {}
+  const QNIC_type qnic_type;
+  const int qnic_index;
+  const int qubit_index;
+};
+}  // namespace quisp::modules::qrsa

--- a/quisp/modules/QRSA/QRSA.h
+++ b/quisp/modules/QRSA/QRSA.h
@@ -5,7 +5,7 @@
 
 namespace quisp::modules::qrsa {
 
-using UniqueQubitRecord = std::unique_ptr<quisp::modules::qubit_record::IQubitRecord>;
+using IQubitRecord = quisp::modules::qubit_record::IQubitRecord;
 // points qnode local qubit
 struct LocalQubitRef {
   LocalQubitRef(QNIC_type qnic_type, int qnic_index, int qubit_index) : qnic_type(qnic_type), qnic_index(qnic_index), qubit_index(qubit_index) {}

--- a/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
@@ -15,6 +15,7 @@ class IRealTimeController : public cSimpleModule {
  public:
   virtual void EmitPhoton(int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse) = 0;
   virtual void ReInitialize_StationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed) = 0;
+  virtual void ReInitialize_StationaryQubit(qrsa::IQubitRecord* const qubit_record, bool consumed) = 0;
   virtual void applyXGate(qrsa::IQubitRecord* const qubit_record) = 0;
   virtual void applyZGate(qrsa::IQubitRecord* const qubit_record) = 0;
   virtual void assertNoEntanglement(qrsa::IQubitRecord* const qubit_record) = 0;

--- a/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
@@ -15,9 +15,9 @@ class IRealTimeController : public cSimpleModule {
  public:
   virtual void EmitPhoton(int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse) = 0;
   virtual void ReInitialize_StationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed) = 0;
-  virtual void applyXGate(qrsa::UniqueQubitRecord& qubit_record) = 0;
-  virtual void applyZGate(qrsa::UniqueQubitRecord& qubit_record) = 0;
-  virtual void assertNoEntanglement(qrsa::UniqueQubitRecord& qubit_record) = 0;
+  virtual void applyXGate(qrsa::IQubitRecord* const qubit_record) = 0;
+  virtual void applyZGate(qrsa::IQubitRecord* const qubit_record) = 0;
+  virtual void assertNoEntanglement(qrsa::IQubitRecord* const qubit_record) = 0;
 };
 }  // namespace modules
 }  // namespace quisp

--- a/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
@@ -2,7 +2,8 @@
 #define QUISP_MODULES_IREALTIMECONTROLLER_H_
 
 #include <modules/QNIC.h>
-
+#include <modules/QRSA/QRSA.h>
+#include <modules/QRSA/RuleEngine/QubitRecord/IQubitRecord.h>
 namespace quisp {
 namespace modules {
 
@@ -14,6 +15,9 @@ class IRealTimeController : public cSimpleModule {
  public:
   virtual void EmitPhoton(int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse) = 0;
   virtual void ReInitialize_StationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed) = 0;
+  virtual void applyXGate(qrsa::UniqueQubitRecord& qubit_record) = 0;
+  virtual void applyZGate(qrsa::UniqueQubitRecord& qubit_record) = 0;
+  virtual void assertNoEntanglement(qrsa::UniqueQubitRecord& qubit_record) = 0;
 };
 }  // namespace modules
 }  // namespace quisp

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
@@ -30,9 +30,19 @@ void RealTimeController::ReInitialize_StationaryQubit(int qnic_index, int qubit_
   auto *q = provider.getStationaryQubit(qnic_index, qubit_index, qnic_type);
   q->setFree(consumed);
 }
+void RealTimeController::ReInitialize_StationaryQubit(qrsa::IQubitRecord *const qubit_record, bool consumed) {
+  auto *qubit = provider.getStationaryQubit(qubit_record);
+  qubit->setFree(consumed);
+}
 
-void RealTimeController::applyXGate(qrsa::IQubitRecord *const qubit_record) {}
-void RealTimeController::applyZGate(qrsa::IQubitRecord *const qubit_record) {}
+void RealTimeController::applyXGate(qrsa::IQubitRecord *const qubit_record) {
+  auto *qubit = provider.getStationaryQubit(qubit_record);
+  qubit->X_gate();
+}
+void RealTimeController::applyZGate(qrsa::IQubitRecord *const qubit_record) {
+  auto *qubit = provider.getStationaryQubit(qubit_record);
+  qubit->Z_gate();
+}
 void RealTimeController::assertNoEntanglement(qrsa::IQubitRecord *const qubit_record) {
   auto *qubit = provider.getStationaryQubit(qubit_record);
   if (qubit->entangled_partner == nullptr && qubit->Density_Matrix_Collapsed(0, 0).real() == -111 && !qubit->no_density_matrix_nullptr_entangled_partner_ok) {

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
@@ -31,9 +31,9 @@ void RealTimeController::ReInitialize_StationaryQubit(int qnic_index, int qubit_
   q->setFree(consumed);
 }
 
-void RealTimeController::applyXGate(qrsa::UniqueQubitRecord &qubit_record) {}
-void RealTimeController::applyZGate(qrsa::UniqueQubitRecord &qubit_record) {}
-void RealTimeController::assertNoEntanglement(qrsa::UniqueQubitRecord &qubit_record) {
+void RealTimeController::applyXGate(qrsa::IQubitRecord *const qubit_record) {}
+void RealTimeController::applyZGate(qrsa::IQubitRecord *const qubit_record) {}
+void RealTimeController::assertNoEntanglement(qrsa::IQubitRecord *const qubit_record) {
   auto *qubit = provider.getStationaryQubit(qubit_record);
   if (qubit->entangled_partner == nullptr && qubit->Density_Matrix_Collapsed(0, 0).real() == -111 && !qubit->no_density_matrix_nullptr_entangled_partner_ok) {
     error("something went wrong");

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
@@ -30,5 +30,22 @@ void RealTimeController::ReInitialize_StationaryQubit(int qnic_index, int qubit_
   auto *q = provider.getStationaryQubit(qnic_index, qubit_index, qnic_type);
   q->setFree(consumed);
 }
+
+void RealTimeController::applyXGate(qrsa::UniqueQubitRecord &qubit_record) {}
+void RealTimeController::applyZGate(qrsa::UniqueQubitRecord &qubit_record) {}
+void RealTimeController::assertNoEntanglement(qrsa::UniqueQubitRecord &qubit_record) {
+  auto *qubit = provider.getStationaryQubit(qubit_record);
+  if (qubit->entangled_partner == nullptr && qubit->Density_Matrix_Collapsed(0, 0).real() == -111 && !qubit->no_density_matrix_nullptr_entangled_partner_ok) {
+    error("something went wrong");
+  }
+  if (qubit->entangled_partner != nullptr) {
+    if (qubit->entangled_partner->entangled_partner == nullptr) {
+      error("1. Entanglement tracking is not doing its job. in update resource E.S.");
+    }
+    if (qubit->entangled_partner->entangled_partner != qubit) {
+      error("2. Entanglement tracking is not doing its job. in update resource E.S.");
+    }
+  }
+}
 }  // namespace modules
 }  // namespace quisp

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.h
@@ -29,6 +29,8 @@ class RealTimeController : public IRealTimeController {
   RealTimeController();
   void EmitPhoton(int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse) override;
   void ReInitialize_StationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed) override;
+  void ReInitialize_StationaryQubit(qrsa::IQubitRecord* const qubit_record, bool consumed) override;
+
   void applyXGate(qrsa::IQubitRecord* const qubit_record) override;
   void applyZGate(qrsa::IQubitRecord* const qubit_record) override;
   void assertNoEntanglement(qrsa::IQubitRecord* const qubit_record) override;

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.h
@@ -29,9 +29,9 @@ class RealTimeController : public IRealTimeController {
   RealTimeController();
   void EmitPhoton(int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse) override;
   void ReInitialize_StationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed) override;
-  void applyXGate(qrsa::UniqueQubitRecord& qubit_record) override;
-  void applyZGate(qrsa::UniqueQubitRecord& qubit_record) override;
-  void assertNoEntanglement(qrsa::UniqueQubitRecord& qubit_record) override;
+  void applyXGate(qrsa::IQubitRecord* const qubit_record) override;
+  void applyZGate(qrsa::IQubitRecord* const qubit_record) override;
+  void assertNoEntanglement(qrsa::IQubitRecord* const qubit_record) override;
   utils::ComponentProvider provider;
 };
 

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.h
@@ -29,6 +29,9 @@ class RealTimeController : public IRealTimeController {
   RealTimeController();
   void EmitPhoton(int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse) override;
   void ReInitialize_StationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed) override;
+  void applyXGate(qrsa::UniqueQubitRecord& qubit_record) override;
+  void applyZGate(qrsa::UniqueQubitRecord& qubit_record) override;
+  void assertNoEntanglement(qrsa::UniqueQubitRecord& qubit_record) override;
   utils::ComponentProvider provider;
 };
 

--- a/quisp/modules/QRSA/RuleEngine/BellPairStore/BellPairStore.h
+++ b/quisp/modules/QRSA/RuleEngine/BellPairStore/BellPairStore.h
@@ -2,12 +2,13 @@
 
 #include <modules/QNIC.h>
 #include <modules/QNIC/StationaryQubit/IStationaryQubit.h>
+#include <modules/QRSA/QRSA.h>
 namespace quisp::modules {
 
 using QNodeAddr = int;
 using QNicIndex = int;
 // entangled partner qnode address -> qubit
-using PartnerAddrQubitMap = std::multimap<QNodeAddr, IStationaryQubit*>;
+using PartnerAddrQubitMap = std::multimap<QNodeAddr, qrsa::IQubitRecord*>;
 using ResourceKey = std::pair<QNIC_type, QNicIndex>;
 using PartnerAddrQubitMapRange = std::pair<PartnerAddrQubitMap::iterator, PartnerAddrQubitMap::iterator>;
 
@@ -21,9 +22,9 @@ class BellPairStore {
  public:
   BellPairStore();
   ~BellPairStore();
-  void eraseQubit(IStationaryQubit* const qubit);
-  void insertEntangledQubit(QNodeAddr partner_addr, IStationaryQubit* const qubit);
-  IStationaryQubit* findQubit(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr addr);
+  void eraseQubit(qrsa::IQubitRecord* const qubit);
+  void insertEntangledQubit(QNodeAddr partner_addr, qrsa::IQubitRecord* qubit);
+  qrsa::IQubitRecord* findQubit(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr addr);
   PartnerAddrQubitMapRange getBellPairsRange(QNIC_type qnic_type, QNicIndex qnic_index, QNodeAddr partner_addr);
 
  protected:

--- a/quisp/modules/QRSA/RuleEngine/BellPairStore/BellPairStore_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/BellPairStore/BellPairStore_test.cc
@@ -1,11 +1,15 @@
 #include "BellPairStore.h"
 #include <gtest/gtest.h>
-#include <modules/QNIC/StationaryQubit/StationaryQubit.h>
+
+#include <modules/QRSA/RuleEngine/QubitRecord/IQubitRecord.h>
+#include <modules/QRSA/RuleEngine/QubitRecord/QubitRecord.h>
 #include <utility>
 #include "test_utils/TestUtils.h"
 
 namespace {
 using namespace quisp::modules;
+using quisp::modules::qubit_record::IQubitRecord;
+using quisp::modules::qubit_record::QubitRecord;
 using namespace quisp_test;
 class MockQubit : public StationaryQubit {
  public:
@@ -28,7 +32,7 @@ TEST(BellPairStoreTest, init) {
 
 TEST(BellPairStoreTest, insert) {
   prepareSimulation();
-  auto *qubit1 = new MockQubit(QNIC_E, 3, 6);
+  auto *qubit1 = new QubitRecord(QNIC_E, 3, 6);
   BellPairStore store;
   store.insertEntangledQubit(7, qubit1);
   auto key = std::make_pair(QNIC_E, 3);
@@ -40,12 +44,12 @@ TEST(BellPairStoreTest, insert) {
   ASSERT_NE(store._resources.find(key), store._resources.end()) << "bell pair not found";
   auto it = store._resources[key].find(7);
   ASSERT_FALSE(it == store._resources[key].end());
-  EXPECT_EQ(it->second, dynamic_cast<StationaryQubit *>(qubit1));
+  EXPECT_EQ(it->second, dynamic_cast<IQubitRecord *>(qubit1));
 }
 
 TEST(BellPairStoreTest, erase) {
   prepareSimulation();
-  auto *qubit1 = new MockQubit(QNIC_E, 3, 6);
+  auto *qubit1 = new QubitRecord(QNIC_E, 3, 6);
   BellPairStore store;
   store.insertEntangledQubit(7, qubit1);
   auto key = std::make_pair(QNIC_E, 3);
@@ -53,8 +57,8 @@ TEST(BellPairStoreTest, erase) {
   auto it = store._resources[key].find(7);
   ASSERT_TRUE(it == store._resources[key].end());
 
-  auto *qubit2 = new MockQubit(QNIC_E, 3, 6);
-  auto *qubit3 = new MockQubit(QNIC_E, 3, 6);
+  auto *qubit2 = new QubitRecord(QNIC_E, 3, 6);
+  auto *qubit3 = new QubitRecord(QNIC_E, 3, 6);
   store.insertEntangledQubit(7, qubit1);
   store.insertEntangledQubit(7, qubit2);
   store.insertEntangledQubit(7, qubit1);
@@ -66,9 +70,9 @@ TEST(BellPairStoreTest, erase) {
 
 TEST(BellPairStoreTest, find) {
   prepareSimulation();
-  auto *qubit1 = new MockQubit(QNIC_E, 3, 6);
-  auto *qubit2 = new MockQubit(QNIC_E, 3, 6);
-  auto *qubit3 = new MockQubit(QNIC_E, 3, 6);
+  auto *qubit1 = new QubitRecord(QNIC_E, 3, 6);
+  auto *qubit2 = new QubitRecord(QNIC_E, 3, 6);
+  auto *qubit3 = new QubitRecord(QNIC_E, 3, 6);
   BellPairStore store;
   store.insertEntangledQubit(7, qubit1);
   store.insertEntangledQubit(8, qubit2);
@@ -86,9 +90,9 @@ TEST(BellPairStoreTest, find) {
 
 TEST(BellPairStoreTest, getRange) {
   prepareSimulation();
-  auto *qubit1 = new MockQubit(QNIC_E, 3, 6);
-  auto *qubit2 = new MockQubit(QNIC_E, 3, 6);
-  auto *qubit3 = new MockQubit(QNIC_E, 3, 6);
+  auto *qubit1 = new QubitRecord(QNIC_E, 3, 6);
+  auto *qubit2 = new QubitRecord(QNIC_E, 3, 6);
+  auto *qubit3 = new QubitRecord(QNIC_E, 3, 6);
   BellPairStore store;
   store.insertEntangledQubit(7, qubit1);
   store.insertEntangledQubit(6, qubit2);
@@ -117,7 +121,7 @@ TEST(BellPairStoreTest, getRangeWithLoop) {
   EXPECT_EQ(count, 0);
 
   // 1 qubit
-  auto *qubit1 = new MockQubit(QNIC_E, 3, 6);
+  auto *qubit1 = new QubitRecord(QNIC_E, 3, 6);
   store.insertEntangledQubit(7, qubit1);
   range = store.getBellPairsRange(QNIC_E, 3, 7);
   count = 0;
@@ -127,9 +131,9 @@ TEST(BellPairStoreTest, getRangeWithLoop) {
   EXPECT_EQ(count, 1);
 
   // 4 qubits and same partner addr.
-  auto *qubit2 = new MockQubit(QNIC_E, 3, 6);
-  auto *qubit3 = new MockQubit(QNIC_E, 3, 6);
-  auto *qubit4 = new MockQubit(QNIC_E, 3, 6);
+  auto *qubit2 = new QubitRecord(QNIC_E, 3, 6);
+  auto *qubit3 = new QubitRecord(QNIC_E, 3, 6);
+  auto *qubit4 = new QubitRecord(QNIC_E, 3, 6);
   store.insertEntangledQubit(7, qubit2);
   store.insertEntangledQubit(7, qubit3);
   store.insertEntangledQubit(7, qubit4);

--- a/quisp/modules/QRSA/RuleEngine/QNicRecord/IQNicRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicRecord/IQNicRecord.h
@@ -17,7 +17,7 @@ class IQNicRecord {
   virtual int countNumFreeQubits() = 0;
   virtual int takeFreeQubitIndex() = 0;
   virtual void setQubitBusy(int qubit_index, bool is_busy) = 0;
-  virtual qrsa::UniqueQubitRecord& getQubit(int qubit_index) = 0;
+  virtual qrsa::IQubitRecord* getQubit(int qubit_index) = 0;
 };
 
 }  // namespace quisp::modules::qnic_record

--- a/quisp/modules/QRSA/RuleEngine/QNicRecord/IQNicRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicRecord/IQNicRecord.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "utils/ComponentProvider.h"
+#include <modules/QRSA/QRSA.h>
+#include <utils/ComponentProvider.h>
 
 namespace quisp::modules::qnic_record {
 
@@ -16,6 +17,7 @@ class IQNicRecord {
   virtual int countNumFreeQubits() = 0;
   virtual int takeFreeQubitIndex() = 0;
   virtual void setQubitBusy(int qubit_index, bool is_busy) = 0;
+  virtual qrsa::UniqueQubitRecord& getQubit(int qubit_index) = 0;
 };
 
 }  // namespace quisp::modules::qnic_record

--- a/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.cc
+++ b/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.cc
@@ -26,17 +26,21 @@ int QNicRecord::takeFreeQubitIndex() {
   for (auto& qubit : qubits) {
     if (!qubit->isBusy()) {
       qubit->setBusy(true);
-      return qubit->getIndex();
+      return qubit->getQubitIndex();
     }
   }
   return -1;
 }
-
-void QNicRecord::setQubitBusy(int qubit_index, bool is_busy) {
+qrsa::UniqueQubitRecord& QNicRecord::getQubit(int qubit_index) {
   if (qubits.size() <= qubit_index) {
     throw omnetpp::cRuntimeError("QNicRecord::setQubitBusy: Qubit index:%d out of range. QNIC{%s, %d}, qubits.size(): %d", qubit_index, QNIC_names[type], index, qubits.size());
   }
-  qubits.at(qubit_index)->setBusy(is_busy);
+  return qubits.at(qubit_index);
+}
+
+void QNicRecord::setQubitBusy(int qubit_index, bool is_busy) {
+  auto& qubit = getQubit(qubit_index);
+  qubit->setBusy(is_busy);
 }
 
 }  // namespace quisp::modules::qnic_record

--- a/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.cc
+++ b/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.cc
@@ -31,15 +31,15 @@ int QNicRecord::takeFreeQubitIndex() {
   }
   return -1;
 }
-qrsa::UniqueQubitRecord& QNicRecord::getQubit(int qubit_index) {
+qrsa::IQubitRecord* QNicRecord::getQubit(int qubit_index) {
   if (qubits.size() <= qubit_index) {
     throw omnetpp::cRuntimeError("QNicRecord::setQubitBusy: Qubit index:%d out of range. QNIC{%s, %d}, qubits.size(): %d", qubit_index, QNIC_names[type], index, qubits.size());
   }
-  return qubits.at(qubit_index);
+  return qubits.at(qubit_index).get();
 }
 
 void QNicRecord::setQubitBusy(int qubit_index, bool is_busy) {
-  auto& qubit = getQubit(qubit_index);
+  auto* qubit = getQubit(qubit_index);
   qubit->setBusy(is_busy);
 }
 

--- a/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.cc
+++ b/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.cc
@@ -8,7 +8,7 @@ using quisp::modules::qubit_record::QubitRecord;
 QNicRecord::QNicRecord(utils::ComponentProvider& provider, int index, QNIC_type type) : index(index), type(type) {
   int num_qubits = provider.getNumQubits(index, type);
   for (int i = 0; i < num_qubits; i++) {
-    qubits.emplace_back(std::make_unique<QubitRecord>(index, type, i));
+    qubits.emplace_back(std::make_unique<QubitRecord>(type, index, i));
   }
 }
 

--- a/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.h
@@ -17,6 +17,7 @@ class QNicRecord : public IQNicRecord {
   int countNumFreeQubits() override;
   int takeFreeQubitIndex() override;
   void setQubitBusy(int qubit_index, bool is_busy) override;
+  qrsa::UniqueQubitRecord& getQubit(int qubit_index) override;
 
   const int index;
   const QNIC_type type;

--- a/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicRecord/QNicRecord.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "../QubitRecord/IQubitRecord.h"
 #include "IQNicRecord.h"
 #include "modules/QNIC.h"
@@ -17,12 +18,14 @@ class QNicRecord : public IQNicRecord {
   int countNumFreeQubits() override;
   int takeFreeQubitIndex() override;
   void setQubitBusy(int qubit_index, bool is_busy) override;
-  qrsa::UniqueQubitRecord& getQubit(int qubit_index) override;
+  qrsa::IQubitRecord* getQubit(int qubit_index) override;
 
   const int index;
   const QNIC_type type;
 
  protected:
+  // QNicRecord class has the ownership of the QubitRecords.
+  // if QNicRecord is destroyed, all QubitRecords will be destroyed automatically.
   std::vector<std::unique_ptr<IQubitRecord>> qubits;
 };
 

--- a/quisp/modules/QRSA/RuleEngine/QNicStore/IQNicStore.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicStore/IQNicStore.h
@@ -17,7 +17,7 @@ class IQNicStore {
   virtual int countNumFreeQubits(QNIC_type type, int qnic_index) = 0;
   virtual int takeFreeQubitIndex(QNIC_type type, int qnic_index) = 0;
   virtual void setQubitBusy(QNIC_type type, int qnic_index, int qubit_index, bool is_busy) = 0;
-  virtual qrsa::UniqueQubitRecord& getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) = 0;
+  virtual qrsa::IQubitRecord* getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) = 0;
 };
 
 }  // namespace quisp::modules::qnic_store

--- a/quisp/modules/QRSA/RuleEngine/QNicStore/IQNicStore.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicStore/IQNicStore.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "modules/QNIC.h"
+#include "modules/QRSA/QRSA.h"
 
 namespace quisp::modules::qnic_store {
 
@@ -16,6 +17,7 @@ class IQNicStore {
   virtual int countNumFreeQubits(QNIC_type type, int qnic_index) = 0;
   virtual int takeFreeQubitIndex(QNIC_type type, int qnic_index) = 0;
   virtual void setQubitBusy(QNIC_type type, int qnic_index, int qubit_index, bool is_busy) = 0;
+  virtual qrsa::UniqueQubitRecord& getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) = 0;
 };
 
 }  // namespace quisp::modules::qnic_store

--- a/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.cc
+++ b/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.cc
@@ -38,6 +38,10 @@ void QNicStore::setQubitBusy(QNIC_type type, int qnic_index, int qubit_index, bo
   auto& qnic = getQNic(type, qnic_index);
   return qnic->setQubitBusy(qubit_index, is_busy);
 }
+qrsa::UniqueQubitRecord& QNicStore::getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) {
+  auto& qnic = getQNic(type, qnic_index);
+  return qnic->getQubit(qubit_index);
+}
 
 UniqueQNicRecord& QNicStore::getQNic(QNIC_type type, int qnic_index) {
   if (qnics.size() <= type) {

--- a/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.cc
+++ b/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.cc
@@ -38,7 +38,7 @@ void QNicStore::setQubitBusy(QNIC_type type, int qnic_index, int qubit_index, bo
   auto& qnic = getQNic(type, qnic_index);
   return qnic->setQubitBusy(qubit_index, is_busy);
 }
-qrsa::UniqueQubitRecord& QNicStore::getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) {
+qrsa::IQubitRecord* QNicStore::getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) {
   auto& qnic = getQNic(type, qnic_index);
   return qnic->getQubit(qubit_index);
 }

--- a/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.h
@@ -21,7 +21,7 @@ class QNicStore : public IQNicStore {
   int countNumFreeQubits(QNIC_type type, int qnic_index) override;
   int takeFreeQubitIndex(QNIC_type type, int qnic_index) override;
   void setQubitBusy(QNIC_type type, int qnic_index, int qubit_index, bool is_busy) override;
-  qrsa::UniqueQubitRecord& getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) override;
+  qrsa::IQubitRecord* getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) override;
 
  protected:
   UniqueQNicRecord& getQNic(QNIC_type type, int qnic_index);

--- a/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.h
+++ b/quisp/modules/QRSA/RuleEngine/QNicStore/QNicStore.h
@@ -21,6 +21,7 @@ class QNicStore : public IQNicStore {
   int countNumFreeQubits(QNIC_type type, int qnic_index) override;
   int takeFreeQubitIndex(QNIC_type type, int qnic_index) override;
   void setQubitBusy(QNIC_type type, int qnic_index, int qubit_index, bool is_busy) override;
+  qrsa::UniqueQubitRecord& getQubitRecord(QNIC_type type, int qnic_index, int qubit_index) override;
 
  protected:
   UniqueQNicRecord& getQNic(QNIC_type type, int qnic_index);

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/IQubitRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/IQubitRecord.h
@@ -1,5 +1,6 @@
 #pragma once
-
+#include <modules/QNIC.h>
+#include <memory>
 namespace quisp::modules::qubit_record {
 
 /**
@@ -16,7 +17,9 @@ class IQubitRecord {
   virtual ~IQubitRecord() {}
   virtual bool isBusy() const = 0;
   virtual void setBusy(bool _is_busy) = 0;
-  virtual int getIndex() const = 0;
+  virtual int getQubitIndex() const = 0;
+  virtual int getQNicIndex() const = 0;
+  virtual QNIC_type getQNicType() const = 0;
 };
 
 }  // namespace quisp::modules::qubit_record

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/IQubitRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/IQubitRecord.h
@@ -17,9 +17,15 @@ class IQubitRecord {
   virtual ~IQubitRecord() {}
   virtual bool isBusy() const = 0;
   virtual void setBusy(bool _is_busy) = 0;
+  virtual bool isAllocated() const = 0;
+  virtual void setAllocated(bool _is_allocated) = 0;
   virtual int getQubitIndex() const = 0;
   virtual int getQNicIndex() const = 0;
   virtual QNIC_type getQNicType() const = 0;
+
+  virtual bool isRuleApplied(unsigned long rule_id) const = 0;
+  virtual void markRuleApplied(unsigned long rule_id) = 0;
+  virtual void clearAppliedRules() = 0;
 };
 
 }  // namespace quisp::modules::qubit_record

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.cc
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.cc
@@ -16,8 +16,34 @@ void QubitRecord::setBusy(bool _is_busy) {
   is_busy = _is_busy;
 }
 
+bool QubitRecord::isAllocated() const { return is_allocated; }
+
+void QubitRecord::setAllocated(bool _is_allocated) {
+  if (is_allocated == _is_allocated) {
+    throw omnetpp::cRuntimeError("QubitRecord::setAllocated: is_allocated is already set to the same value. Qubit(%s, %d, %d)", QNIC_names[qnic_type], qnic_index, qubit_index);
+  }
+  is_allocated = _is_allocated;
+}
+
 int QubitRecord::getQubitIndex() const { return qubit_index; }
-int QubitRecord::getQNicIndex() const { return qnic_type; }
+int QubitRecord::getQNicIndex() const { return qnic_index; }
 QNIC_type QubitRecord::getQNicType() const { return qnic_type; }
 
+bool QubitRecord::isRuleApplied(unsigned long rule_id) const {
+  for (auto& id : applied_rule_ids) {
+    if (id == rule_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void QubitRecord::markRuleApplied(unsigned long rule_id) {
+  if (std::find(applied_rule_ids.cbegin(), applied_rule_ids.cend(), rule_id) != applied_rule_ids.cend()) {
+    throw omnetpp::cRuntimeError("QubitRecord::markRuleApplied: rule_id:%lu is already applied. Qubit(%s, %d, %d)", rule_id, QNIC_names[qnic_type], qnic_index, qubit_index);
+  }
+  applied_rule_ids.push_back(rule_id);
+}
+
+void QubitRecord::clearAppliedRules() { applied_rule_ids.clear(); }
 }  // namespace quisp::modules::qubit_record

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.cc
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.cc
@@ -16,6 +16,8 @@ void QubitRecord::setBusy(bool _is_busy) {
   is_busy = _is_busy;
 }
 
-int QubitRecord::getIndex() const { return qubit_index; }
+int QubitRecord::getQubitIndex() const { return qubit_index; }
+int QubitRecord::getQNicIndex() const { return qnic_type; }
+QNIC_type QubitRecord::getQNicType() const { return qnic_type; }
 
 }  // namespace quisp::modules::qubit_record

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.cc
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.cc
@@ -3,7 +3,7 @@
 
 namespace quisp::modules::qubit_record {
 
-QubitRecord::QubitRecord(int qnic_index, QNIC_type qnic_type, int qubit_index) : qnic_type(qnic_type), qnic_index(qnic_index), qubit_index(qubit_index) {}
+QubitRecord::QubitRecord(QNIC_type qnic_type, int qnic_index, int qubit_index) : qnic_type(qnic_type), qnic_index(qnic_index), qubit_index(qubit_index) {}
 
 QubitRecord::~QubitRecord() {}
 

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.h
@@ -8,7 +8,7 @@ namespace quisp::modules::qubit_record {
 
 class QubitRecord : public IQubitRecord {
  public:
-  QubitRecord(int qnic_index, QNIC_type qnic_type, int qubit_index);
+  QubitRecord(QNIC_type qnic_type, int qnic_index, int qubit_index);
   ~QubitRecord();
   bool isBusy() const override;
   void setBusy(bool _is_busy) override;

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.h
@@ -12,15 +12,22 @@ class QubitRecord : public IQubitRecord {
   ~QubitRecord();
   bool isBusy() const override;
   void setBusy(bool _is_busy) override;
+  bool isAllocated() const override;
+  void setAllocated(bool _is_allocated) override;
   int getQubitIndex() const override;
   int getQNicIndex() const override;
   QNIC_type getQNicType() const override;
+  bool isRuleApplied(unsigned long rule_id) const override;
+  void markRuleApplied(unsigned long rule_id) override;
+  void clearAppliedRules() override;
 
  protected:
   QNIC_type qnic_type;
   int qnic_index;
   int qubit_index;
   bool is_busy = false;
+  bool is_allocated = false;
+  std::vector<unsigned long> applied_rule_ids;
 };
 
 }  // namespace quisp::modules::qubit_record

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.h
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord.h
@@ -12,7 +12,9 @@ class QubitRecord : public IQubitRecord {
   ~QubitRecord();
   bool isBusy() const override;
   void setBusy(bool _is_busy) override;
-  int getIndex() const override;
+  int getQubitIndex() const override;
+  int getQNicIndex() const override;
+  QNIC_type getQNicType() const override;
 
  protected:
   QNIC_type qnic_type;

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord_test.cc
@@ -23,7 +23,7 @@ TEST(QubitRecord, Init) {
   auto qnic_type = QNIC_R;
   int qubit_index = 5;
   QubitRecord record(qnic_index, qnic_type, qubit_index);
-  EXPECT_EQ(qubit_index, record.getIndex());
+  EXPECT_EQ(qubit_index, record.getQubitIndex());
   EXPECT_EQ(qubit_index, record.qubit_index);
   EXPECT_EQ(qnic_index, record.qnic_index);
   EXPECT_EQ(qnic_type, record.qnic_type);

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord_test.cc
@@ -17,16 +17,16 @@ class QubitRecord : public quisp::modules::qubit_record::QubitRecord {
   using quisp::modules::qubit_record::QubitRecord::qnic_index;
   using quisp::modules::qubit_record::QubitRecord::qnic_type;
   using quisp::modules::qubit_record::QubitRecord::qubit_index;
-  QubitRecord(int qnic_index, QNIC_type qnic_type, int qubit_index) : quisp::modules::qubit_record::QubitRecord(qnic_index, qnic_type, qubit_index) {}
+  QubitRecord(QNIC_type qnic_type, int qnic_index, int qubit_index) : quisp::modules::qubit_record::QubitRecord(qnic_type, qnic_index, qubit_index) {}
 };
 
 class QubitRecordTest : public ::testing::Test {
  protected:
-  void SetUp() override { record = QubitRecord(qnic_index, qnic_type, qubit_index); }
+  void SetUp() override { record = QubitRecord(qnic_type, qnic_index, qubit_index); }
   int qnic_index = 3;
   QNIC_type qnic_type = QNIC_R;
   int qubit_index = 5;
-  QubitRecord record = QubitRecord(0, QNIC_E, 0);
+  QubitRecord record = QubitRecord(QNIC_E, 0, 0);
 };
 
 TEST_F(QubitRecordTest, Init) {

--- a/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/QubitRecord/QubitRecord_test.cc
@@ -11,6 +11,8 @@ using quisp::utils::ComponentProvider;
 
 class QubitRecord : public quisp::modules::qubit_record::QubitRecord {
  public:
+  using quisp::modules::qubit_record::QubitRecord::applied_rule_ids;
+  using quisp::modules::qubit_record::QubitRecord::is_allocated;
   using quisp::modules::qubit_record::QubitRecord::is_busy;
   using quisp::modules::qubit_record::QubitRecord::qnic_index;
   using quisp::modules::qubit_record::QubitRecord::qnic_type;
@@ -18,26 +20,58 @@ class QubitRecord : public quisp::modules::qubit_record::QubitRecord {
   QubitRecord(int qnic_index, QNIC_type qnic_type, int qubit_index) : quisp::modules::qubit_record::QubitRecord(qnic_index, qnic_type, qubit_index) {}
 };
 
-TEST(QubitRecord, Init) {
+class QubitRecordTest : public ::testing::Test {
+ protected:
+  void SetUp() override { record = QubitRecord(qnic_index, qnic_type, qubit_index); }
   int qnic_index = 3;
-  auto qnic_type = QNIC_R;
+  QNIC_type qnic_type = QNIC_R;
   int qubit_index = 5;
-  QubitRecord record(qnic_index, qnic_type, qubit_index);
-  EXPECT_EQ(qubit_index, record.getQubitIndex());
+  QubitRecord record = QubitRecord(0, QNIC_E, 0);
+};
+
+TEST_F(QubitRecordTest, Init) {
   EXPECT_EQ(qubit_index, record.qubit_index);
   EXPECT_EQ(qnic_index, record.qnic_index);
   EXPECT_EQ(qnic_type, record.qnic_type);
 }
 
-TEST(QubitRecord, SetBusy) {
-  int qnic_index = 3;
-  auto qnic_type = QNIC_R;
-  int qubit_index = 5;
-  QubitRecord record(qnic_index, qnic_type, qubit_index);
+TEST_F(QubitRecordTest, Getters) {
+  EXPECT_EQ(qubit_index, record.getQubitIndex());
+  EXPECT_EQ(qnic_index, record.getQNicIndex());
+  EXPECT_EQ(qnic_type, record.getQNicType());
+}
+
+TEST_F(QubitRecordTest, SetBusy) {
   EXPECT_FALSE(record.is_busy);
+  EXPECT_FALSE(record.isBusy());
   record.setBusy(true);
   EXPECT_TRUE(record.is_busy);
+  EXPECT_TRUE(record.isBusy());
   EXPECT_THROW(record.setBusy(true), omnetpp::cRuntimeError);
 }
 
+TEST_F(QubitRecordTest, SetAllocated) {
+  EXPECT_FALSE(record.is_allocated);
+  EXPECT_FALSE(record.isAllocated());
+  record.setAllocated(true);
+  EXPECT_TRUE(record.is_allocated);
+  EXPECT_TRUE(record.isAllocated());
+  EXPECT_THROW(record.setAllocated(true), omnetpp::cRuntimeError);
+}
+
+TEST_F(QubitRecordTest, AppliedRules) {
+  EXPECT_EQ(0, record.applied_rule_ids.size());
+  EXPECT_FALSE(record.isRuleApplied(1));
+  record.markRuleApplied(11);
+  EXPECT_EQ(1, record.applied_rule_ids.size());
+  EXPECT_FALSE(record.isRuleApplied(1));
+  EXPECT_TRUE(record.isRuleApplied(11));
+  record.markRuleApplied(12);
+  record.markRuleApplied(13);
+  record.markRuleApplied(14);
+  record.markRuleApplied(15);
+  EXPECT_EQ(5, record.applied_rule_ids.size());
+  record.clearAppliedRules();
+  EXPECT_EQ(0, record.applied_rule_ids.size());
+}
 }  // namespace

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -834,7 +834,7 @@ void RuleEngine::updateResources_EntanglementSwapping(swapping_result swapr) {
   int qubit_index = swapr.measured_qubit_index;
 
   // qubit with address Addr was shot in nth time. This list is ordered from old to new.
-  auto &qubit_record = qnic_store->getQubitRecord(qnic_type, qnic_index, qubit_index);
+  auto *qubit_record = qnic_store->getQubitRecord(qnic_type, qnic_index, qubit_index);
   // check
   if (operation_type == 0) {
     // do nothing
@@ -899,7 +899,7 @@ void RuleEngine::updateResources_SimultaneousEntanglementSwapping(swapping_resul
   int qnic_index = info->qnic.index;
   QNIC_type qnic_type = info->qnic.type;
   int qubit_index = swapr.measured_qubit_index;
-  auto &qubit_record = qnic_store->getQubitRecord(qnic_type, qnic_index, qubit_index);
+  auto *qubit_record = qnic_store->getQubitRecord(qnic_type, qnic_index, qubit_index);
 
   if (operation_type == 0) {
     // nothing

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -187,9 +187,8 @@ TEST(RuleEngineTest, resourceAllocation) {
   rs->addRule(std::move(rule));
   rule_engine->rp.insert(rs);
 
-  EXPECT_CALL(*mockQubit1, Allocate()).WillRepeatedly(Return());
-  EXPECT_CALL(*mockQubit1, isAllocated()).WillRepeatedly(Return(false));
   rule_engine->ResourceAllocation(QNIC_E, 3);
+  EXPECT_TRUE(qubit_record1->isAllocated());
 
   // resource allocation assigns a corresponding qubit to action's resource
   auto& _rs = rule_engine->rp[0];

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -107,7 +107,7 @@ TEST(RuleEngineTest, ESResourceUpdate) {
   auto* mockHardwareMonitor = new MockHardwareMonitor;
   auto* realtime_controller = new MockRealTimeController;
   auto* mockQubit1 = new MockQubit(QNIC_E, 0);
-  std::unique_ptr<IQubitRecord> qubit_record = std::make_unique<QubitRecord>(0, QNIC_E, 0);
+  std::unique_ptr<IQubitRecord> qubit_record = std::make_unique<QubitRecord>(QNIC_E, 0, 0);
   auto rule_engine = new RuleEngineTestTarget{mockQubit1, routingdaemon, mockHardwareMonitor, realtime_controller, qnic_specs};
 
   auto info = std::make_unique<ConnectionSetupInfo>();
@@ -499,7 +499,7 @@ TEST(RuleEngineTest, updateResourcesEntanglementSwappingWithoutRuleSet) {
   auto* realtime_controller = new MockRealTimeController;
   auto* qubit = new MockQubit(QNIC_E, 7);
   auto* rule_engine = new RuleEngineTestTarget{qubit, routing_daemon, hardware_monitor, realtime_controller, qnic_specs};
-  std::unique_ptr<IQubitRecord> qubit_record = std::make_unique<QubitRecord>(0, QNIC_E, 0);
+  std::unique_ptr<IQubitRecord> qubit_record = std::make_unique<QubitRecord>(QNIC_E, 0, 0);
   EXPECT_CALL(*dynamic_cast<MockQNicStore*>(rule_engine->qnic_store.get()), getQubitRecord(QNIC_E, 0, 0)).Times(3).WillRepeatedly(Return(qubit_record.get()));
   EXPECT_CALL(*realtime_controller, assertNoEntanglement(qubit_record.get())).Times(3);
   rule_engine->callInitialize();
@@ -551,7 +551,7 @@ TEST(RuleEngineTest, updateResourcesEntanglementSwappingWithRuleSet) {
   auto* realtime_controller = new MockRealTimeController;
   auto* qubit = new MockQubit(QNIC_E, 7);
   auto* rule_engine = new RuleEngineTestTarget{qubit, routing_daemon, hardware_monitor, realtime_controller, qnic_specs};
-  std::unique_ptr<IQubitRecord> qubit_record = std::make_unique<QubitRecord>(7, QNIC_E, 0);
+  std::unique_ptr<IQubitRecord> qubit_record = std::make_unique<QubitRecord>(QNIC_E, 7, 0);
   EXPECT_CALL(*dynamic_cast<MockQNicStore*>(rule_engine->qnic_store.get()), getQubitRecord(QNIC_E, 0, 0)).Times(1).WillRepeatedly(Return(qubit_record.get()));
   EXPECT_CALL(*realtime_controller, assertNoEntanglement(qubit_record.get())).Times(1);
   rule_engine->callInitialize();

--- a/quisp/rules/actions/SimultaneousSwappingAction.cc
+++ b/quisp/rules/actions/SimultaneousSwappingAction.cc
@@ -98,10 +98,6 @@ cPacket *SimultaneousSwappingAction::run(cModule *re) {
   if (std::rand() / RAND_MAX < success_probability) {
     right_partner_qubit->setEntangledPartnerInfo(left_partner_qubit);
     left_partner_qubit->setEntangledPartnerInfo(right_partner_qubit);
-
-  } else {
-    left_partner_qubit->isBusy = false;
-    right_partner_qubit->isBusy = false;
   }
   removeResource_fromRule(left_qubit);
   removeResource_fromRule(right_qubit);
@@ -109,9 +105,6 @@ cPacket *SimultaneousSwappingAction::run(cModule *re) {
   // free consumed
   rule_engine->freeConsumedResource(self_left_qnic_id, left_qubit, self_left_qnic_type);  // free left
   rule_engine->freeConsumedResource(self_right_qnic_id, right_qubit, self_right_qnic_type);  // free right
-
-  left_qubit->isBusy = false;
-  right_qubit->isBusy = false;
 
   auto *pk = new SimultaneousSwappingResult;
 

--- a/quisp/test_utils/mock_modules/MockQNicStore.h
+++ b/quisp/test_utils/mock_modules/MockQNicStore.h
@@ -16,6 +16,6 @@ class MockQNicStore : public IQNicStore {
   MOCK_METHOD(int, countNumFreeQubits, (QNIC_type type, int qnic_index), (override));
   MOCK_METHOD(int, takeFreeQubitIndex, (QNIC_type type, int qnic_index), (override));
   MOCK_METHOD(void, setQubitBusy, (QNIC_type type, int qnic_index, int qubit_index, bool is_busy), (override));
-  MOCK_METHOD(qrsa::UniqueQubitRecord&, getQubitRecord, (QNIC_type type, int qnic_index, int qubit_index), (override));
+  MOCK_METHOD(qrsa::IQubitRecord*, getQubitRecord, (QNIC_type type, int qnic_index, int qubit_index), (override));
 };
 }  // namespace quisp_test::mock_modules::qnic_store

--- a/quisp/test_utils/mock_modules/MockQNicStore.h
+++ b/quisp/test_utils/mock_modules/MockQNicStore.h
@@ -16,5 +16,6 @@ class MockQNicStore : public IQNicStore {
   MOCK_METHOD(int, countNumFreeQubits, (QNIC_type type, int qnic_index), (override));
   MOCK_METHOD(int, takeFreeQubitIndex, (QNIC_type type, int qnic_index), (override));
   MOCK_METHOD(void, setQubitBusy, (QNIC_type type, int qnic_index, int qubit_index, bool is_busy), (override));
+  MOCK_METHOD(qrsa::UniqueQubitRecord&, getQubitRecord, (QNIC_type type, int qnic_index, int qubit_index), (override));
 };
 }  // namespace quisp_test::mock_modules::qnic_store

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -27,7 +27,6 @@ class MockQubit : public IStationaryQubit {
   MOCK_METHOD(quisp::types::MeasureYResult, measure_Y, (), (override));
   MOCK_METHOD(bool, Xpurify, (IStationaryQubit *), (override));
   MOCK_METHOD(bool, Zpurify, (IStationaryQubit *), (override));
-  MOCK_METHOD(bool, checkBusy, (), (override));
   MOCK_METHOD(void, addXerror, (), (override));
   MOCK_METHOD(void, addZerror, (), (override));
   MOCK_METHOD(void, Z_gate, (), (override));

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -36,9 +36,6 @@ class MockQubit : public IStationaryQubit {
   MOCK_METHOD(void, Lock, (unsigned long rs_id, unsigned long rule_id, int action_id), (override));
   MOCK_METHOD(void, Unlock, (), (override));
   MOCK_METHOD(bool, isLocked, (), (override));
-  MOCK_METHOD(void, Allocate, (), (override));
-  MOCK_METHOD(void, Deallocate, (), (override));
-  MOCK_METHOD(bool, isAllocated, (), (override));
   MOCK_METHOD(quisp::modules::measurement_outcome, measure_density_independent, (), (override));
   MOCK_METHOD(void, setCompletelyMixedDensityMatrix, (), (override));
   MOCK_METHOD(void, setEntangledPartnerInfo, (IStationaryQubit *), (override));

--- a/quisp/test_utils/mock_modules/MockRealTimeController.h
+++ b/quisp/test_utils/mock_modules/MockRealTimeController.h
@@ -9,7 +9,7 @@ namespace mock_modules {
 namespace realtime_controller {
 
 using quisp::modules::QNIC_type;
-using quisp::modules::qrsa::UniqueQubitRecord;
+using quisp::modules::qrsa::IQubitRecord;
 
 class MockRealTimeController : public quisp::modules::IRealTimeController {
  public:
@@ -17,9 +17,9 @@ class MockRealTimeController : public quisp::modules::IRealTimeController {
   MOCK_METHOD(void, handleMessage, (cMessage * msg), (override));
   MOCK_METHOD(void, EmitPhoton, (int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse), (override));
   MOCK_METHOD(void, ReInitialize_StationaryQubit, (int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed), (override));
-  MOCK_METHOD(void, applyXGate, (UniqueQubitRecord & qubit_record), (override));
-  MOCK_METHOD(void, applyZGate, (UniqueQubitRecord & qubit_record), (override));
-  MOCK_METHOD(void, assertNoEntanglement, (UniqueQubitRecord & qubit_record), (override));
+  MOCK_METHOD(void, applyXGate, (IQubitRecord* const qubit_record), (override));
+  MOCK_METHOD(void, applyZGate, (IQubitRecord* const qubit_record), (override));
+  MOCK_METHOD(void, assertNoEntanglement, (IQubitRecord* const qubit_record), (override));
 };
 }  // namespace realtime_controller
 }  // namespace mock_modules

--- a/quisp/test_utils/mock_modules/MockRealTimeController.h
+++ b/quisp/test_utils/mock_modules/MockRealTimeController.h
@@ -17,6 +17,7 @@ class MockRealTimeController : public quisp::modules::IRealTimeController {
   MOCK_METHOD(void, handleMessage, (cMessage * msg), (override));
   MOCK_METHOD(void, EmitPhoton, (int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse), (override));
   MOCK_METHOD(void, ReInitialize_StationaryQubit, (int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed), (override));
+  MOCK_METHOD(void, ReInitialize_StationaryQubit, (IQubitRecord* const qubit_record, bool consumed), (override));
   MOCK_METHOD(void, applyXGate, (IQubitRecord* const qubit_record), (override));
   MOCK_METHOD(void, applyZGate, (IQubitRecord* const qubit_record), (override));
   MOCK_METHOD(void, assertNoEntanglement, (IQubitRecord* const qubit_record), (override));

--- a/quisp/test_utils/mock_modules/MockRealTimeController.h
+++ b/quisp/test_utils/mock_modules/MockRealTimeController.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <gmock/gmock.h>
 #include "modules/QNIC.h"
+#include "modules/QRSA/QRSA.h"
 #include "modules/QRSA/RealTimeController/IRealTimeController.h"
 
 namespace quisp_test {
@@ -8,6 +9,7 @@ namespace mock_modules {
 namespace realtime_controller {
 
 using quisp::modules::QNIC_type;
+using quisp::modules::qrsa::UniqueQubitRecord;
 
 class MockRealTimeController : public quisp::modules::IRealTimeController {
  public:
@@ -15,6 +17,9 @@ class MockRealTimeController : public quisp::modules::IRealTimeController {
   MOCK_METHOD(void, handleMessage, (cMessage * msg), (override));
   MOCK_METHOD(void, EmitPhoton, (int qnic_index, int qubit_index, QNIC_type qnic_type, int pulse), (override));
   MOCK_METHOD(void, ReInitialize_StationaryQubit, (int qnic_index, int qubit_index, QNIC_type qnic_type, bool consumed), (override));
+  MOCK_METHOD(void, applyXGate, (UniqueQubitRecord & qubit_record), (override));
+  MOCK_METHOD(void, applyZGate, (UniqueQubitRecord & qubit_record), (override));
+  MOCK_METHOD(void, assertNoEntanglement, (UniqueQubitRecord & qubit_record), (override));
 };
 }  // namespace realtime_controller
 }  // namespace mock_modules

--- a/quisp/utils/ComponentProvider.cc
+++ b/quisp/utils/ComponentProvider.cc
@@ -36,6 +36,12 @@ IStationaryQubit *ComponentProvider::getStationaryQubit(int qnic_index, int qubi
   ensureStrategy();
   return strategy->getStationaryQubit(qnic_index, qubit_index, qnic_type);
 }
+
+IStationaryQubit *ComponentProvider::getStationaryQubit(modules::qrsa::UniqueQubitRecord &qubit_record) {
+  ensureStrategy();
+  return strategy->getStationaryQubit(qubit_record->getQNicIndex(), qubit_record->getQubitIndex(), qubit_record->getQNicType());
+}
+
 cModule *ComponentProvider::getQNIC(int qnic_index, QNIC_type qnic_type) {
   ensureStrategy();
   return strategy->getQNIC(qnic_index, qnic_type);

--- a/quisp/utils/ComponentProvider.cc
+++ b/quisp/utils/ComponentProvider.cc
@@ -37,7 +37,7 @@ IStationaryQubit *ComponentProvider::getStationaryQubit(int qnic_index, int qubi
   return strategy->getStationaryQubit(qnic_index, qubit_index, qnic_type);
 }
 
-IStationaryQubit *ComponentProvider::getStationaryQubit(modules::qrsa::UniqueQubitRecord &qubit_record) {
+IStationaryQubit *ComponentProvider::getStationaryQubit(modules::qrsa::IQubitRecord *const qubit_record) {
   ensureStrategy();
   return strategy->getStationaryQubit(qubit_record->getQNicIndex(), qubit_record->getQubitIndex(), qubit_record->getQNicType());
 }

--- a/quisp/utils/ComponentProvider.h
+++ b/quisp/utils/ComponentProvider.h
@@ -27,7 +27,7 @@ class ComponentProvider {
   bool isQNodeType(const cModuleType *const type);
   bool isHoMNodeType(const cModuleType *const type);
   bool isSPDCNodeType(const cModuleType *const type);
-  IStationaryQubit *getStationaryQubit(modules::qrsa::UniqueQubitRecord &qubit_record);
+  IStationaryQubit *getStationaryQubit(modules::qrsa::IQubitRecord *const qubit_record);
   IStationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type);
   cModule *getQNIC(int qnic_index, QNIC_type qnic_type);
   int getNumQubits(int qnic_index, QNIC_type qnic_type);

--- a/quisp/utils/ComponentProvider.h
+++ b/quisp/utils/ComponentProvider.h
@@ -3,6 +3,7 @@
 
 #include "DefaultComponentProviderStrategy.h"
 #include "IComponentProviderStrategy.h"
+#include "modules/QRSA/QRSA.h"
 #include "omnetpp/cmodule.h"
 #include "utils.h"
 
@@ -26,6 +27,7 @@ class ComponentProvider {
   bool isQNodeType(const cModuleType *const type);
   bool isHoMNodeType(const cModuleType *const type);
   bool isSPDCNodeType(const cModuleType *const type);
+  IStationaryQubit *getStationaryQubit(modules::qrsa::UniqueQubitRecord &qubit_record);
   IStationaryQubit *getStationaryQubit(int qnic_index, int qubit_index, QNIC_type qnic_type);
   cModule *getQNIC(int qnic_index, QNIC_type qnic_type);
   int getNumQubits(int qnic_index, QNIC_type qnic_type);


### PR DESCRIPTION
now I'm replacing `IStationaryQubit` with `IQubitRecord`.
In this PR, I'll replace RuleEngine and BellPairStore, not RuleSet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/322)
<!-- Reviewable:end -->
