### PR TITLE
Add new topology config for small linear 5 nodes for QIP class

### DIFF
--- a/quisp/networks/omnetpp.ini
+++ b/quisp/networks/omnetpp.ini
@@ -529,6 +529,64 @@ seed-set = 1
 **.entanglement_swapping_with_purification = true
 
 
+[Config EntanglementSwapping_Linear_FIVE_MM_Test]
+network= Linear_five_MM_network
+sim-time-limit = 11s
+seed-set = 1
+**.num_measure = 10
+**.buffers = 10
+
+**.tomography_output_filename = "ES_linear_five_MM_network"
+
+
+**.emission_success_probability = 1
+
+**.Measurement_error_rate = 0
+**.Measurement_X_error_ratio = 0
+**.Measurement_Y_error_ratio = 0
+**.Measurement_Z_error_ratio = 0
+
+
+# Error on optical qubit in a channel
+**.channel_Loss_error_rate = 0 # per km. 1 - 10^(-0.2/10)
+**.channel_X_error_rate = 0 #ratio. Not the error rate!! By default the ratio is 1:1:1
+**.channel_Z_error_rate = 0 #ratio. Not the error rate!!
+**.channel_Y_error_rate = 0 #ratio. Not the error rate!!
+
+**.memory_X_error_rate = 0 #ratio. Not the error rate!!
+**.memory_Y_error_rate = 0 #ratio. Not the error rate!!
+**.memory_Z_error_rate = 0 #ratio. Not the error rate!! By default the ratio is 1:1:1
+**.memory_energy_excitation_rate = 0
+**.memory_energy_relaxation_rate = 0
+**.memory_completely_mixed_rate = 0
+
+# Internal HoM in QNIC
+**.internal_hom_loss_rate = 0
+**.internal_hom_error_rate = 0 #Not inplemented
+**.internal_hom_required_precision = 1.5e-9 #Schuck et al., PRL 96,
+**.internal_hom_photon_detection_per_sec = 1000000000
+**.internal_hom_darkcount_probability = 0 #10/s * 10^-9
+
+#Stand-alone HoM in the network
+**.hom_loss_rate = 0
+**.hom_error_rate = 0 #Not inplemented
+**.hom_required_precision = 1.5e-9 #Schuck et al., PRL 96,
+**.hom_photon_detection_per_sec = 1000000000
+**.hom_darkcount_probability = 10e-8 #1%
+
+**.EndToEndConnection = true
+# Which traffic pattern? 
+# 1 = single connection from Node 1 to a random location in the network
+# 2 = every node selects a random partner
+**.TrafficPattern = 1
+**.link_tomography = false
+**.NumberOfResources = 1
+**.distant_measure_count = 10
+**.initial_purification = 1
+**.Purification_type = 2002
+**.entanglement_swapping_with_purification = false
+
+
 [Config EntanglementSwapping_Purification_Star_Test]
 network= Realistic_Layer2_Star_Sep
 sim-time-limit = 100s


### PR DESCRIPTION
I add a new config for 5 nodes linear MM with small buffer size and count so we can demonstrate this in class using WASM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/338)
<!-- Reviewable:end -->
