### PR TITLE
Fix Measurement Error and add new function for measurement

### DIFF
--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -150,13 +150,13 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
    * \param pulse is 1 for the beginning of the burst, 2 for the end.
    */
   virtual void emitPhoton(int pulse) = 0;
-  virtual types::MeasureXResult correlation_measure_X() = 0;
-  virtual types::MeasureYResult correlation_measure_Y() = 0;
-  virtual types::MeasureZResult correlation_measure_Z() = 0;
+  virtual types::MeasureXResult correlationMeasureX() = 0;
+  virtual types::MeasureYResult correlationMeasureY() = 0;
+  virtual types::MeasureZResult correlationMeasureZ() = 0;
 
-  virtual types::EigenvalueResult local_measure_X() = 0;
-  virtual types::EigenvalueResult local_measure_Y() = 0;
-  virtual types::EigenvalueResult local_measure_Z() = 0;
+  virtual types::EigenvalueResult localMeasureX() = 0;
+  virtual types::EigenvalueResult localMeasureY() = 0;
+  virtual types::EigenvalueResult localMeasureZ() = 0;
 
   /**
    * Performs measurement and returns +(true) or -(false) based on the density matrix of the state. Used for tomography.

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -17,6 +17,12 @@ enum class MeasureZResult : int {
   NO_X_ERROR,
   HAS_X_ERROR,
 };
+
+enum class EigenvalueResult : int {
+  MINUS_ONE,
+  PLUS_ONE,
+};
+
 }  // namespace types
 
 namespace modules {
@@ -80,6 +86,12 @@ struct memory_error_model {
   double completely_mixed_rate;
 };
 
+struct MeasurementErrorModel {
+  double X_measurement_error_rate;
+  double Y_measurement_error_rate;
+  double Z_measurement_error_rate;
+};
+
 // Matrices of single qubit errors. Used when conducting tomography.
 struct single_qubit_error {
   Eigen::Matrix2cd X;  // double 2*2 matrix
@@ -138,9 +150,13 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
    * \param pulse is 1 for the beginning of the burst, 2 for the end.
    */
   virtual void emitPhoton(int pulse) = 0;
