### PR TITLE
rename rule_index to rule_id in purifications

### DIFF
--- a/quisp/rules/actions/DoublePurifyAction.cc
+++ b/quisp/rules/actions/DoublePurifyAction.cc
@@ -4,9 +4,9 @@
 
 namespace quisp::rules::actions {
 
-DoublePurifyAction::DoublePurifyAction(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+DoublePurifyAction::DoublePurifyAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                                        int trash_resource_z)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_id),
@@ -67,9 +67,9 @@ cPacket *DoublePurifyAction::run(cModule *re) {
   return pk;
 }
 
-DoublePurifyActionInv::DoublePurifyActionInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+DoublePurifyActionInv::DoublePurifyActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                                              int trash_resource_z)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_id),

--- a/quisp/rules/actions/DoublePurifyAction.h
+++ b/quisp/rules/actions/DoublePurifyAction.h
@@ -23,8 +23,7 @@ class DoublePurifyAction : public Action {
 
 class DoublePurifyActionInv : public Action {
  public:
-  DoublePurifyActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
-                        int trash_resource_z);
+  DoublePurifyActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x, int trash_resource_z);
   cPacket* run(cModule* re) override;
 
  protected:

--- a/quisp/rules/actions/DoublePurifyAction.h
+++ b/quisp/rules/actions/DoublePurifyAction.h
@@ -6,7 +6,7 @@ namespace quisp::rules::actions {
 
 class DoublePurifyAction : public Action {
  public:
-  DoublePurifyAction(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x, int trash_resource_z);
+  DoublePurifyAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x, int trash_resource_z);
   cPacket* run(cModule* re) override;
 
  protected:
@@ -23,7 +23,7 @@ class DoublePurifyAction : public Action {
 
 class DoublePurifyActionInv : public Action {
  public:
-  DoublePurifyActionInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+  DoublePurifyActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                         int trash_resource_z);
   cPacket* run(cModule* re) override;
 

--- a/quisp/rules/actions/DoubleSelectionAction.cc
+++ b/quisp/rules/actions/DoubleSelectionAction.cc
@@ -4,9 +4,9 @@
 
 namespace quisp::rules::actions {
 
-DoubleSelectionAction::DoubleSelectionAction(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+DoubleSelectionAction::DoubleSelectionAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                                              int trash_resource_z)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_id),
@@ -64,9 +64,9 @@ cPacket *DoubleSelectionAction::run(cModule *re) {
   return pk;
 }
 
-DoubleSelectionActionInv::DoubleSelectionActionInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource,
+DoubleSelectionActionInv::DoubleSelectionActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource,
                                                    int trash_resource_x, int trash_resource_z)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_id),

