### PR TITLE
For different serialization format

### DIFF
--- a/quisp/rules/RuleSet.cc
+++ b/quisp/rules/RuleSet.cc
@@ -13,14 +13,15 @@ Rule *RuleSet::addRule(std::unique_ptr<Rule> rule, std::vector<int> partners) {
   for (int partner : partners) {
     rule->partners.push_back(partner);
   }
-  rule->rule_id = createUniqueId();
+  rule->rule_id = current_rule_id;
+  current_rule_id++;
   rule->parent_ruleset_id = ruleset_id;
   Rule *raw_ptr = rule.get();
   rules.push_back(std::move(rule));
   return raw_ptr;
 };
 
-json RuleSet::serialize() {
+void RuleSet::serialize_json() {
   // inialize json and put metadata
   json ruleset;
   ruleset["ruleset_id"] = ruleset_id;
@@ -29,20 +30,11 @@ json RuleSet::serialize() {
   for (auto &rule : rules) {
     ruleset["rules"].push_back(rule->serialize());
   }
-  return ruleset;
+  out.json = ruleset;
 };
 
-void RuleSet::deserialize(){};
+void RuleSet::serialize_protobuf() { throw omnetpp::cRuntimeError("Protobuf serialization is not yet implemented"); }
 
-unsigned long RuleSet::createUniqueId() {
-  std::string time = omnetpp::SimTime().str();
-  std::string address = std::to_string(owner_addr);
-  std::string random = std::to_string(std::rand() % 10000000);
-  std::string hash_seed = address + time + random;
-  std::hash<std::string> hash_fn;
-  size_t t = hash_fn(hash_seed);
-  unsigned long id = static_cast<long>(t);
-  return id;
-}
+void RuleSet::deserialize(){};
 
 }  // namespace quisp::rules

--- a/quisp/rules/RuleSet.h
+++ b/quisp/rules/RuleSet.h
@@ -6,6 +6,9 @@
 using json = nlohmann::json;
 namespace quisp::rules {
 
+struct Serialized {
+  json json;
+};
 /**
  * @brief RuleSet class which includes a set of Rule Information
  *
@@ -16,10 +19,13 @@ class RuleSet {
 
   unsigned long ruleset_id;  ///< `ruleset_id` is used for identifying connection
   int owner_addr;  ///< Address of RuleSet owner
+  int current_rule_id = 0;
   std::vector<std::unique_ptr<Rule>> rules;
+  Serialized out;
 
   Rule *addRule(std::unique_ptr<Rule> rule, std::vector<int> partners);
-  json serialize();
+  void serialize_json();
+  void serialize_protobuf();
   void deserialize();
   unsigned long createUniqueId();
 };

--- a/quisp/rules/RuleSet_test.cc
+++ b/quisp/rules/RuleSet_test.cc
@@ -46,16 +46,25 @@ TEST(RuleSetTest, addRule) {
   EXPECT_EQ(ruleset.rules.at(2)->partners.at(1), 3);
 }
 
-TEST(RuleSetTest, metadata_serialize) {
+TEST(RuleSetTest, metadata_serialize_json) {
   prepareSimulation();
   RuleSet ruleset(1234, 2);  // ruleset_id, owner_addr
   auto purification = std::make_unique<Rule>();
   auto rule1 = ruleset.addRule(std::move(purification), {1});  // rule type, partners
 
-  json serialized = ruleset.serialize();
-  EXPECT_EQ(serialized["ruleset_id"], 1234);
-  EXPECT_EQ(serialized["owner_address"], 2);
-  EXPECT_EQ(serialized["num_rules"], 1);
+  ruleset.serialize_json();
+  auto ruleset_json = ruleset.out.json;
+  json expected_json = R"({"ruleset_id": 1234,
+                           "owner_address": 2,
+                           "num_rules": 1,
+                           "rules": [{
+                             "name": "",
+                             "next_rule_id": 0,
+                             "partners": [1],
+                             "rule_id": 0
+                            }]
+                          })"_json;
+  EXPECT_EQ(ruleset_json, expected_json);
 }
 
 TEST(RuleSetTest, deserialize) { prepareSimulation(); }


### PR DESCRIPTION
So far, we only have JSON format for serialization. In this PR, I'd like to include other serialization formats such as [protobuf](https://developers.google.com/protocol-buffers). 

I'm expecting the number of serialization formats won't be larger. Thus, I'll prepare serialization functions for each serialization format.