### PR TITLE
Fix wasm icon

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           submodules: true
       - name: wasm build
-        uses: zigen/omnetpp-wasm@v0.6
+        uses: zigen/omnetpp-wasm@v0.7
       - uses: actions/upload-artifact@v2
         with:
           name: wasm-build

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           submodules: true
       - name: wasm build
-        uses: zigen/omnetpp-wasm@v0.7
+        uses: zigen/omnetpp-wasm@v0.8
       - uses: actions/upload-artifact@v2
         with:
           name: wasm-build

--- a/build.toml
+++ b/build.toml
@@ -6,6 +6,9 @@ ned-folders = [
 	"./channels",
 	"./modules"
 ]
+images = [
+	"./images"
+]
 ini-file = "./networks/omnetpp.ini"
 project-folder = "./quisp"
 output-folder = "./wasm-out"

--- a/build.toml
+++ b/build.toml
@@ -7,7 +7,7 @@ ned-folders = [
 	"./modules"
 ]
 images = [
-	"./images"
+	"./images@quisp/images"
 ]
 ini-file = "./networks/omnetpp.ini"
 project-folder = "./quisp"

--- a/build.toml
+++ b/build.toml
@@ -12,3 +12,6 @@ images = [
 ini-file = "./networks/omnetpp.ini"
 project-folder = "./quisp"
 output-folder = "./wasm-out"
+exec-args =  [
+	"--image-path=/quisp/images"
+]

--- a/build.toml
+++ b/build.toml
@@ -7,7 +7,7 @@ ned-folders = [
 	"./modules"
 ]
 images = [
-	"./images@quisp/images"
+	"./images@./quisp/images"
 ]
 ini-file = "./networks/omnetpp.ini"
 project-folder = "./quisp"


### PR DESCRIPTION
fixed the broken images.
https://github.com/zigen/omnetpp-wasm
https://aqua.sfc.wide.ad.jp/quisp-online/master
<img width="841" alt="スクリーンショット 2022-02-09 16 22 01" src="https://user-images.githubusercontent.com/3610296/153141298-2e4b5a9a-2b49-49ec-9c42-84265412ee84.png">

you can check the latest artifact
https://github.com/zigen/quisp/actions/runs/1816236177

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/380)
<!-- Reviewable:end -->