--- a/quisp/rules/actions/DoubleSelectionAction.h
+++ b/quisp/rules/actions/DoubleSelectionAction.h
@@ -8,7 +8,7 @@ namespace quisp::rules::actions {
 // https://arxiv.org/abs/0811.2639
 class DoubleSelectionAction : public Action {
  public:
-  DoubleSelectionAction(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+  DoubleSelectionAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                         int trash_resource_z);
   cPacket* run(cModule* re) override;
 
@@ -29,7 +29,7 @@ class DoubleSelectionAction : public Action {
 // https://arxiv.org/abs/0811.2639
 class DoubleSelectionActionInv : public Action {
  public:
-  DoubleSelectionActionInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+  DoubleSelectionActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                            int trash_resource_z);
   cPacket* run(cModule* re) override;
 

--- a/quisp/rules/actions/DoubleSelectionAction.h
+++ b/quisp/rules/actions/DoubleSelectionAction.h
@@ -8,8 +8,7 @@ namespace quisp::rules::actions {
 // https://arxiv.org/abs/0811.2639
 class DoubleSelectionAction : public Action {
  public:
-  DoubleSelectionAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
-                        int trash_resource_z);
+  DoubleSelectionAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x, int trash_resource_z);
   cPacket* run(cModule* re) override;
 
  protected:

--- a/quisp/rules/actions/DoubleSelectionDualAction.cc
+++ b/quisp/rules/actions/DoubleSelectionDualAction.cc
@@ -3,9 +3,9 @@
 #include <modules/QRSA/RuleEngine/IRuleEngine.h>
 
 namespace quisp::rules::actions {
-DoubleSelectionDualAction::DoubleSelectionDualAction(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_index, int resource,
+DoubleSelectionDualAction::DoubleSelectionDualAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_index, int resource,
                                                      int trash_resource_x, int trash_resource_z, int ds_trash_resource_x, int ds_trash_resource_z)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_index),
@@ -84,9 +84,9 @@ cPacket *DoubleSelectionDualAction::run(cModule *re) {
   return pk;
 }
 
-DoubleSelectionDualActionInv::DoubleSelectionDualActionInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_index, int resource,
+DoubleSelectionDualActionInv::DoubleSelectionDualActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_index, int resource,
                                                            int trash_resource_x, int trash_resource_z, int ds_trash_resource_x, int ds_trash_resource_z)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_index),

--- a/quisp/rules/actions/DoubleSelectionDualAction.h
+++ b/quisp/rules/actions/DoubleSelectionDualAction.h
@@ -7,7 +7,7 @@ namespace quisp::rules::actions {
 // https://arxiv.org/abs/0811.2639
 class DoubleSelectionDualAction : public Action {
  public:
-  DoubleSelectionDualAction(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_index, int resource, int trash_resource_x,
+  DoubleSelectionDualAction(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_index, int resource, int trash_resource_x,
                             int trash_resource_z, int ds_trash_resource_x, int ds_trash_resource_z);
   cPacket* run(cModule* re) override;
 
@@ -28,7 +28,7 @@ class DoubleSelectionDualAction : public Action {
 // https://arxiv.org/abs/0811.2639
 class DoubleSelectionDualActionInv : public Action {
  public:
-  DoubleSelectionDualActionInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_index, int resource, int trash_resource_x,
+  DoubleSelectionDualActionInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_index, int resource, int trash_resource_x,
                                int trash_resource_z, int ds_trash_resource_x, int ds_trash_resource_z);
   cPacket* run(cModule* re) override;
 

--- a/quisp/rules/actions/DoubleSelectionDualActionSecond.cc
+++ b/quisp/rules/actions/DoubleSelectionDualActionSecond.cc
@@ -4,9 +4,9 @@
 
 namespace quisp::rules::actions {
 
-DoubleSelectionDualActionSecond::DoubleSelectionDualActionSecond(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource,
+DoubleSelectionDualActionSecond::DoubleSelectionDualActionSecond(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource,
                                                                  int trash_resource_x, int trash_resource_z, int ds_trash_resource_x)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_id),
@@ -75,9 +75,9 @@ cPacket *DoubleSelectionDualActionSecond::run(cModule *re) {
   return pk;
 }
 
-DoubleSelectionDualActionSecondInv::DoubleSelectionDualActionSecondInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id,
+DoubleSelectionDualActionSecondInv::DoubleSelectionDualActionSecondInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id,
                                                                        int resource, int trash_resource_x, int trash_resource_z, int ds_trash_resource_z)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_id),

--- a/quisp/rules/actions/DoubleSelectionDualActionSecond.cc
+++ b/quisp/rules/actions/DoubleSelectionDualActionSecond.cc
@@ -75,8 +75,8 @@ cPacket *DoubleSelectionDualActionSecond::run(cModule *re) {
   return pk;
 }
 
-DoubleSelectionDualActionSecondInv::DoubleSelectionDualActionSecondInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id,
-                                                                       int resource, int trash_resource_x, int trash_resource_z, int ds_trash_resource_z)
+DoubleSelectionDualActionSecondInv::DoubleSelectionDualActionSecondInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource,
+                                                                       int trash_resource_x, int trash_resource_z, int ds_trash_resource_z)
     : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),

--- a/quisp/rules/actions/DoubleSelectionDualActionSecond.h
+++ b/quisp/rules/actions/DoubleSelectionDualActionSecond.h
@@ -7,7 +7,7 @@ namespace quisp::rules::actions {
 // https://arxiv.org/abs/0811.2639
 class DoubleSelectionDualActionSecond : public Action {
  public:
-  DoubleSelectionDualActionSecond(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+  DoubleSelectionDualActionSecond(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                                   int trash_resource_z, int ds_trash_resource_x);
   cPacket* run(cModule* re) override;
 
@@ -29,7 +29,7 @@ class DoubleSelectionDualActionSecond : public Action {
 // https://arxiv.org/abs/0811.2639
 class DoubleSelectionDualActionSecondInv : public Action {
  public:
-  DoubleSelectionDualActionSecondInv(unsigned long ruleset_id, unsigned long rule_index, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
+  DoubleSelectionDualActionSecondInv(unsigned long ruleset_id, unsigned long rule_id, int partner, QNIC_type qnic_type, int qnic_id, int resource, int trash_resource_x,
                                      int trash_resource_z, int ds_trash_resource_z);
   cPacket* run(cModule* re) override;
 

--- a/quisp/rules/actions/PurifyAction.cc
+++ b/quisp/rules/actions/PurifyAction.cc
@@ -4,9 +4,9 @@
 
 namespace quisp::rules::actions {
 
-PurifyAction::PurifyAction(unsigned long ruleset_id, unsigned long rule_index, bool x_purification, bool z_purification, int num_purification, int partner, QNIC_type qnic_type,
+PurifyAction::PurifyAction(unsigned long ruleset_id, unsigned long rule_id, bool x_purification, bool z_purification, int num_purification, int partner, QNIC_type qnic_type,
                            int qnic_id, int resource, int trash_resource)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       partner(partner),
       qnic_type(qnic_type),
       qnic_id(qnic_id),

--- a/quisp/rules/actions/PurifyAction.h
+++ b/quisp/rules/actions/PurifyAction.h
@@ -6,7 +6,7 @@ namespace quisp::rules::actions {
 
 class PurifyAction : public Action {
  public:
-  PurifyAction(unsigned long ruleset_id, unsigned long rule_index, bool x_purification, bool z_purification, int num_purification, int partner, QNIC_type qnic_type, int qnic_id,
+  PurifyAction(unsigned long ruleset_id, unsigned long rule_id, bool x_purification, bool z_purification, int num_purification, int partner, QNIC_type qnic_type, int qnic_id,
                int resource, int trash_resource);
 
   cPacket* run(cModule* re) override;

--- a/quisp/rules/actions/RandomMeasureAction.cc
+++ b/quisp/rules/actions/RandomMeasureAction.cc
@@ -4,9 +4,9 @@
 
 namespace quisp::rules::actions {
 
-RandomMeasureAction::RandomMeasureAction(unsigned long ruleset_id, unsigned long rule_index, int owner_address, int partner, QNIC_type qnic_type, int qnic_id, int resource,
+RandomMeasureAction::RandomMeasureAction(unsigned long ruleset_id, unsigned long rule_id, int owner_address, int partner, QNIC_type qnic_type, int qnic_id, int resource,
                                          int max_count)
-    : Action(ruleset_id, rule_index), partner(partner), qnic_type(qnic_type), qnic_id(qnic_id), resource(resource), src(owner_address), dst(partner), max_count(max_count) {
+    : Action(ruleset_id, rule_id), partner(partner), qnic_type(qnic_type), qnic_id(qnic_id), resource(resource), src(owner_address), dst(partner), max_count(max_count) {
   current_count = 0;
   start = simTime();
 };

--- a/quisp/rules/actions/RandomMeasureAction.h
+++ b/quisp/rules/actions/RandomMeasureAction.h
@@ -6,7 +6,7 @@ namespace quisp::rules::actions {
 
 class RandomMeasureAction : public Action {
  public:
-  RandomMeasureAction(unsigned long ruleset_id, unsigned long rule_index, int owner_address, int partner, QNIC_type qnic_type, int qnic_id, int resource, int max_count);
+  RandomMeasureAction(unsigned long ruleset_id, unsigned long rule_id, int owner_address, int partner, QNIC_type qnic_type, int qnic_id, int resource, int max_count);
   cPacket* run(cModule* re) override;
 
  protected:

--- a/quisp/rules/actions/SimultaneousSwappingAction.cc
+++ b/quisp/rules/actions/SimultaneousSwappingAction.cc
@@ -4,13 +4,13 @@
 
 using quisp::types::MeasureZResult;
 namespace quisp::rules::actions {
-SimultaneousSwappingAction::SimultaneousSwappingAction(unsigned long ruleset_id, unsigned long rule_index, int left_partner, QNIC_type left_qnic_type, int left_qnic_index,
+SimultaneousSwappingAction::SimultaneousSwappingAction(unsigned long ruleset_id, unsigned long rule_id, int left_partner, QNIC_type left_qnic_type, int left_qnic_index,
                                                        int left_qnic_address, int left_resource, int right_partner, QNIC_type right_qnic_type, int right_qnic_index,
                                                        int right_qnic_address, int right_resource, int self_left_qnic_id, QNIC_type self_left_qnic_type, int self_right_qnic_id,
                                                        QNIC_type self_right_qnic_type, int initiator, QNIC_type initiator_qnic_type, int initiator_qnic_id,
                                                        int initiator_qnic_address, int initiator_resource, int responder, QNIC_type responder_qnic_type, int responder_qnic_id,
                                                        int responder_qnic_address, int responder_resource, int index_in_path, int path_length_exclude_ir)
-    : Action(ruleset_id, rule_index),
+    : Action(ruleset_id, rule_id),
       left_partner(),
       left_qnic_type(left_qnic_type),
       left_qnic_id(left_qnic_index),

--- a/quisp/rules/actions/SimultaneousSwappingAction.h
+++ b/quisp/rules/actions/SimultaneousSwappingAction.h
@@ -6,7 +6,7 @@ namespace quisp::rules::actions {
 
 class SimultaneousSwappingAction : public Action {
  public:
-  SimultaneousSwappingAction(unsigned long ruleset_id, unsigned long rule_index, int left_partner, QNIC_type left_qnic_type, int left_qnic_index, int left_qnic_address,
+  SimultaneousSwappingAction(unsigned long ruleset_id, unsigned long rule_id, int left_partner, QNIC_type left_qnic_type, int left_qnic_index, int left_qnic_address,
                              int left_resource, int right_partner, QNIC_type right_qnic_type, int right_qnic_index, int right_qnic_address, int right_resource,
                              int self_left_qnic_id, QNIC_type self_left_qnic_type, int self_right_qnic_id, QNIC_type self_right_qnic_type, int initiator,
                              QNIC_type initiator_qnic_type, int initiator_qnic_id, int initiator_qnic_address, int initiator_resource, int responder, QNIC_type responder_qnic_type,

--- a/quisp/rules/actions/SwappingAction_test.cc
+++ b/quisp/rules/actions/SwappingAction_test.cc
@@ -41,7 +41,7 @@ class SwappingAction : public OriginalSwappingAction {
   using OriginalSwappingAction::SwappingAction;
   static std::unique_ptr<SwappingAction> setupAction() {
     unsigned long ruleset_id = 0;
-    unsigned long rule_index = 1;
+    unsigned long rule_id = 1;
 
     int left_partner_addr = 2;
     QNIC_type left_qnic_type = QNIC_E;
@@ -60,7 +60,7 @@ class SwappingAction : public OriginalSwappingAction {
     int self_right_qnic_id = 13;
     QNIC_type self_right_qnic_type = QNIC_E;
 
-    return std::make_unique<SwappingAction>(ruleset_id, rule_index, left_partner_addr, left_qnic_type, left_qnic_id, left_qnic_addr, left_resource, right_partner_addr,
+    return std::make_unique<SwappingAction>(ruleset_id, rule_id, left_partner_addr, left_qnic_type, left_qnic_id, left_qnic_addr, left_resource, right_partner_addr,
                                             right_qnic_type, right_qnic_id, right_qnic_addr, right_resource, self_left_qnic_id, self_left_qnic_type, self_right_qnic_id,
                                             self_right_qnic_type);
   }
@@ -91,7 +91,7 @@ class SwappingActionTest : public ::testing::Test {
 
 TEST_F(SwappingActionTest, init) {
   unsigned long ruleset_id = 0;
-  unsigned long rule_index = 1;
+  unsigned long rule_id = 1;
 
   int left_partner_addr = 2;
   QNIC_type left_qnic_type = QNIC_E;
@@ -110,10 +110,10 @@ TEST_F(SwappingActionTest, init) {
   int self_right_qnic_id = 13;
   QNIC_type self_right_qnic_type = QNIC_E;
 
-  auto action = new SwappingAction(ruleset_id, rule_index, left_partner_addr, left_qnic_type, left_qnic_id, left_qnic_addr, left_resource, right_partner_addr, right_qnic_type,
+  auto action = new SwappingAction(ruleset_id, rule_id, left_partner_addr, left_qnic_type, left_qnic_id, left_qnic_addr, left_resource, right_partner_addr, right_qnic_type,
                                    right_qnic_id, right_qnic_addr, right_resource, self_left_qnic_id, self_left_qnic_type, self_right_qnic_id, self_right_qnic_type);
   EXPECT_EQ(ruleset_id, action->ruleset_id);
-  EXPECT_EQ(rule_index, action->rule_id);
+  EXPECT_EQ(rule_id, action->rule_id);
   EXPECT_EQ(left_partner_addr, action->left_partner);
   EXPECT_EQ(right_partner_addr, action->right_partner);
   EXPECT_EQ(left_qnic_id, action->left_qnic_id);


### PR DESCRIPTION
Renamed `rule_index` with `rule_id` in purifications.
The next thing will be writing tests for Rules and conditions and rename `rule_index` used in Rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/328)
<!-- Reviewable:end -->