-  virtual quisp::types::MeasureXResult measure_X() = 0;
-  virtual types::MeasureYResult measure_Y() = 0;
-  virtual types::MeasureZResult measure_Z() = 0;
+  virtual types::MeasureXResult correlation_measure_X() = 0;
+  virtual types::MeasureYResult correlation_measure_Y() = 0;
+  virtual types::MeasureZResult correlation_measure_Z() = 0;
+
+  virtual types::EigenvalueResult local_measure_X() = 0;
+  virtual types::EigenvalueResult local_measure_Y() = 0;
+  virtual types::EigenvalueResult local_measure_Z() = 0;
 
   /**
    * Performs measurement and returns +(true) or -(false) based on the density matrix of the state. Used for tomography.

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -199,7 +199,7 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   SingleGateErrorModel Xgate_error;
   SingleGateErrorModel Zgate_error;
   TwoQubitGateErrorModel CNOTgate_error;
-  SingleGateErrorModel Measurement_error;
+  MeasurementErrorModel Measurement_error;
 
   Eigen::Matrix2cd Density_Matrix_Collapsed;  // Used when partner has been measured.
   bool partner_measured;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -87,9 +87,9 @@ struct memory_error_model {
 };
 
 struct MeasurementErrorModel {
-  double X_measurement_error_rate;
-  double Y_measurement_error_rate;
-  double Z_measurement_error_rate;
+  double x_error_rate;
+  double y_error_rate;
+  double z_error_rate;
 };
 
 // Matrices of single qubit errors. Used when conducting tomography.

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -221,14 +221,14 @@ void StationaryQubit::setTwoQubitGateErrorCeilings(TwoQubitGateErrorModel &model
 }
 
 void StationaryQubit::setMeasurementErrorModel(MeasurementErrorModel &model) {
-  model.X_measurement_error_rate = par("X_measurement_error_rate").doubleValue();
-  model.Y_measurement_error_rate = par("Y_measurement_error_rate").doubleValue();
-  model.Z_measurement_error_rate = par("Z_measurement_error_rate").doubleValue();
+  model.x_error_rate = par("X_measurement_error_rate").doubleValue();
+  model.y_error_rate = par("Y_measurement_error_rate").doubleValue();
+  model.z_error_rate = par("Z_measurement_error_rate").doubleValue();
 }
 
 MeasureXResult StationaryQubit::correlation_measure_X() {
   bool error = par("GOD_Zerror").boolValue();
-  if (dblrand() < Measurement_error.X_measurement_error_rate) {
+  if (dblrand() < Measurement_error.x_error_rate) {
     error = !error;
   }
   return error ? MeasureXResult::HAS_Z_ERROR : MeasureXResult::NO_Z_ERROR;
@@ -236,7 +236,7 @@ MeasureXResult StationaryQubit::correlation_measure_X() {
 
 MeasureYResult StationaryQubit::correlation_measure_Y() {
   bool error = par("GOD_Zerror").boolValue() != par("GOD_Xerror").boolValue();
-  if (dblrand() < Measurement_error.Y_measurement_error_rate) {
+  if (dblrand() < Measurement_error.y_error_rate) {
     error = !error;
   }
   return error ? MeasureYResult::HAS_XZ_ERROR : MeasureYResult::NO_XZ_ERROR;
@@ -244,7 +244,7 @@ MeasureYResult StationaryQubit::correlation_measure_Y() {
 
 MeasureZResult StationaryQubit::correlation_measure_Z() {
   bool error = par("GOD_Xerror").boolValue();
-  if (dblrand() < Measurement_error.X_measurement_error_rate) {
+  if (dblrand() < Measurement_error.x_error_rate) {
     error = !error;
   }
   return error ? MeasureZResult::HAS_X_ERROR : MeasureZResult::NO_X_ERROR;
@@ -263,7 +263,7 @@ EigenvalueResult StationaryQubit::local_measure_X() {
       this->entangled_partner->addZerror();
     }
   }
-  if (dblrand() < this->Measurement_error.X_measurement_error_rate) {
+  if (dblrand() < this->Measurement_error.x_error_rate) {
     result = result == EigenvalueResult::PLUS_ONE ? EigenvalueResult::MINUS_ONE : EigenvalueResult::PLUS_ONE;
   }
   return result;
@@ -287,7 +287,7 @@ EigenvalueResult StationaryQubit::local_measure_Z() {
       this->entangled_partner->addXerror();
     }
   }
-  if (dblrand() < this->Measurement_error.Z_measurement_error_rate) {
+  if (dblrand() < this->Measurement_error.z_error_rate) {
     result = result == EigenvalueResult::PLUS_ONE ? EigenvalueResult::MINUS_ONE : EigenvalueResult::PLUS_ONE;
   }
   return result;
@@ -1014,9 +1014,9 @@ measurement_outcome StationaryQubit::measure_density_independent() {
 
   // add measurement error
   auto rand_num = dblrand();
-  if (this_measurement.basis == meas_op.X_basis.basis && rand_num < Measurement_error.X_measurement_error_rate ||
-      this_measurement.basis == meas_op.Y_basis.basis && rand_num < Measurement_error.Y_measurement_error_rate ||
-      this_measurement.basis == meas_op.Z_basis.basis && rand_num < Measurement_error.Z_measurement_error_rate) {
+  if (this_measurement.basis == meas_op.X_basis.basis && rand_num < Measurement_error.x_error_rate ||
+      this_measurement.basis == meas_op.Y_basis.basis && rand_num < Measurement_error.y_error_rate ||
+      this_measurement.basis == meas_op.Z_basis.basis && rand_num < Measurement_error.z_error_rate) {
     Output_is_plus = !Output_is_plus;
   }
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -226,7 +226,7 @@ void StationaryQubit::setMeasurementErrorModel(MeasurementErrorModel &model) {
   model.z_error_rate = par("Z_measurement_error_rate").doubleValue();
 }
 
-MeasureXResult StationaryQubit::correlation_measure_X() {
+MeasureXResult StationaryQubit::correlationMeasureX() {
   bool error = par("GOD_Zerror").boolValue();
   if (dblrand() < Measurement_error.x_error_rate) {
     error = !error;
@@ -234,7 +234,7 @@ MeasureXResult StationaryQubit::correlation_measure_X() {
   return error ? MeasureXResult::HAS_Z_ERROR : MeasureXResult::NO_Z_ERROR;
 }
 
-MeasureYResult StationaryQubit::correlation_measure_Y() {
+MeasureYResult StationaryQubit::correlationMeasureY() {
   bool error = par("GOD_Zerror").boolValue() != par("GOD_Xerror").boolValue();
   if (dblrand() < Measurement_error.y_error_rate) {
     error = !error;
@@ -242,7 +242,7 @@ MeasureYResult StationaryQubit::correlation_measure_Y() {
   return error ? MeasureYResult::HAS_XZ_ERROR : MeasureYResult::NO_XZ_ERROR;
 }
 
-MeasureZResult StationaryQubit::correlation_measure_Z() {
+MeasureZResult StationaryQubit::correlationMeasureZ() {
   bool error = par("GOD_Xerror").boolValue();
   if (dblrand() < Measurement_error.x_error_rate) {
     error = !error;
@@ -250,7 +250,7 @@ MeasureZResult StationaryQubit::correlation_measure_Z() {
   return error ? MeasureZResult::HAS_X_ERROR : MeasureZResult::NO_X_ERROR;
 }
 
-EigenvalueResult StationaryQubit::local_measure_X() {
+EigenvalueResult StationaryQubit::localMeasureX() {
   // the Z error will propagate to its partner; This only works for Bell pair and entanglement swapping for now
   if (this->entangled_partner != nullptr && par("GOD_Zerror").boolValue()) {
     this->entangled_partner->addZerror();
@@ -269,12 +269,12 @@ EigenvalueResult StationaryQubit::local_measure_X() {
   return result;
 }
 
-EigenvalueResult StationaryQubit::local_measure_Y() {
+EigenvalueResult StationaryQubit::localMeasureY() {
   error("Not Yet Implemented");
   return EigenvalueResult::PLUS_ONE;
 }
 
-EigenvalueResult StationaryQubit::local_measure_Z() {
+EigenvalueResult StationaryQubit::localMeasureZ() {
   // the X error will propagate to its partner; This only works for Bell pair and entanglement swapping for now
   if (this->entangled_partner != nullptr && par("GOD_Xerror").boolValue()) {
     this->entangled_partner->addXerror();
@@ -567,7 +567,7 @@ bool StationaryQubit::Xpurify(IStationaryQubit *resource_qubit /*Controlled*/) {
   applyMemoryError();
   check_and_cast<StationaryQubit *>(resource_qubit)->applyMemoryError();
   /*Target qubit*/ this->CNOT_gate(resource_qubit /*controlled qubit*/);
-  bool meas = this->correlation_measure_Z() == MeasureZResult::NO_X_ERROR;
+  bool meas = this->correlationMeasureZ() == MeasureZResult::NO_X_ERROR;
   return meas;
 }
 
