### PR TITLE
Setup dependabot and fix CI error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -7,8 +7,8 @@ jobs:
   all:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Generate doxygen 
+      - uses: actions/checkout@v3
+      - name: Generate doxygen
         uses: mattnotmitt/doxygen-action@v1
       - name: Deploy to github pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           ln -sf /usr/bin/llvm-profdata-12 /usr/bin/llvm-profdata
           ln -sf /usr/bin/llvm-cov-12 /usr/bin/llvm-cov
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: make eigen
         run: make eigen
       - name: generate makefile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
           ln -sf /usr/bin/clang++-12 /usr/bin/clang++
           ln -sf /usr/bin/llvm-profdata-12 /usr/bin/llvm-profdata
           ln -sf /usr/bin/llvm-cov-12 /usr/bin/llvm-cov
+      - name: work around permission issue
+        run: git config --global --add safe.directory /__w/quisp/quisp
       - name: Check out repository
         uses: actions/checkout@v3
       - name: make eigen

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: wasm build

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -4,6 +4,8 @@ jobs:
   build-wasm:
     runs-on: ubuntu-latest
     steps:
+      - name: work around permission issue
+        run: git config --global --add safe.directory /__w/quisp/quisp
       - name: Check out repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
CI won't work because of https://github.blog/2022-04-12-git-security-vulnerability-announced/ 
so in this PR, I fixed it. see also https://github.com/actions/checkout/issues/760#issuecomment-1097501613

and also I set up dependabot to automatically update GitHub Actions deps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/390)
<!-- Reviewable:end -->
