### PR TITLE
Active ruleset generation

### DIFF
--- a/quisp/messages/entanglement_swapping_messages.msg
+++ b/quisp/messages/entanglement_swapping_messages.msg
@@ -67,3 +67,8 @@ packet SimultaneousSwappingResult extends Header{
     int index_in_path;
     int path_length_exclude_IR;
 }
+
+packet WaitResult extends Header {
+    unsigned long RuleSet_id;
+    unsigned long Rule_id;
+}

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -75,7 +75,7 @@ void ConnectionManager::handleMessage(cMessage *msg) {
 
     if (actual_dst == my_address) {
       // got ConnectionSetupRequest and return the response
-      respondToRequest_deprecated(req);
+      respondToRequest(req);
       delete msg;
     } else if (actual_src == my_address) {
       // initiator node
@@ -1221,7 +1221,8 @@ std::unique_ptr<Rule> ConnectionManager::waitRule(int partner_address, QNIC_type
   return wait_rule;
 }
 
-std::unique_ptr<Rule> ConnectionManager::tomographyRule(int partner_address, int owner_address, int num_measure, double threshold_fidelity, QNIC_type qnic_type, int qnic_id, std::string name) {
+std::unique_ptr<Rule> ConnectionManager::tomographyRule(int partner_address, int owner_address, int num_measure, double threshold_fidelity, QNIC_type qnic_type, int qnic_id,
+                                                        std::string name) {
   auto tomography_rule = std::make_unique<Rule>(partner_address, qnic_type, qnic_id, true);
   tomography_rule->setName(name);
 

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
@@ -51,7 +51,7 @@ class ConnectionManager : public IConnectionManager {
   int num_of_qnics;
   std::map<int, std::queue<ConnectionSetupRequest *>> connection_setup_buffer;  // key is qnic address
   std::map<int, int> connection_retry_count;  // key is qnic address
-  std::map<int, bool> qnic_res_table;
+  std::vector<int> reserved_qnics = {};  // reserved qnic address table
   std::vector<cMessage *> request_send_timing;  // self message, notification for sending out request
   bool simultaneous_es_enabled;
   bool es_with_purify;
@@ -89,9 +89,9 @@ class ConnectionManager : public IConnectionManager {
 
   std::unique_ptr<Rule> purifyRule(int partner_address, PurType purification_type, double threshold_fidelity, QNIC_type qnic_type, int qnic_id, std::string name = "purification");
   std::unique_ptr<Rule> swapRule(std::vector<int> partner_address, double threshold_fidelity, std::vector<QNIC_type> qnic_type, std::vector<int> qnic_id,
-                                 std::string name = "swapping");
+                                 std::vector<QNIC_type> remote_qnic_type, std::vector<int> remote_qnic_id, std::vector<int> remote_qnic_address, std::string name = "swapping");
   std::unique_ptr<Rule> waitRule(int partner_address, QNIC_type qnic_type, int qnic_id, std::string name = "wait");
-  std::unique_ptr<Rule> tomographyRule(int partner_address, int num_measure, double threshold_fidelity, QNIC_type qnic_type, int qnic_id, std::string name = "tomography");
+  std::unique_ptr<Rule> tomographyRule(int partner_address, int owner_address, int num_measure, double threshold_fidelity, QNIC_type qnic_type, int qnic_id, std::string name = "tomography");
   // Rule generators
   std::unique_ptr<ActiveRule> purificationRule(int partner_address, int purification_type, int num_purification, QNIC_type qnic_type, int qnic_index, unsigned long ruleset_id,
                                                unsigned long rule_id);

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.h
@@ -91,7 +91,8 @@ class ConnectionManager : public IConnectionManager {
   std::unique_ptr<Rule> swapRule(std::vector<int> partner_address, double threshold_fidelity, std::vector<QNIC_type> qnic_type, std::vector<int> qnic_id,
                                  std::vector<QNIC_type> remote_qnic_type, std::vector<int> remote_qnic_id, std::vector<int> remote_qnic_address, std::string name = "swapping");
   std::unique_ptr<Rule> waitRule(int partner_address, QNIC_type qnic_type, int qnic_id, std::string name = "wait");
-  std::unique_ptr<Rule> tomographyRule(int partner_address, int owner_address, int num_measure, double threshold_fidelity, QNIC_type qnic_type, int qnic_id, std::string name = "tomography");
+  std::unique_ptr<Rule> tomographyRule(int partner_address, int owner_address, int num_measure, double threshold_fidelity, QNIC_type qnic_type, int qnic_id,
+                                       std::string name = "tomography");
   // Rule generators
   std::unique_ptr<ActiveRule> purificationRule(int partner_address, int purification_type, int num_purification, QNIC_type qnic_type, int qnic_index, unsigned long ruleset_id,
                                                unsigned long rule_id);

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_rule_generator_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_rule_generator_test.cc
@@ -71,7 +71,7 @@ TEST(ConnectionManagerRuleGenTest, PurificationRule) {
   QNIC_type qnic_type = QNIC_E;
   int qnic_id = 4;
   unsigned long ruleset_id = 5;
-  unsigned long rule_id = 6;
+  int rule_id = 6;
   std::unique_ptr<ActiveRule> rule;
   rule = connection_manager.purificationRule(partner_addr, purification_type, num_purification, qnic_type, qnic_id, ruleset_id, rule_id);
   ASSERT_NE(rule, nullptr);
@@ -130,7 +130,7 @@ TEST(ConnectionManagerRuleGenTest, PurificationRule) {
 TEST(ConnectionManagerRuleGenTest, SwappingRule) {
   ConnectionManager connection_manager;
   unsigned long ruleset_id = 5;
-  unsigned long rule_id = 6;
+  int rule_id = 6;
 
   SwappingConfig conf{
       .left_partner = 40,

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_ruleset_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_ruleset_test.cc
@@ -109,9 +109,12 @@ TEST(ConnectionManagerRuleSetTest, SwapRule) {
   std::vector<int> partner_addr = {1, 3};
   std::vector<QNIC_type> qnic_type = {QNIC_E, QNIC_R};
   std::vector<int> qnic_id = {4, 5};
+  std::vector<QNIC_type> remote_qnic_type = {QNIC_R, QNIC_E};
+  std::vector<int> remote_qnic_id = {3, 6};
+  std::vector<int> remote_qnic_address = {11, 12};
   double threshold_fidelity = 0;
 
-  auto purification_rule = connection_manager.swapRule(partner_addr, threshold_fidelity, qnic_type, qnic_id);
+  auto purification_rule = connection_manager.swapRule(partner_addr, threshold_fidelity, qnic_type, qnic_id, remote_qnic_type, remote_qnic_id, remote_qnic_address);
   EXPECT_EQ(purification_rule->rule_id, -1);
   EXPECT_EQ(purification_rule->name, "swapping");
 
@@ -171,6 +174,18 @@ TEST(ConnectionManagerRuleSetTest, SwapRule) {
          "qnic_id":[
             4,
             5
+         ],
+         "remote_qnic_type":[
+           "QNIC_R",
+           "QNIC_E"
+         ],
+         "remote_qnic_id":[
+           3,
+           6
+         ],
+         "remote_qnic_address":[
+           11,
+           12
          ]
       }
    }
@@ -242,12 +257,13 @@ TEST(ConnectionManagerRuleSetTest, tomographyRule) {
 
   // rule arguments
   int partner_addr = 1;
+  int owner_addr = 2;
   QNIC_type qnic_type = QNIC_E;
   int qnic_id = 4;
   int num_measurement = 5000;
   double threshold_fidelity = 0;
 
-  auto tomography_rule = connection_manager.tomographyRule(partner_addr, num_measurement, threshold_fidelity, qnic_type, qnic_id);
+  auto tomography_rule = connection_manager.tomographyRule(partner_addr, owner_addr, num_measurement, threshold_fidelity, qnic_type, qnic_id);
   EXPECT_EQ(tomography_rule->rule_id, -1);
   EXPECT_EQ(tomography_rule->name, "tomography");
 
@@ -284,6 +300,7 @@ TEST(ConnectionManagerRuleSetTest, tomographyRule) {
       "type":"tomography",
       "options":{
          "num_measure":5000,
+         "owner_address": 2,
          "partner_address":[
             1
          ],

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
@@ -127,14 +127,10 @@ TEST(ConnectionManagerTest, parsePurType) {
   EXPECT_EQ(pur_type, PurType::DOUBLE);
   pur_type = connection_manager->parsePurType("DOUBLE_INV");
   EXPECT_EQ(pur_type, PurType::DOUBLE_INV);
-  pur_type = connection_manager->parsePurType("SSDP_X");
-  EXPECT_EQ(pur_type, PurType::SSDP_X);
-  pur_type = connection_manager->parsePurType("SSDP_Z");
-  EXPECT_EQ(pur_type, PurType::SSDP_Z);
-  pur_type = connection_manager->parsePurType("SSDP_X_INV");
-  EXPECT_EQ(pur_type, PurType::SSDP_X_INV);
-  pur_type = connection_manager->parsePurType("SSDP_Z_INV");
-  EXPECT_EQ(pur_type, PurType::SSDP_Z_INV);
+  pur_type = connection_manager->parsePurType("DSSA");
+  EXPECT_EQ(pur_type, PurType::DSSA);
+  pur_type = connection_manager->parsePurType("DSSA_INV");
+  EXPECT_EQ(pur_type, PurType::DSSA_INV);
   pur_type = connection_manager->parsePurType("DSDA");
   EXPECT_EQ(pur_type, PurType::DSDA);
   pur_type = connection_manager->parsePurType("DSDA_INV");
@@ -176,13 +172,7 @@ TEST(ConnectionManagerTest, RespondToRequest) {
   req->setStack_of_QNICs(2, QNIC_pair_info{.fst = {.type = QNIC_E, .index = 14, .address = 104}, .snd = {.type = QNIC_E, .index = 15, .address = 105}});
   EXPECT_CALL(*routing_daemon, return_QNIC_address_to_destAddr(5)).Times(1).WillOnce(Return(-1));
   EXPECT_CALL(*routing_daemon, return_QNIC_address_to_destAddr(2)).Times(1).WillOnce(Return(106));
-  auto src_info = new ConnectionSetupInfo{.qnic =
-                                              {
-                                                  .type = QNIC_E,
-                                                  .index = 16,
-                                              },
-                                          .neighbor_address = 4,
-                                          .quantum_link_cost = 10};
+  auto src_info = new ConnectionSetupInfo{.qnic = {.type = QNIC_E, .index = 16, .address = 106}, .neighbor_address = 4, .quantum_link_cost = 10};
   EXPECT_CALL(*hardware_monitor, findConnectionInfoByQnicAddr(106)).Times(1).WillOnce(Return(ByMove(std::unique_ptr<ConnectionSetupInfo>(src_info))));
 
   sim->setContext(connection_manager);
@@ -345,6 +335,7 @@ TEST(ConnectionManagerTest, RespondToRequest) {
             "type":"tomography",
             "options":{
                "num_measure":0,
+               "owner_address":2 ,
                "partner_address":[
                   5
                ],
@@ -589,6 +580,18 @@ TEST(ConnectionManagerTest, RespondToRequest) {
                "qnic_type":[
                   "QNIC_E",
                   "QNIC_E"
+               ],
+               "remote_qnic_type":[
+                 "QNIC_E",
+                 "QNIC_E"
+               ],
+               "remote_qnic_id": [
+                 11,
+                 16
+               ],
+               "remote_qnic_address": [
+                 101,
+                 106
                ]
             }
          },
@@ -755,6 +758,18 @@ TEST(ConnectionManagerTest, RespondToRequest) {
                "qnic_type":[
                   "QNIC_E",
                   "QNIC_E"
+               ],
+               "remote_qnic_type":[
+                 "QNIC_E",
+                 "QNIC_E"
+               ],
+               "remote_qnic_id":[
+                 13,
+                 16
+               ],
+               "remote_qnic_address": [
+                 103,
+                 106
                ]
             }
          },
@@ -1034,6 +1049,7 @@ TEST(ConnectionManagerTest, RespondToRequest) {
             "type":"tomography",
             "options":{
                "num_measure":0,
+               "owner_address": 5,
                "partner_address":[
                   2
                ],

--- a/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
+++ b/quisp/modules/QRSA/RuleEngine/IRuleEngine.h
@@ -22,7 +22,7 @@ using namespace rules::active;
 
 typedef struct {
   unsigned long ruleset_id;
-  unsigned long rule_id;
+  int rule_id;
   int index;
 } process_id;
 

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -370,30 +370,26 @@ std::unique_ptr<ActiveRule> RuleEngine::constructRule(std::unique_ptr<ActiveRule
 ActiveCondition *RuleEngine::constructCondition(std::unique_ptr<Condition> condition) {
   auto active_condition = new ActiveCondition();
   auto clauses = std::move(condition->clauses);
-  std::cout<<"size: "<<clauses.size()<<std::endl;
+  std::cout << "size: " << clauses.size() << std::endl;
   for (int i = 0; i < clauses.size(); i++) {
     auto clause = std::move(clauses.at(i));
     if (auto *cond = dynamic_cast<EnoughResourceConditionClause *>(clause.get())) {
       // EnoughResourceClause(partner_address, num_resource)
       auto *resource_clause = new EnoughResourceClause(cond->partner_address, cond->num_resource);
       active_condition->addClause(resource_clause);
-    }
-    else if (auto *cond = dynamic_cast<MeasureCountConditionClause *>(clause.get())) {
+    } else if (auto *cond = dynamic_cast<MeasureCountConditionClause *>(clause.get())) {
       // MeasureCountClause (num_measure)
       auto *measure_count_clause = new MeasureCountClause(cond->num_measure);
       active_condition->addClause(measure_count_clause);
-    }
-    else if (auto *cond = dynamic_cast<WaitConditionClause *>(clause.get())) {
+    } else if (auto *cond = dynamic_cast<WaitConditionClause *>(clause.get())) {
       // WaitClause ()
       auto *wait_clause = new WaitClause();
       active_condition->addClause(wait_clause);
-    }
-    else if (auto *cond = dynamic_cast<FidelityConditionClause *>(clause.get())) {
+    } else if (auto *cond = dynamic_cast<FidelityConditionClause *>(clause.get())) {
       // FidelityClause (partner_addr, resource, fidleity)
       auto *fidelity_clause = new FidelityClause(cond->partner_address, 0, cond->required_fidelity);
       active_condition->addClause(fidelity_clause);
-    }
-    else{
+    } else {
       error("Unknown clause");
     }
   }
@@ -473,8 +469,9 @@ ActiveAction *RuleEngine::constructAction(std::unique_ptr<Action> action, unsign
                            right_remote_qnic_id, right_remote_qnic_address, 0, left_qnic_id, left_qnic_type, right_qnic_id, right_qnic_type);
     return active_action;
   }
-  if (auto *act = dynamic_cast<Tomography *>(action.get())){
-    auto active_action = new RandomMeasureAction(ruleset_id, rule_id, act->owner_address, act->partner_address.at(0), act->qnic_types.at(0), act->qnic_ids.at(0), 0, act->num_measurement);
+  if (auto *act = dynamic_cast<Tomography *>(action.get())) {
+    auto active_action =
+        new RandomMeasureAction(ruleset_id, rule_id, act->owner_address, act->partner_address.at(0), act->qnic_types.at(0), act->qnic_ids.at(0), 0, act->num_measurement);
     return active_action;
   }
 }

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.h
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.h
@@ -113,7 +113,10 @@ class RuleEngine : public IRuleEngine {
 
   void updateResources_EntanglementSwapping(swapping_result swapr);
 
-  ActiveRuleSet *constructActiveRuleSet(RuleSet ruleset);
+  std::unique_ptr<ActiveRuleSet> constructActiveRuleSet(RuleSet ruleset);
+  std::unique_ptr<ActiveRule> constructRule(std::unique_ptr<ActiveRule> active_rule, std::unique_ptr<Rule> rule, unsigned long ruleset_id);
+  ActiveCondition *constructCondition(std::unique_ptr<Condition> condition);
+  ActiveAction *constructAction(std::unique_ptr<Action> action, unsigned long ruleset_id, int rule_id);
   virtual void updateResources_SimultaneousEntanglementSwapping(swapping_result swapr);
 
   utils::ComponentProvider provider;

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine_test.cc
@@ -391,7 +391,7 @@ TEST(RuleEngineTest, activeRuleSetConstruction) {
     EXPECT_EQ(access_private::dst(*action), 5);
     EXPECT_EQ(access_private::current_count(*action), 0);
     EXPECT_EQ(access_private::max_count(*action), 0);
-    std::cout<<"here?"<<std::endl;
+    std::cout << "here?" << std::endl;
 
     ASSERT_EQ(rule->condition->clauses.size(), 2);
     auto* measure_count_clause = dynamic_cast<MeasureCountClause*>(rule->condition.get()->clauses.at(0));

--- a/quisp/rules/Action.cc
+++ b/quisp/rules/Action.cc
@@ -32,7 +32,9 @@ void Purification::deserialize_json(json serialized) {
   }
 }
 
-EntanglementSwapping::EntanglementSwapping(std::vector<int> partner_addr, std::vector<QNIC_type> qnic_type, std::vector<int> qnic_id) : Action(partner_addr, qnic_type, qnic_id) {}
+EntanglementSwapping::EntanglementSwapping(std::vector<int> partner_addr, std::vector<QNIC_type> qnic_type, std::vector<int> qnic_id, std::vector<QNIC_type> remote_qnic_type,
+                                           std::vector<int> remote_qnic_id, std::vector<int> remote_qnic_address)
+    : Action(partner_addr, qnic_type, qnic_id), remote_qnic_types(remote_qnic_type), remote_qnic_ids(remote_qnic_id), remote_qnic_address(remote_qnic_address) {}
 
 json EntanglementSwapping::serialize_json() {
   json swapping_json;
@@ -40,6 +42,9 @@ json EntanglementSwapping::serialize_json() {
   swapping_json["options"]["partner_address"] = partner_address;  // should be two
   swapping_json["options"]["qnic_type"] = qnic_types;
   swapping_json["options"]["qnic_id"] = qnic_ids;
+  swapping_json["options"]["remote_qnic_type"] = remote_qnic_types;
+  swapping_json["options"]["remote_qnic_id"] = remote_qnic_ids;
+  swapping_json["options"]["remote_qnic_address"] = remote_qnic_address;
   return swapping_json;
 }
 
@@ -50,6 +55,9 @@ void EntanglementSwapping::deserialize_json(json serialized) {
     options["partner_address"].get_to(partner_address);
     options["qnic_type"].get_to(qnic_types);
     options["qnic_id"].get_to(qnic_ids);
+    options["remote_qnic_type"].get_to(remote_qnic_types);
+    options["remote_qnic_id"].get_to(remote_qnic_ids);
+    options["remote_qnic_address"].get_to(remote_qnic_address);
   }
 }
 
@@ -74,12 +82,13 @@ void Wait::deserialize_json(json serialized) {
   }
 }
 
-Tomography::Tomography(int num_measurement, int partner_addr, QNIC_type qnic_type, int qnic_id) : Action(partner_addr, qnic_type, qnic_id), num_measurement(num_measurement) {}
+Tomography::Tomography(int num_measurement, int owner_addr, int partner_addr, QNIC_type qnic_type, int qnic_id) : Action(partner_addr, qnic_type, qnic_id), owner_address(owner_addr), num_measurement(num_measurement) {}
 
 json Tomography::serialize_json() {
   json tomography_json;
   tomography_json["type"] = "tomography";
   tomography_json["options"]["num_measure"] = num_measurement;
+  tomography_json["options"]["owner_address"] = owner_address;
   tomography_json["options"]["partner_address"] = partner_address;
   tomography_json["options"]["qnic_type"] = qnic_types;
   tomography_json["options"]["qnic_id"] = qnic_ids;
@@ -91,6 +100,7 @@ void Tomography::deserialize_json(json serialized) {
   if (options != nullptr) {
     // get options one by one
     options["num_measure"].get_to(num_measurement);
+    options["owner_address"].get_to(owner_address);
     options["partner_address"].get_to(partner_address);
     options["qnic_type"].get_to(qnic_types);
     options["qnic_id"].get_to(qnic_ids);

--- a/quisp/rules/Action.cc
+++ b/quisp/rules/Action.cc
@@ -82,7 +82,8 @@ void Wait::deserialize_json(json serialized) {
   }
 }
 
-Tomography::Tomography(int num_measurement, int owner_addr, int partner_addr, QNIC_type qnic_type, int qnic_id) : Action(partner_addr, qnic_type, qnic_id), owner_address(owner_addr), num_measurement(num_measurement) {}
+Tomography::Tomography(int num_measurement, int owner_addr, int partner_addr, QNIC_type qnic_type, int qnic_id)
+    : Action(partner_addr, qnic_type, qnic_id), owner_address(owner_addr), num_measurement(num_measurement) {}
 
 json Tomography::serialize_json() {
   json tomography_json;

--- a/quisp/rules/Action.h
+++ b/quisp/rules/Action.h
@@ -13,10 +13,8 @@ enum PurType : int {
   SINGLE_Z,  ///< Single purification for Z error
   DOUBLE,  ///< Double purification both for X and Z errors
   DOUBLE_INV,  ///< Double inverse purification both for X and Z errors
-  SSDP_X,  ///< Single Selection and Double Purification (DoubleSelectionAction) for X error
-  SSDP_Z,  ///< Single Selection and Double Purification (DoubleSelectionAction) for Z error
-  SSDP_X_INV,  ///< Single Selection and Double Purification Inverse (DoubleSelectionAction) for X error
-  SSDP_Z_INV,  ///< Single Selection and Double Purification Inverse (DoubleSelectionAction) for Z error
+  DSSA,  ///< Double selection XZ and single action (DoubleSelectionAction) for X error
+  DSSA_INV,  ///< Inverse Double selection XZ and single action(DoubleSelectionAction) for X error
   DSDA,  ///< Double Selection and Dual Action for both X and Z errors
   DSDA_INV,  ///< Inverse Double Selection and Dual Action for both X and Z errors
   DSDA_SECOND,  ///< Different type of Double Selection and Dual Action for both X and Z errors
@@ -29,10 +27,8 @@ NLOHMANN_JSON_SERIALIZE_ENUM(PurType, {
                                           {SINGLE_Z, "SINGLE_Z"},
                                           {DOUBLE, "DOUBLE"},
                                           {DOUBLE_INV, "DOUBLE_INV"},
-                                          {SSDP_X, "SSDP_X"},
-                                          {SSDP_Z, "SSDP_Z"},
-                                          {SSDP_X_INV, "SSDP_X_INV"},
-                                          {SSDP_Z_INV, "SSDP_Z_INV"},
+                                          {DSSA, "DSSA"},
+                                          {DSSA_INV, "DSSA_INV"},
                                           {DSDA, "DSDA"},
                                           {DSDA_INV, "DSDA_INV"},
                                           {DSDA_SECOND, "DSDA_SECOND"},
@@ -64,7 +60,11 @@ class Purification : public Action {
 class EntanglementSwapping : public Action {
  public:
   EntanglementSwapping(json serialized) { deserialize_json(serialized); }  // for deserialization
-  EntanglementSwapping(std::vector<int> partner_addr, std::vector<QNIC_type> qnic_type, std::vector<int> qnic_id);
+  EntanglementSwapping(std::vector<int> partner_addr, std::vector<QNIC_type> qnic_type, std::vector<int> qnic_id, std::vector<QNIC_type> remote_qnic_type,
+                       std::vector<int> remote_qnic_id, std::vector<int> remote_qnic_address);
+  std::vector<QNIC_type> remote_qnic_types;  // qnic type of partner's interface
+  std::vector<int> remote_qnic_ids;  // qnic id of partner's interface
+  std::vector<int> remote_qnic_address;  // qnic_address of partner's interface
   json serialize_json() override;
   void deserialize_json(json serialized) override;
 };
@@ -80,8 +80,9 @@ class Wait : public Action {
 class Tomography : public Action {
  public:
   Tomography(json serialized) { deserialize_json(serialized); }  // for deserialization
-  Tomography(int num_measurement, int partner_addr, QNIC_type qnic_type, int qnic_id);
+  Tomography(int num_measurement, int owner_addr, int partner_addr, QNIC_type qnic_type, int qnic_id);
   int num_measurement;
+  int owner_address;
   json serialize_json() override;
   void deserialize_json(json serialized) override;
 };

--- a/quisp/rules/Action_serialize_test.cc
+++ b/quisp/rules/Action_serialize_test.cc
@@ -44,7 +44,10 @@ TEST(ActionTest, EntanglementSwapping_serialize_json) {
   std::vector<int> partners = {1, 3};
   std::vector<QNIC_type> qnic_types = {QNIC_E, QNIC_RP};
   std::vector<int> qnic_ids = {13, 15};
-  auto swapping = std::make_unique<EntanglementSwapping>(partners, qnic_types, qnic_ids);
+  std::vector<QNIC_type> remote_qnic_types = {QNIC_R, QNIC_E};
+  std::vector<int> remote_qnic_ids = {12, 16};
+  std::vector<int> remote_qnic_address = {21, 22};
+  auto swapping = std::make_unique<EntanglementSwapping>(partners, qnic_types, qnic_ids, remote_qnic_types, remote_qnic_ids, remote_qnic_address);
   json swapping_json = swapping->serialize_json();
   EXPECT_EQ(swapping_json["type"], "swapping");
   EXPECT_EQ(swapping_json["options"]["partner_address"][0], 1);
@@ -53,6 +56,12 @@ TEST(ActionTest, EntanglementSwapping_serialize_json) {
   EXPECT_EQ(swapping_json["options"]["qnic_type"][1], "QNIC_RP");
   EXPECT_EQ(swapping_json["options"]["qnic_id"][0], 13);
   EXPECT_EQ(swapping_json["options"]["qnic_id"][1], 15);
+  EXPECT_EQ(swapping_json["options"]["remote_qnic_type"][0], "QNIC_R");
+  EXPECT_EQ(swapping_json["options"]["remote_qnic_type"][1], "QNIC_E");
+  EXPECT_EQ(swapping_json["options"]["remote_qnic_id"][0], 12);
+  EXPECT_EQ(swapping_json["options"]["remote_qnic_id"][1], 16);
+  EXPECT_EQ(swapping_json["options"]["remote_qnic_address"][0], 21);
+  EXPECT_EQ(swapping_json["options"]["remote_qnic_address"][1], 22);
 }
 
 TEST(ActionTest, EntanglementSwapping_deserialize_json) {
@@ -62,7 +71,10 @@ TEST(ActionTest, EntanglementSwapping_deserialize_json) {
     "options": {
       "partner_address": [1, 3],
       "qnic_type": ["QNIC_R", "QNIC_RP"],
-      "qnic_id": [30, 32]
+      "qnic_id": [30, 32],
+      "remote_qnic_type": ["QNIC_E", "QNIC_E"],
+      "remote_qnic_id": [29, 33],
+      "remote_qnic_address": [13, 14]
       }
     })");
   auto empty_swapping = std::make_unique<EntanglementSwapping>(serialized);
@@ -72,6 +84,12 @@ TEST(ActionTest, EntanglementSwapping_deserialize_json) {
   EXPECT_EQ(empty_swapping->qnic_types.at(1), QNIC_RP);
   EXPECT_EQ(empty_swapping->qnic_ids.at(0), 30);
   EXPECT_EQ(empty_swapping->qnic_ids.at(1), 32);
+  EXPECT_EQ(empty_swapping->remote_qnic_types.at(0), QNIC_E);
+  EXPECT_EQ(empty_swapping->remote_qnic_types.at(1), QNIC_E);
+  EXPECT_EQ(empty_swapping->remote_qnic_ids.at(0), 29);
+  EXPECT_EQ(empty_swapping->remote_qnic_ids.at(1), 33);
+  EXPECT_EQ(empty_swapping->remote_qnic_address.at(0), 13);
+  EXPECT_EQ(empty_swapping->remote_qnic_address.at(1), 14);
 }
 
 TEST(ActionTest, Wait_serialize_json) {
@@ -104,10 +122,11 @@ TEST(ActionTest, Wait_deserialize_json) {
 TEST(ActionTest, Tomography_serialize_json) {
   prepareSimulation();
   // num measure
-  auto tomography = std::make_unique<Tomography>(1000, 3, QNIC_E, 15);
+  auto tomography = std::make_unique<Tomography>(1000, 2, 3, QNIC_E, 15);
   json tomography_json = tomography->serialize_json();
   EXPECT_EQ(tomography_json["type"], "tomography");
   EXPECT_EQ(tomography_json["options"]["num_measure"], 1000);
+  EXPECT_EQ(tomography_json["options"]["owner_address"], 2);
   EXPECT_EQ(tomography_json["options"]["partner_address"][0], 3);
   EXPECT_EQ(tomography_json["options"]["qnic_type"][0], "QNIC_E");
   EXPECT_EQ(tomography_json["options"]["qnic_id"][0], 15);
@@ -119,6 +138,7 @@ TEST(ActionTest, Tomography_deserialize_json) {
     "type": "tomography",
     "options": {
       "num_measure": 1000,
+      "owner_address": 2,
       "partner_address": [1],
       "qnic_type": ["QNIC_R"],
       "qnic_id": [30]
@@ -126,6 +146,7 @@ TEST(ActionTest, Tomography_deserialize_json) {
     })");
   auto empty_tomography = std::make_unique<Tomography>(serialized);
   EXPECT_EQ(empty_tomography->num_measurement, 1000);
+  EXPECT_EQ(empty_tomography->owner_address, 2);
   EXPECT_EQ(empty_tomography->partner_address.at(0), 1);
   EXPECT_EQ(empty_tomography->qnic_types.at(0), QNIC_R);
   EXPECT_EQ(empty_tomography->qnic_ids.at(0), 30);

--- a/quisp/rules/Active/ActiveAction.h
+++ b/quisp/rules/Active/ActiveAction.h
@@ -9,6 +9,7 @@
 #include "actions/RandomMeasureAction.h"
 #include "actions/SimultaneousSwappingAction.h"
 #include "actions/SwappingAction.h"
+#include "actions/WaitAction.h"
 
 namespace quisp::rules::active {
 
@@ -25,5 +26,6 @@ using actions::PurifyAction;
 using actions::RandomMeasureAction;
 using actions::SimultaneousSwappingAction;
 using actions::SwappingAction;
+using actions::WaitAction;
 
 }  // namespace quisp::rules::active

--- a/quisp/rules/Active/ActiveRule.cc
+++ b/quisp/rules/Active/ActiveRule.cc
@@ -5,7 +5,7 @@ using quisp::messages::ConditionNotSatisfied;
 
 namespace quisp::rules::active {
 
-ActiveRule::ActiveRule(unsigned long ruleset_id, unsigned long rule_id, std::string rule_name, std::vector<int> action_partners)
+ActiveRule::ActiveRule(unsigned long ruleset_id, int rule_id, std::string rule_name, std::vector<int> action_partners)
     : ruleset_id(ruleset_id), rule_id(rule_id), name(rule_name), action_partners(action_partners){};
 
 void ActiveRule::addResource(int address_entangled_with, IStationaryQubit *qubit) { resources.insert(std::make_pair(address_entangled_with, qubit)); }

--- a/quisp/rules/Active/ActiveRule.h
+++ b/quisp/rules/Active/ActiveRule.h
@@ -8,9 +8,9 @@
 namespace quisp::rules::active {
 class ActiveRule {
  public:
-  const unsigned long ruleset_id;
-  const unsigned long rule_id;
-  unsigned long next_rule_id = 0;
+  unsigned long ruleset_id;
+  int rule_id;
+  int next_rule_id = 0;
   std::string name;
   std::unique_ptr<ActiveCondition> condition;
   std::unique_ptr<ActiveAction> action;
@@ -18,7 +18,7 @@ class ActiveRule {
   std::vector<int> action_partners;
   std::vector<int> next_action_partners;  // if this rule extends the entanglement
 
-  ActiveRule(unsigned long ruleset_id, unsigned long rule_id, std::string rule_name = "", std::vector<int> action_partners = {});
+  ActiveRule(unsigned long ruleset_id, int rule_id, std::string rule_name = "", std::vector<int> action_partners = {});
 
   void addResource(int address_entangled_with, IStationaryQubit *qubit);
   void setCondition(ActiveCondition *c);

--- a/quisp/rules/Active/ActiveRuleSet.h
+++ b/quisp/rules/Active/ActiveRuleSet.h
@@ -10,7 +10,7 @@ namespace quisp::rules::active {
 class ActiveRuleSet {
  public:
   ActiveRuleSet(unsigned long _ruleset_id, int _owner_addr);
-  unsigned long ruleset_id;
+  const unsigned long ruleset_id;
   int owner_addr;
   std::vector<std::unique_ptr<ActiveRule>> rules;
 

--- a/quisp/rules/Active/actions/WaitAction.cc
+++ b/quisp/rules/Active/actions/WaitAction.cc
@@ -1,0 +1,13 @@
+#include "WaitAction.h"
+#include <messages/classical_messages.h>
+#include <modules/QRSA/RuleEngine/IRuleEngine.h>
+
+namespace quisp::rules::active::actions {
+  cPacket *WaitAction::run(cModule *re) {
+    auto *pk = new WaitResult;
+    pk->setKind(6);
+    pk->setRuleSet_id(ruleset_id);
+    pk->setRule_id(rule_id);
+    return pk;
+  }
+}  // namespace quisp::rules::active::actions

--- a/quisp/rules/Active/actions/WaitAction.cc
+++ b/quisp/rules/Active/actions/WaitAction.cc
@@ -3,11 +3,11 @@
 #include <modules/QRSA/RuleEngine/IRuleEngine.h>
 
 namespace quisp::rules::active::actions {
-  cPacket *WaitAction::run(cModule *re) {
-    auto *pk = new WaitResult;
-    pk->setKind(6);
-    pk->setRuleSet_id(ruleset_id);
-    pk->setRule_id(rule_id);
-    return pk;
-  }
+cPacket *WaitAction::run(cModule *re) {
+  auto *pk = new WaitResult;
+  pk->setKind(6);
+  pk->setRuleSet_id(ruleset_id);
+  pk->setRule_id(rule_id);
+  return pk;
+}
 }  // namespace quisp::rules::active::actions

--- a/quisp/rules/Active/actions/WaitAction.h
+++ b/quisp/rules/Active/actions/WaitAction.h
@@ -3,9 +3,9 @@
 #include "BaseAction.h"
 
 namespace quisp::rules::active::actions {
-  class WaitAction:public ActiveAction{
-    public:
-      WaitAction(unsigned long ruleset_id, int rule_id): ActiveAction(ruleset_id, rule_id){}
-      cPacket* run(cModule* re) override;
-  };
-} // namespace quisp::rules::active::actions
+class WaitAction : public ActiveAction {
+ public:
+  WaitAction(unsigned long ruleset_id, int rule_id) : ActiveAction(ruleset_id, rule_id) {}
+  cPacket* run(cModule* re) override;
+};
+}  // namespace quisp::rules::active::actions

--- a/quisp/rules/Active/actions/WaitAction.h
+++ b/quisp/rules/Active/actions/WaitAction.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "BaseAction.h"
+
+namespace quisp::rules::active::actions {
+  class WaitAction:public ActiveAction{
+    public:
+      WaitAction(unsigned long ruleset_id, int rule_id): ActiveAction(ruleset_id, rule_id){}
+      cPacket* run(cModule* re) override;
+  };
+} // namespace quisp::rules::active::actions

--- a/quisp/rules/Rule.cc
+++ b/quisp/rules/Rule.cc
@@ -56,12 +56,16 @@ void Rule::deserialize_json(json serialized) {
     // check which action to be initialized
     if (action_name == "purification") {
       auto purification_action = std::make_unique<Purification>(serialized_action);
+      setAction(std::move(purification_action));
     } else if (action_name == "swapping") {
       auto swapping_action = std::make_unique<EntanglementSwapping>(serialized_action);
+      setAction(std::move(swapping_action));
     } else if (action_name == "wait") {
       auto wait_action = std::make_unique<Wait>(serialized_action);
+      setAction(std::move(wait_action));
     } else if (action_name == "tomography") {
       auto tomography_action = std::make_unique<Tomography>(serialized_action);
+      setAction(std::move(tomography_action));
     } else {
       throw omnetpp::cRuntimeError("No action type found");
     }
@@ -71,6 +75,7 @@ void Rule::deserialize_json(json serialized) {
   if (serialized["condition"] != nullptr) {  // condition found
     // empty condition
     auto empty_condition = std::make_unique<Condition>(serialized.at("condition"));
+    setCondition(std::move(empty_condition));
   }
 }
 

--- a/quisp/rules/Rule_test.cc
+++ b/quisp/rules/Rule_test.cc
@@ -46,7 +46,7 @@ TEST(RuleTest, serialize_json_purification_rule) {
   auto enough_resource_clause = std::make_unique<EnoughResourceConditionClause>(1, 0.85, 1, QNIC_E, 13);
   condition->addClause(std::move(enough_resource_clause));
   // purification_type, partner_addr, qnic_type, qnic_id
-  auto action = std::make_unique<Purification>(PurType::SSDP_X, 1, QNIC_E, 13);
+  auto action = std::make_unique<Purification>(PurType::DSSA, 1, QNIC_E, 13);
   // add condition and action
   purification->setCondition(std::move(condition));
   purification->setAction(std::move(action));
@@ -75,7 +75,7 @@ TEST(RuleTest, serialize_json_purification_rule) {
   EXPECT_EQ(clause_json["options"]["qnic_id"], 13);
   auto action_json = purification_json["action"];
   EXPECT_EQ(action_json["type"], "purification");
-  EXPECT_EQ(action_json["options"]["purification_type"], "SSDP_X");
+  EXPECT_EQ(action_json["options"]["purification_type"], "DSSA");
   EXPECT_EQ(action_json["options"]["partner_address"][0], 1);
   EXPECT_EQ(action_json["options"]["qnic_type"][0], "QNIC_E");
   EXPECT_EQ(action_json["options"]["qnic_id"][0], 13);
@@ -89,6 +89,9 @@ TEST(RuleTest, serialize_json_swapping_rule) {
   std::vector<int> partners = {1, 3};
   std::vector<QNIC_type> qnic_types = {QNIC_E, QNIC_R};
   std::vector<int> qnic_id = {13, 15};
+  std::vector<QNIC_type> remote_qnic_types = {QNIC_R, QNIC_E};
+  std::vector<int> remote_qnic_id = {12, 16};
+  std::vector<int> remote_qnic_address = {21, 22};
   auto swapping = std::make_unique<Rule>(partners, qnic_types, qnic_id, true);
   swapping->setName("swapping");
   auto condition = std::make_unique<Condition>();
@@ -99,7 +102,7 @@ TEST(RuleTest, serialize_json_swapping_rule) {
   condition->addClause(std::move(enough_resource_clause_left));
   condition->addClause(std::move(enough_resource_clause_right));
 
-  auto action = std::make_unique<EntanglementSwapping>(partners, qnic_types, qnic_id);
+  auto action = std::make_unique<EntanglementSwapping>(partners, qnic_types, qnic_id, remote_qnic_types, remote_qnic_id, remote_qnic_address);
 
   // add condition and action
   swapping->setCondition(std::move(condition));
@@ -163,7 +166,7 @@ TEST(RuleTest, deserialize_json_purification_rule) {
   auto enough_resource_clause = std::make_unique<EnoughResourceConditionClause>(1, 0.85, 1, QNIC_E, 13);
   condition->addClause(std::move(enough_resource_clause));
   // purification_type, partner_addr, qnic_type, qnic_id
-  auto action = std::make_unique<Purification>(PurType::SSDP_X, 1, QNIC_E, 13);
+  auto action = std::make_unique<Purification>(PurType::DSSA, 1, QNIC_E, 13);
   // add condition and action
   purification->setCondition(std::move(condition));
   purification->setAction(std::move(action));


### PR DESCRIPTION
What I did in this PR
- [x] Add function to build up ActiveRuleSet in RuleEngine and tests for it
- [x] Modified Qnic reservation method to fix [bug](https://github.com/sfc-aqua/quisp/issues/384)
- [x] Fixed several clauses and actions to fit the current ActiveRuleSet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/385)
<!-- Reviewable:end -->