@@ -577,7 +577,7 @@ bool StationaryQubit::Zpurify(IStationaryQubit *resource_qubit /*Target*/) {
   check_and_cast<StationaryQubit *>(resource_qubit)->applyMemoryError();
   /*Target qubit*/ resource_qubit->CNOT_gate(this /*controlled qubit*/);
   this->Hadamard_gate();
-  bool meas = this->correlation_measure_Z() == MeasureZResult::NO_X_ERROR;
+  bool meas = this->correlationMeasureZ() == MeasureZResult::NO_X_ERROR;
   return meas;
 }
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -45,7 +45,7 @@ class StationaryQubit : public IStationaryQubit {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual quisp::types::MeasureXResult measure_X() override;
+  virtual quisp::types::MeasureXResult correlation_measure_X() override;
 
   /**
    * \brief Single Qubit Y measurement.
@@ -53,7 +53,7 @@ class StationaryQubit : public IStationaryQubit {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual types::MeasureYResult measure_Y() override;
+  virtual types::MeasureYResult correlation_measure_Y() override;
 
   /**
    * \brief Single Qubit Z measurement.
@@ -61,7 +61,11 @@ class StationaryQubit : public IStationaryQubit {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual types::MeasureZResult measure_Z() override;
+  virtual types::MeasureZResult correlation_measure_Z() override;
+
+  virtual types::EigenvalueResult local_measure_X() override;
+  virtual types::EigenvalueResult local_measure_Y() override;
+  virtual types::EigenvalueResult local_measure_Z() override;
 
   /**
    * Performs measurement and returns +(true) or -(false) based on the density matrix of the state. Used for tomography.
@@ -134,6 +138,7 @@ class StationaryQubit : public IStationaryQubit {
   measurement_operator Random_Measurement_Basis_Selection();
   void setSingleQubitGateErrorModel(SingleGateErrorModel &model, std::string gate_name);
   void setTwoQubitGateErrorCeilings(TwoQubitGateErrorModel &model, std::string gate_name);
+  void setMeasurementErrorModel(MeasurementErrorModel &model);
   /*Applies memory error to the given qubit*/
   void applyMemoryError();
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -45,7 +45,7 @@ class StationaryQubit : public IStationaryQubit {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual quisp::types::MeasureXResult correlation_measure_X() override;
+  virtual quisp::types::MeasureXResult correlationMeasureX() override;
 
   /**
    * \brief Single Qubit Y measurement.
@@ -53,7 +53,7 @@ class StationaryQubit : public IStationaryQubit {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual types::MeasureYResult correlation_measure_Y() override;
+  virtual types::MeasureYResult correlationMeasureY() override;
 
   /**
    * \brief Single Qubit Z measurement.
@@ -61,11 +61,11 @@ class StationaryQubit : public IStationaryQubit {
    * New errors only occur when wrong measurement result is delivered for feed-forward
    * (The error on the measured qubit propagates to the byproduct gate target qubit).
    */
-  virtual types::MeasureZResult correlation_measure_Z() override;
+  virtual types::MeasureZResult correlationMeasureZ() override;
 
-  virtual types::EigenvalueResult local_measure_X() override;
-  virtual types::EigenvalueResult local_measure_Y() override;
-  virtual types::EigenvalueResult local_measure_Z() override;
+  virtual types::EigenvalueResult localMeasureX() override;
+  virtual types::EigenvalueResult localMeasureY() override;
+  virtual types::EigenvalueResult localMeasureZ() override;
 
   /**
    * Performs measurement and returns +(true) or -(false) based on the density matrix of the state. Used for tomography.

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -103,7 +103,7 @@ class StationaryQubit : public IStationaryQubit {
   SingleGateErrorModel Xgate_error;
   SingleGateErrorModel Zgate_error;
   TwoQubitGateErrorModel CNOTgate_error;
-  SingleGateErrorModel Measurement_error;
+  MeasurementErrorModel Measurement_error;
   memory_error_model memory_err;
   double memory_error_rate;
   double memory_No_error_ceil;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -89,15 +89,6 @@ simple StationaryQubit
         // characteristics of the hardware
         // could eventually change over time if we model dynamic
         // changes to the device
-        double Measurement_error_rate = default(0);
-        double Measurement_X_error_ratio = default(1);
-        double Measurement_Y_error_ratio = default(1);
-        double Measurement_Z_error_ratio = default(1);
-
-        // ZZZ -- these are configured at boot time
-        // characteristics of the hardware
-        // could eventually change over time if we model dynamic
-        // changes to the device
         double Xgate_error_rate = default(0);
         double Xgate_X_error_ratio = default(1);
         double Xgate_Y_error_ratio = default(1);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -127,9 +127,12 @@ simple StationaryQubit
         double CNOTgate_YI_error_ratio = default(1);
         double CNOTgate_YY_error_ratio = default(1);
 
+        double X_measurement_error_rate = default(0);
+        double Y_measurement_error_rate = default(0);
+        double Z_measurement_error_rate = default(0);
         //int ruleset_id = default(-1);
         //int rule_id = default(-1);
         //int action_index = default(-1);
-    gates:
+        gates:
         inout tolens_quantum_port;
 }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -124,6 +124,6 @@ simple StationaryQubit
         //int ruleset_id = default(-1);
         //int rule_id = default(-1);
         //int action_index = default(-1);
-        gates:
+    gates:
         inout tolens_quantum_port;
 }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -47,11 +47,6 @@ class StatQubitTarget : public StationaryQubit {
     setParDouble(this, "Zgate_Z_error_ratio", 1);
     setParDouble(this, "Zgate_Y_error_ratio", 1);
 
-    setParDouble(this, "Measurement_error_rate", 0.6);
-    setParDouble(this, "Measurement_X_error_ratio", 1);
-    setParDouble(this, "Measurement_Y_error_ratio", 1);
-    setParDouble(this, "Measurement_Z_error_ratio", 1);
-
     // clean = 0.1,
     // IX = 0.2, XI = 0.3, XX = 0.4,
     // IZ = 0.5, ZI = 0.6, ZZ = 0.7,

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -67,6 +67,10 @@ class StatQubitTarget : public StationaryQubit {
     setParDouble(this, "CNOTgate_YI_error_ratio", 1);
     setParDouble(this, "CNOTgate_YY_error_ratio", 1);
 
+    setParDouble(this, "X_measurement_error_rate", 1.0 / 2000);
+    setParDouble(this, "Y_measurement_error_rate", 1.0 / 2000);
+    setParDouble(this, "Z_measurement_error_rate", 1.0 / 2000);
+
     setParInt(this, "stationaryQubit_address", 1);
     setParInt(this, "node_address", 1);
     setParInt(this, "qnic_address", 1);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -1,0 +1,616 @@
+#include <gtest/gtest.h>
+#include <test_utils/TestUtils.h>
+#include <unsupported/Eigen/MatrixFunctions>
+#include "StationaryQubit.h"
+#include "modules/QNIC/StationaryQubit/IStationaryQubit.h"
+#include "omnetpp/simtime.h"
+
+using namespace quisp::modules;
+using namespace quisp_test;
+namespace {
+
+class StatQubitTarget : public StationaryQubit {
+ public:
+  using StationaryQubit::addXerror;
+  using StationaryQubit::addZerror;
+  using StationaryQubit::correlation_measure_X;
+  using StationaryQubit::correlation_measure_Y;
+  using StationaryQubit::correlation_measure_Z;
+  using StationaryQubit::initialize;
+  using StationaryQubit::local_measure_X;
+  using StationaryQubit::local_measure_Y;
+  using StationaryQubit::local_measure_Z;
+  using StationaryQubit::par;
+  using StationaryQubit::setMeasurementErrorModel;
+  StatQubitTarget() : StationaryQubit() { setComponentType(new TestModuleType("test qubit")); }
+  void reset() {
+    setParBool(this, "GOD_Xerror", false);
+    setParBool(this, "GOD_Yerror", false);
+    setParBool(this, "GOD_Zerror", false);
+  }
+  void fillParams() {
+    setParDouble(this, "emission_success_probability", 0.5);
+    setParDouble(this, "memory_X_error_rate", 1.11111111e-7);
+    setParDouble(this, "memory_Y_error_rate", 1.11111111e-7);
+    setParDouble(this, "memory_Z_error_rate", 1.11111111e-7);
+    setParDouble(this, "memory_energy_excitation_rate", 0.000198);
+    setParDouble(this, "memory_energy_relaxation_rate", 0.00000198);
+    setParDouble(this, "memory_completely_mixed_rate", 0);
+
+    // No error= 0.4, X error = 0.6, Z error = 0.8, Y error = 1.0
+    setParDouble(this, "Hgate_error_rate", 0.6);
+    setParDouble(this, "Hgate_X_error_ratio", 1);
+    setParDouble(this, "Hgate_Z_error_ratio", 1);
+    setParDouble(this, "Hgate_Y_error_ratio", 1);
+
+    setParDouble(this, "Xgate_error_rate", 0.6);
+    setParDouble(this, "Xgate_X_error_ratio", 1);
+    setParDouble(this, "Xgate_Z_error_ratio", 1);
+    setParDouble(this, "Xgate_Y_error_ratio", 1);
+
+    setParDouble(this, "Zgate_error_rate", 0.6);
+    setParDouble(this, "Zgate_X_error_ratio", 1);
+    setParDouble(this, "Zgate_Z_error_ratio", 1);
+    setParDouble(this, "Zgate_Y_error_ratio", 1);
+
+    setParDouble(this, "Measurement_error_rate", 0.6);
+    setParDouble(this, "Measurement_X_error_ratio", 1);
+    setParDouble(this, "Measurement_Y_error_ratio", 1);
+    setParDouble(this, "Measurement_Z_error_ratio", 1);
+
+    // clean = 0.1,
+    // IX = 0.2, XI = 0.3, XX = 0.4,
+    // IZ = 0.5, ZI = 0.6, ZZ = 0.7,
+    // IY = 0.8, IY = 0.9, YY = 1.0
+    setParDouble(this, "CNOTgate_error_rate", 0.9);
+    setParDouble(this, "CNOTgate_IX_error_ratio", 1);
+    setParDouble(this, "CNOTgate_XI_error_ratio", 1);
+    setParDouble(this, "CNOTgate_XX_error_ratio", 1);
+    setParDouble(this, "CNOTgate_IZ_error_ratio", 1);
+    setParDouble(this, "CNOTgate_ZI_error_ratio", 1);
+    setParDouble(this, "CNOTgate_ZZ_error_ratio", 1);
+    setParDouble(this, "CNOTgate_IY_error_ratio", 1);
+    setParDouble(this, "CNOTgate_YI_error_ratio", 1);
+    setParDouble(this, "CNOTgate_YY_error_ratio", 1);
+
+    setParDouble(this, "X_measurement_error_rate", 1.0 / 2000);
+    setParDouble(this, "Y_measurement_error_rate", 1.0 / 2000);
+    setParDouble(this, "Z_measurement_error_rate", 1.0 / 2000);
+
+    setParInt(this, "stationaryQubit_address", 1);
+    setParInt(this, "node_address", 1);
+    setParInt(this, "qnic_address", 1);
+    setParInt(this, "qnic_type", 0);
+    setParInt(this, "qnic_index", 0);
+    setParDouble(this, "std", 0.5);
+
+    setParDouble(this, "photon_emitted_at", 0.0);
+    setParDouble(this, "last_updated_at", 0.0);
+    setParBool(this, "GOD_Xerror", false);
+    setParBool(this, "GOD_Zerror", false);
+    setParBool(this, "GOD_CMerror", false);
+    setParBool(this, "GOD_EXerror", false);
+    setParBool(this, "GOD_REerror", false);
+    setParBool(this, "isBusy", false);
+    setParInt(this, "GOD_entangled_stationaryQubit_address", 0);
+    setParInt(this, "GOD_entangled_node_address", 0);
+    setParInt(this, "GOD_entangled_qnic_address", 0);
+    setParInt(this, "GOD_entangled_qnic_type", 0);
+    setParDouble(this, "fidelity", -1.0);
+  }
+};
+
+TEST(StatQubitMeasurementTest, SetMeasurementErrorRate) {
+  auto *sim = prepareSimulation();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  setParDouble(qubit, "X_measurement_error_rate", 0.1);
+  setParDouble(qubit, "Y_measurement_error_rate", 0.2);
+  setParDouble(qubit, "Z_measurement_error_rate", 0.4);
+  sim->registerComponent(qubit);
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  auto &error_model = qubit->Measurement_error;
+  EXPECT_FALSE(std::isnan(error_model.X_measurement_error_rate));
+  EXPECT_FALSE(std::isnan(error_model.Y_measurement_error_rate));
+  EXPECT_FALSE(std::isnan(error_model.Z_measurement_error_rate));
+  EXPECT_DOUBLE_EQ(error_model.X_measurement_error_rate, 0.1);
+  EXPECT_DOUBLE_EQ(error_model.Y_measurement_error_rate, 0.2);
+  EXPECT_DOUBLE_EQ(error_model.Z_measurement_error_rate, 0.4);
+}
+
+TEST(StatQubitMeasurementTest, CorrelationMeasureXwithoutError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+}
+
+TEST(StatQubitMeasurementTest, CorrelationMeasureXwithError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+
+  // X error
+  qubit->addXerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+
+  // Y error
+  qubit->addZerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+
+  // Z error
+  qubit->addXerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+}
+
+TEST(StatQubitMeasurementTest, CorrelationMeasureYwithoutError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+}
+
+TEST(StatQubitMeasurementTest, CorrelationMeasureYwithError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+
+  // X error
+  qubit->addXerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+
+  // Y error
+  qubit->addZerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+
+  // Z error
+  qubit->addXerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+}
+
+TEST(StatQubitMeasurementTest, CorrelationMeasureZwithoutError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+}
+
+TEST(StatQubitMeasurementTest, CorrelationMeasureZwithError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+
+  // X error
+  qubit->addXerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+
+  // Y error
+  qubit->addZerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+
+  // Z error
+  qubit->addXerror();
+  rng->doubleValue = 0.5;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+  rng->doubleValue = 1.0 / 3000;
+  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+}
+
+TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  auto *another_qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  another_qubit->fillParams();
+  qubit->entangled_partner = another_qubit;
+  another_qubit->entangled_partner = qubit;
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+}
+
+TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  auto *another_qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  another_qubit->fillParams();
+  setParDouble(qubit, "X_measurement_error_rate", 0.99);
+  qubit->entangled_partner = another_qubit;
+  another_qubit->entangled_partner = qubit;
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+}
+
+TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  auto *another_qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  another_qubit->fillParams();
+  qubit->entangled_partner = another_qubit;
+  another_qubit->entangled_partner = qubit;
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+}
+
+TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
+  auto *sim = prepareSimulation();
+  auto *rng = useTestRNG();
+  auto *qubit = new StatQubitTarget{};
+  auto *another_qubit = new StatQubitTarget{};
+  qubit->fillParams();
+  another_qubit->fillParams();
+  setParDouble(qubit, "Z_measurement_error_rate", 0.99);
+  qubit->entangled_partner = another_qubit;
+  another_qubit->entangled_partner = qubit;
+  qubit->setMeasurementErrorModel(qubit->Measurement_error);
+  sim->registerComponent(qubit);
+
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_FALSE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.7;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+
+  qubit->reset();
+  another_qubit->reset();
+  qubit->addZerror();
+  qubit->addXerror();
+  rng->doubleValue = 0.3;
+  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_TRUE(qubit->par("GOD_Xerror"));
+  EXPECT_TRUE(qubit->par("GOD_Zerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
+  EXPECT_FALSE(another_qubit->par("GOD_Zerror"));
+}
+
+}  // end namespace

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -13,13 +13,13 @@ class StatQubitTarget : public StationaryQubit {
  public:
   using StationaryQubit::addXerror;
   using StationaryQubit::addZerror;
-  using StationaryQubit::correlation_measure_X;
-  using StationaryQubit::correlation_measure_Y;
-  using StationaryQubit::correlation_measure_Z;
+  using StationaryQubit::correlationMeasureX;
+  using StationaryQubit::correlationMeasureY;
+  using StationaryQubit::correlationMeasureZ;
   using StationaryQubit::initialize;
-  using StationaryQubit::local_measure_X;
-  using StationaryQubit::local_measure_Y;
-  using StationaryQubit::local_measure_Z;
+  using StationaryQubit::localMeasureX;
+  using StationaryQubit::localMeasureY;
+  using StationaryQubit::localMeasureZ;
   using StationaryQubit::par;
   using StationaryQubit::setMeasurementErrorModel;
   StatQubitTarget() : StationaryQubit() { setComponentType(new TestModuleType("test qubit")); }
@@ -121,9 +121,9 @@ TEST(StatQubitMeasurementTest, CorrelationMeasureXwithoutError) {
   qubit->setMeasurementErrorModel(qubit->Measurement_error);
   sim->registerComponent(qubit);
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::NO_Z_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::HAS_Z_ERROR);
 }
 
 TEST(StatQubitMeasurementTest, CorrelationMeasureXwithError) {
@@ -137,23 +137,23 @@ TEST(StatQubitMeasurementTest, CorrelationMeasureXwithError) {
   // X error
   qubit->addXerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::NO_Z_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::HAS_Z_ERROR);
 
   // Y error
   qubit->addZerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::HAS_Z_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::NO_Z_ERROR);
 
   // Z error
   qubit->addXerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::HAS_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::HAS_Z_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_X(), quisp::types::MeasureXResult::NO_Z_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureX(), quisp::types::MeasureXResult::NO_Z_ERROR);
 }
 
 TEST(StatQubitMeasurementTest, CorrelationMeasureYwithoutError) {
@@ -164,9 +164,9 @@ TEST(StatQubitMeasurementTest, CorrelationMeasureYwithoutError) {
   qubit->setMeasurementErrorModel(qubit->Measurement_error);
   sim->registerComponent(qubit);
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::NO_XZ_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
 }
 
 TEST(StatQubitMeasurementTest, CorrelationMeasureYwithError) {
@@ -180,23 +180,23 @@ TEST(StatQubitMeasurementTest, CorrelationMeasureYwithError) {
   // X error
   qubit->addXerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::NO_XZ_ERROR);
 
   // Y error
   qubit->addZerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::NO_XZ_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
 
   // Z error
   qubit->addXerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::HAS_XZ_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Y(), quisp::types::MeasureYResult::NO_XZ_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureY(), quisp::types::MeasureYResult::NO_XZ_ERROR);
 }
 
 TEST(StatQubitMeasurementTest, CorrelationMeasureZwithoutError) {
@@ -207,9 +207,9 @@ TEST(StatQubitMeasurementTest, CorrelationMeasureZwithoutError) {
   qubit->setMeasurementErrorModel(qubit->Measurement_error);
   sim->registerComponent(qubit);
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::NO_X_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::HAS_X_ERROR);
 }
 
 TEST(StatQubitMeasurementTest, CorrelationMeasureZwithError) {
@@ -223,23 +223,23 @@ TEST(StatQubitMeasurementTest, CorrelationMeasureZwithError) {
   // X error
   qubit->addXerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::HAS_X_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::NO_X_ERROR);
 
   // Y error
   qubit->addZerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::HAS_X_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::NO_X_ERROR);
 
   // Z error
   qubit->addXerror();
   rng->doubleValue = 0.5;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::NO_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::NO_X_ERROR);
   rng->doubleValue = 1.0 / 3000;
-  EXPECT_EQ(qubit->correlation_measure_Z(), quisp::types::MeasureZResult::HAS_X_ERROR);
+  EXPECT_EQ(qubit->correlationMeasureZ(), quisp::types::MeasureZResult::HAS_X_ERROR);
 }
 
 TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
@@ -255,7 +255,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   sim->registerComponent(qubit);
 
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -264,7 +264,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -274,7 +274,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -284,7 +284,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -294,7 +294,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -304,7 +304,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -315,7 +315,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -326,7 +326,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -347,7 +347,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   sim->registerComponent(qubit);
 
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -356,7 +356,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -366,7 +366,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -376,7 +376,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -386,7 +386,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -396,7 +396,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -407,7 +407,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -418,7 +418,7 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_X(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -438,7 +438,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   sim->registerComponent(qubit);
 
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -447,7 +447,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -457,7 +457,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -467,7 +467,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -477,7 +477,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -487,7 +487,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -498,7 +498,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -509,7 +509,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -530,7 +530,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   sim->registerComponent(qubit);
 
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -539,7 +539,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -549,7 +549,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -559,7 +559,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_FALSE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -569,7 +569,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -579,7 +579,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_FALSE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));
@@ -590,7 +590,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.7;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::MINUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_TRUE(another_qubit->par("GOD_Xerror"));
@@ -601,7 +601,7 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   qubit->addZerror();
   qubit->addXerror();
   rng->doubleValue = 0.3;
-  EXPECT_EQ(qubit->local_measure_Z(), quisp::types::EigenvalueResult::PLUS_ONE);
+  EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
   EXPECT_TRUE(qubit->par("GOD_Xerror"));
   EXPECT_TRUE(qubit->par("GOD_Zerror"));
   EXPECT_FALSE(another_qubit->par("GOD_Xerror"));

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -53,11 +53,6 @@ class StatQubitTarget : public StationaryQubit {
     setParDouble(this, "Zgate_Z_error_ratio", 1);
     setParDouble(this, "Zgate_Y_error_ratio", 1);
 
-    setParDouble(this, "Measurement_error_rate", 0.6);
-    setParDouble(this, "Measurement_X_error_ratio", 1);
-    setParDouble(this, "Measurement_Y_error_ratio", 1);
-    setParDouble(this, "Measurement_Z_error_ratio", 1);
-
     // clean = 0.1,
     // IX = 0.2, XI = 0.3, XX = 0.4,
     // IZ = 0.5, ZI = 0.6, ZZ = 0.7,
@@ -110,12 +105,12 @@ TEST(StatQubitMeasurementTest, SetMeasurementErrorRate) {
   sim->registerComponent(qubit);
   qubit->setMeasurementErrorModel(qubit->Measurement_error);
   auto &error_model = qubit->Measurement_error;
-  EXPECT_FALSE(std::isnan(error_model.X_measurement_error_rate));
-  EXPECT_FALSE(std::isnan(error_model.Y_measurement_error_rate));
-  EXPECT_FALSE(std::isnan(error_model.Z_measurement_error_rate));
-  EXPECT_DOUBLE_EQ(error_model.X_measurement_error_rate, 0.1);
-  EXPECT_DOUBLE_EQ(error_model.Y_measurement_error_rate, 0.2);
-  EXPECT_DOUBLE_EQ(error_model.Z_measurement_error_rate, 0.4);
+  EXPECT_FALSE(std::isnan(error_model.x_error_rate));
+  EXPECT_FALSE(std::isnan(error_model.y_error_rate));
+  EXPECT_FALSE(std::isnan(error_model.z_error_rate));
+  EXPECT_DOUBLE_EQ(error_model.x_error_rate, 0.1);
+  EXPECT_DOUBLE_EQ(error_model.y_error_rate, 0.2);
+  EXPECT_DOUBLE_EQ(error_model.z_error_rate, 0.4);
 }
 
 TEST(StatQubitMeasurementTest, CorrelationMeasureXwithoutError) {

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -44,11 +44,6 @@ class StatQubitTarget : public StationaryQubit {
     setParDouble(this, "Zgate_Z_error_ratio", 0);
     setParDouble(this, "Zgate_Y_error_ratio", 0);
 
-    setParDouble(this, "Measurement_error_rate", 1 / 2000);
-    setParDouble(this, "Measurement_X_error_ratio", 1);
-    setParDouble(this, "Measurement_Y_error_ratio", 1);
-    setParDouble(this, "Measurement_Z_error_ratio", 1);
-
     setParDouble(this, "CNOTgate_error_rate", 1 / 2000);
     setParDouble(this, "CNOTgate_IX_error_ratio", 1);
     setParDouble(this, "CNOTgate_XI_error_ratio", 1);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -60,6 +60,10 @@ class StatQubitTarget : public StationaryQubit {
     setParDouble(this, "CNOTgate_YI_error_ratio", 1);
     setParDouble(this, "CNOTgate_YY_error_ratio", 1);
 
+    setParDouble(this, "X_measurement_error_rate", 1. / 2000);
+    setParDouble(this, "Y_measurement_error_rate", 1. / 2000);
+    setParDouble(this, "Z_measurement_error_rate", 1. / 2000);
+
     setParInt(this, "stationaryQubit_address", 1);
     setParInt(this, "node_address", 1);
     setParInt(this, "qnic_address", 1);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -46,11 +46,6 @@ class StatQubitTarget : public StationaryQubit {
     setParDouble(this, "Zgate_Z_error_ratio", 0);
     setParDouble(this, "Zgate_Y_error_ratio", 0);
 
-    setParDouble(this, "Measurement_error_rate", 1 / 2000);
-    setParDouble(this, "Measurement_X_error_ratio", 1);
-    setParDouble(this, "Measurement_Y_error_ratio", 1);
-    setParDouble(this, "Measurement_Z_error_ratio", 1);
-
     setParDouble(this, "CNOTgate_error_rate", 1 / 2000);
     setParDouble(this, "CNOTgate_IX_error_ratio", 1);
     setParDouble(this, "CNOTgate_XI_error_ratio", 1);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -62,6 +62,10 @@ class StatQubitTarget : public StationaryQubit {
     setParDouble(this, "CNOTgate_YI_error_ratio", 1);
     setParDouble(this, "CNOTgate_YY_error_ratio", 1);
 
+    setParDouble(this, "X_measurement_error_rate", 1. / 2000);
+    setParDouble(this, "Y_measurement_error_rate", 1. / 2000);
+    setParDouble(this, "Z_measurement_error_rate", 1. / 2000);
+
     setParInt(this, "stationaryQubit_address", 1);
     setParInt(this, "node_address", 1);
     setParInt(this, "qnic_address", 1);

--- a/quisp/rules/actions/SimultaneousSwappingAction.cc
+++ b/quisp/rules/actions/SimultaneousSwappingAction.cc
@@ -59,8 +59,8 @@ cPacket *SimultaneousSwappingAction::run(cModule *re) {
   right_qubit->CNOT_gate(left_qubit);
   left_qubit->Hadamard_gate();
 
-  auto left_measure = left_qubit->correlation_measure_Z();
-  auto right_measure = right_qubit->correlation_measure_Z();
+  auto left_measure = left_qubit->correlationMeasureZ();
+  auto right_measure = right_qubit->correlationMeasureZ();
 
   int operation_type_left, operation_type_right;
 

--- a/quisp/rules/actions/SimultaneousSwappingAction.cc
+++ b/quisp/rules/actions/SimultaneousSwappingAction.cc
@@ -59,8 +59,8 @@ cPacket *SimultaneousSwappingAction::run(cModule *re) {
   right_qubit->CNOT_gate(left_qubit);
   left_qubit->Hadamard_gate();
 
-  auto left_measure = left_qubit->measure_Z();
-  auto right_measure = right_qubit->measure_Z();
+  auto left_measure = left_qubit->correlation_measure_Z();
+  auto right_measure = right_qubit->correlation_measure_Z();
 
   int operation_type_left, operation_type_right;
 

--- a/quisp/rules/actions/SwappingAction.cc
+++ b/quisp/rules/actions/SwappingAction.cc
@@ -59,8 +59,8 @@ cPacket *SwappingAction::run(cModule *re) {
   int lindex = left_partner_qubit->stationaryQubit_address;
   int rindex = right_partner_qubit->stationaryQubit_address;
 
-  auto left_measure = left_qubit->local_measure_X();
-  auto right_measure = right_qubit->local_measure_Z();
+  auto left_measure = left_qubit->localMeasureX();
+  auto right_measure = right_qubit->localMeasureZ();
 
   // RuleEngine::updateResources_EntanglementSwapping handles the operation type.
   // operation_type: 0 = I, 1 = X, 2 = Z

--- a/quisp/rules/actions/SwappingAction.cc
+++ b/quisp/rules/actions/SwappingAction.cc
@@ -60,8 +60,8 @@ cPacket *SwappingAction::run(cModule *re) {
   int lindex = left_partner_qubit->stationaryQubit_address;
   int rindex = right_partner_qubit->stationaryQubit_address;
 
-  auto left_measure = left_qubit->measure_Z();
-  auto right_measure = right_qubit->measure_Z();
+  auto left_measure = left_qubit->correlation_measure_Z();
+  auto right_measure = right_qubit->correlation_measure_Z();
 
   // RuleEngine::updateResources_EntanglementSwapping handles the operation type.
   int operation_type_left, operation_type_right;

--- a/quisp/rules/actions/SwappingAction_test.cc
+++ b/quisp/rules/actions/SwappingAction_test.cc
@@ -186,8 +186,8 @@ TEST_F(SwappingActionTest, runWithMeasuredResult00) {
   left_partner_qubit->entangled_partner = left_qubit;
 
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
-  EXPECT_CALL(*left_qubit, local_measure_X()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
-  EXPECT_CALL(*right_qubit, local_measure_Z()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
+  EXPECT_CALL(*left_qubit, localMeasureX()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
+  EXPECT_CALL(*right_qubit, localMeasureZ()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
   EXPECT_CALL(*left_partner_qubit, setEntangledPartnerInfo(right_partner_qubit));
   EXPECT_CALL(*right_partner_qubit, setEntangledPartnerInfo(left_partner_qubit));
 
@@ -224,8 +224,8 @@ TEST_F(SwappingActionTest, runWithMeasuredResult01) {
   left_partner_qubit->entangled_partner = left_qubit;
 
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
-  EXPECT_CALL(*left_qubit, local_measure_X()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
-  EXPECT_CALL(*right_qubit, local_measure_Z()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
+  EXPECT_CALL(*left_qubit, localMeasureX()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
+  EXPECT_CALL(*right_qubit, localMeasureZ()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
   EXPECT_CALL(*right_partner_qubit, setEntangledPartnerInfo(left_partner_qubit));
   EXPECT_CALL(*left_partner_qubit, setEntangledPartnerInfo(right_partner_qubit));
 
@@ -262,8 +262,8 @@ TEST_F(SwappingActionTest, runWithMeasuredResult10) {
   left_partner_qubit->entangled_partner = left_qubit;
 
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
-  EXPECT_CALL(*left_qubit, local_measure_X()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
-  EXPECT_CALL(*right_qubit, local_measure_Z()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
+  EXPECT_CALL(*left_qubit, localMeasureX()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
+  EXPECT_CALL(*right_qubit, localMeasureZ()).WillOnce(Return(quisp::types::EigenvalueResult::PLUS_ONE));
   EXPECT_CALL(*right_partner_qubit, setEntangledPartnerInfo(left_partner_qubit));
   EXPECT_CALL(*left_partner_qubit, setEntangledPartnerInfo(right_partner_qubit));
 
@@ -300,8 +300,8 @@ TEST_F(SwappingActionTest, runWithMeasuredResult11) {
   left_partner_qubit->entangled_partner = left_qubit;
 
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
-  EXPECT_CALL(*left_qubit, local_measure_X()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
-  EXPECT_CALL(*right_qubit, local_measure_Z()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
+  EXPECT_CALL(*left_qubit, localMeasureX()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
+  EXPECT_CALL(*right_qubit, localMeasureZ()).WillOnce(Return(quisp::types::EigenvalueResult::MINUS_ONE));
   EXPECT_CALL(*right_partner_qubit, setEntangledPartnerInfo(left_partner_qubit));
   EXPECT_CALL(*left_partner_qubit, setEntangledPartnerInfo(right_partner_qubit));
 

--- a/quisp/rules/actions/SwappingAction_test.cc
+++ b/quisp/rules/actions/SwappingAction_test.cc
@@ -175,12 +175,12 @@ TEST_F(SwappingActionTest, runWithNoError) {
   right_qubit->entangled_partner = left_qubit;
   left_qubit->entangled_partner = right_qubit;
 
-  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
+  EXPECT_CALL(*right_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
   EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit));
   EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit));
   EXPECT_CALL(*left_qubit, Hadamard_gate());
-  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
+  EXPECT_CALL(*left_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
   EXPECT_CALL(*action, getResource(23, 24)).WillOnce(Return(left_qubit));
@@ -210,12 +210,12 @@ TEST_F(SwappingActionTest, runWithRightHasError) {
   right_qubit->entangled_partner = left_qubit;
   left_qubit->entangled_partner = right_qubit;
 
-  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
+  EXPECT_CALL(*right_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
   EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit));
   EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit));
   EXPECT_CALL(*left_qubit, Hadamard_gate());
-  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
+  EXPECT_CALL(*left_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
   EXPECT_CALL(*action, getResource(23, 24)).WillOnce(Return(left_qubit));
@@ -244,12 +244,12 @@ TEST_F(SwappingActionTest, runWithLeftHasError) {
   right_qubit->entangled_partner = left_qubit;
   left_qubit->entangled_partner = right_qubit;
 
-  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
+  EXPECT_CALL(*right_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::NO_X_ERROR));
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
   EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit));
   EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit));
   EXPECT_CALL(*left_qubit, Hadamard_gate());
-  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
+  EXPECT_CALL(*left_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
   EXPECT_CALL(*action, getResource(23, 24)).WillOnce(Return(left_qubit));
@@ -278,12 +278,12 @@ TEST_F(SwappingActionTest, runWithBothErrors) {
   right_qubit->entangled_partner = left_qubit;
   left_qubit->entangled_partner = right_qubit;
 
-  EXPECT_CALL(*right_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
+  EXPECT_CALL(*right_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
   EXPECT_CALL(*right_qubit, CNOT_gate(left_qubit));
   EXPECT_CALL(*right_qubit, setEntangledPartnerInfo(left_qubit));
   EXPECT_CALL(*left_qubit, setEntangledPartnerInfo(right_qubit));
   EXPECT_CALL(*left_qubit, Hadamard_gate());
-  EXPECT_CALL(*left_qubit, measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
+  EXPECT_CALL(*left_qubit, correlation_measure_Z()).WillOnce(Return(quisp::types::MeasureZResult::HAS_X_ERROR));
 
   EXPECT_CALL(*action, getResource(21, 22)).WillOnce(Return(right_qubit));
   EXPECT_CALL(*action, getResource(23, 24)).WillOnce(Return(left_qubit));

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -93,6 +93,10 @@ class MockQubit : public IStationaryQubit {
     setParDouble(this, "CNOTgate_YI_error_ratio", 1);
     setParDouble(this, "CNOTgate_YY_error_ratio", 1);
 
+    setParDouble(this, "X_measurement_error_rate", 1. / 2000);
+    setParDouble(this, "Y_measurement_error_rate", 1. / 2000);
+    setParDouble(this, "Z_measurement_error_rate", 1. / 2000);
+
     setParInt(this, "stationaryQubit_address", 1);
     setParInt(this, "node_address", 1);
     setParInt(this, "qnic_address", 1);

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -77,11 +77,6 @@ class MockQubit : public IStationaryQubit {
     setParDouble(this, "Zgate_Z_error_ratio", 0);
     setParDouble(this, "Zgate_Y_error_ratio", 0);
 
-    setParDouble(this, "Measurement_error_rate", 1 / 2000);
-    setParDouble(this, "Measurement_X_error_ratio", 1);
-    setParDouble(this, "Measurement_Y_error_ratio", 1);
-    setParDouble(this, "Measurement_Z_error_ratio", 1);
-
     setParDouble(this, "CNOTgate_error_rate", 1 / 2000);
     setParDouble(this, "CNOTgate_IX_error_ratio", 1);
     setParDouble(this, "CNOTgate_XI_error_ratio", 1);

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -22,12 +22,12 @@ class MockQubit : public IStationaryQubit {
   using IStationaryQubit::par;
   MOCK_METHOD(void, emitPhoton, (int pulse), (override));
   MOCK_METHOD(void, setFree, (bool consumed), (override));
-  MOCK_METHOD(quisp::types::MeasureZResult, correlation_measure_Z, (), (override));
-  MOCK_METHOD(quisp::types::MeasureXResult, correlation_measure_X, (), (override));
-  MOCK_METHOD(quisp::types::MeasureYResult, correlation_measure_Y, (), (override));
-  MOCK_METHOD(quisp::types::EigenvalueResult, local_measure_X, (), (override));
-  MOCK_METHOD(quisp::types::EigenvalueResult, local_measure_Y, (), (override));
-  MOCK_METHOD(quisp::types::EigenvalueResult, local_measure_Z, (), (override));
+  MOCK_METHOD(quisp::types::MeasureZResult, correlationMeasureZ, (), (override));
+  MOCK_METHOD(quisp::types::MeasureXResult, correlationMeasureX, (), (override));
+  MOCK_METHOD(quisp::types::MeasureYResult, correlationMeasureY, (), (override));
+  MOCK_METHOD(quisp::types::EigenvalueResult, localMeasureX, (), (override));
+  MOCK_METHOD(quisp::types::EigenvalueResult, localMeasureY, (), (override));
+  MOCK_METHOD(quisp::types::EigenvalueResult, localMeasureZ, (), (override));
   MOCK_METHOD(bool, Xpurify, (IStationaryQubit *), (override));
   MOCK_METHOD(bool, Zpurify, (IStationaryQubit *), (override));
   MOCK_METHOD(void, addXerror, (), (override));

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -22,9 +22,12 @@ class MockQubit : public IStationaryQubit {
   using IStationaryQubit::par;
   MOCK_METHOD(void, emitPhoton, (int pulse), (override));
   MOCK_METHOD(void, setFree, (bool consumed), (override));
-  MOCK_METHOD(quisp::types::MeasureZResult, measure_Z, (), (override));
-  MOCK_METHOD(quisp::types::MeasureXResult, measure_X, (), (override));
-  MOCK_METHOD(quisp::types::MeasureYResult, measure_Y, (), (override));
+  MOCK_METHOD(quisp::types::MeasureZResult, correlation_measure_Z, (), (override));
+  MOCK_METHOD(quisp::types::MeasureXResult, correlation_measure_X, (), (override));
+  MOCK_METHOD(quisp::types::MeasureYResult, correlation_measure_Y, (), (override));
+  MOCK_METHOD(quisp::types::EigenvalueResult, local_measure_X, (), (override));
+  MOCK_METHOD(quisp::types::EigenvalueResult, local_measure_Y, (), (override));
+  MOCK_METHOD(quisp::types::EigenvalueResult, local_measure_Z, (), (override));
   MOCK_METHOD(bool, Xpurify, (IStationaryQubit *), (override));
   MOCK_METHOD(bool, Zpurify, (IStationaryQubit *), (override));
   MOCK_METHOD(void, addXerror, (), (override));


### PR DESCRIPTION
I added new functions called "local_measurement" which can only be used with Bell pair when we want the eigenvalues to determine the next operation e.g., entanglement swapping.

This should fix #337 #343

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/351)
<!-- Reviewable:end -->
