### PR TITLE
Set up coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./quisp/lcov_filtered.info
-          base-path: quisp
       # - name: module tests
       # run: make run-module-test
       - name: Run Simulations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,12 +42,17 @@ jobs:
           opp_makemake -f --deep -O out -i ./makefrag -M release --make-so
           make lcov.info
         working-directory: quisp
-      - name: Run codacy-coverage-reporter
-        if: ${{ github.event_name == 'push' && github.repository == 'sfc-aqua/quisp' }}
-        uses: codacy/codacy-coverage-reporter-action@v1
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: quisp/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./quisp/lcov.info
+      # - name: Run codacy-coverage-reporter
+      #   if: ${{ github.event_name == 'push' && github.repository == 'sfc-aqua/quisp' }}
+      #   uses: codacy/codacy-coverage-reporter-action@v1
+      #   with:
+      #     project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      #     coverage-reports: quisp/lcov.info
       # - name: module tests
       # run: make run-module-test
       - name: Run Simulations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./quisp/lcov_filtered.info
+          base-path: quisp
       # - name: module tests
       # run: make run-module-test
       - name: Run Simulations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,13 +41,13 @@ jobs:
         run: |
           opp_makemake -f --deep -O out -i ./makefrag -M release --make-so
           make lcov.info
-          lcov -r lcov.info googletest/ -o lcov.info
+          lcov -r lcov.info 'googletest/*' -o lcov_filtered.info
         working-directory: quisp
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./quisp/lcov.info
+          path-to-lcov: ./quisp/lcov_filtered.info
       # - name: module tests
       # run: make run-module-test
       - name: Run Simulations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
           apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main"
           apt-get update -y
-          apt install clang-format-12 clang-tidy-12 lldb-12 git -y
+          apt install clang-format-12 clang-tidy-12 lldb-12 git lcov -y
           ln -s /usr/bin/clang-format-12 /usr/bin/clang-format
           ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy
           ln -sf /usr/bin/clang-12 /usr/bin/clang
@@ -41,18 +41,13 @@ jobs:
         run: |
           opp_makemake -f --deep -O out -i ./makefrag -M release --make-so
           make lcov.info
+          lcov -r lcov.info googletest/ -o lcov.info
         working-directory: quisp
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./quisp/lcov.info
-      # - name: Run codacy-coverage-reporter
-      #   if: ${{ github.event_name == 'push' && github.repository == 'sfc-aqua/quisp' }}
-      #   uses: codacy/codacy-coverage-reporter-action@v1
-      #   with:
-      #     project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-      #     coverage-reports: quisp/lcov.info
       # - name: module tests
       # run: make run-module-test
       - name: Run Simulations

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QUISP
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/83c96c45f2684211a8cef800b1d07f81)](https://www.codacy.com/gh/sfc-aqua/quisp/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=sfc-aqua/quisp&amp;utm_campaign=Badge_Grade)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/83c96c45f2684211a8cef800b1d07f81)](https://www.codacy.com/gh/sfc-aqua/quisp/dashboard?utm_source=github.com&utm_medium=referral&utm_content=sfc-aqua/quisp&utm_campaign=Badge_Coverage)
+[![Coverage Status](https://coveralls.io/repos/github/sfc-aqua/quisp/badge.svg?branch=master)](https://coveralls.io/github/sfc-aqua/quisp?branch=master)
 ![github workflow](https://github.com/sfc-aqua/quisp/actions/workflows/main.yml/badge.svg)
 <a href="https://aqua-quisp.slack.com/" rel="nofollow"><img src="https://img.shields.io/badge/join-us%20on%20slack-gray.svg?colorB=red&amp;logo=slack&amp;longCache=true" alt="Slack Widget"></a>
 The Quantum Internet Simulation Package (QuISP) is an event-driven
@@ -180,7 +180,7 @@ Docker, ffmpeg for making videos, etc.), documented in the installation notes.
 
 ## Trying it out on the web
 
-If you just want to take a peek at the basic sample simulation set, we encourage you to try them out on the web ([here](https://aqua.sfc.wide.ad.jp/quisp-online/master/)) which is built using the [WebAssembly](https://webassembly.org). Currently the Wasm version only supports running the pre-configured simulations and users cannot upload custom topology, we are still working on that. Also due to the heavy load of the OMNeT++ and the QuISP itself the performance on the web version is a lot slower than running it locally. 
+If you just want to take a peek at the basic sample simulation set, we encourage you to try them out on the web ([here](https://aqua.sfc.wide.ad.jp/quisp-online/master/)) which is built using the [WebAssembly](https://webassembly.org). Currently the Wasm version only supports running the pre-configured simulations and users cannot upload custom topology, we are still working on that. Also due to the heavy load of the OMNeT++ and the QuISP itself the performance on the web version is a lot slower than running it locally.
 
 ## Building and running locally
 

--- a/quisp/makefrag
+++ b/quisp/makefrag
@@ -64,7 +64,7 @@ $(TARGET_DIR)/coverage.profdata: $(TARGET_DIR)/coverage.profraw
 	llvm-profdata merge -sparse -o $(TARGET_DIR)/coverage.profdata $(TARGET_DIR)/coverage.profraw
 
 $(TARGET_DIR)/lcov.info: $(TARGET_DIR)/coverage.profdata
-	llvm-cov export -instr-profile=./coverage.profdata ./run_unit_test -format=lcov ../ -ignore-filename-regex=".*_test.cc|eigen/.*|.*test_utils/.*|.*_m.h|.*_m.cc" > lcov.info
+	llvm-cov export -instr-profile=./coverage.profdata ./run_unit_test -format=lcov ../ -ignore-filename-regex=".*_test.cc|.*_test_main.cc|googletest/.*|json/.*|eigen/.*|.*test_utils/.*|.*_m.h|.*_m.cc" > lcov.info
 
 $(TARGET_DIR)/coverage/index.html: $(TARGET_DIR)/lcov.info
 	genhtml lcov.info -o $(TARGET_DIR)/coverage


### PR DESCRIPTION
Sometimes Codacy's coverage viewer doesn't work well; for example, it shows only the coverages for the header files.
And also, Codacy only retains a coverage report for the latest commit.

So, I tried the Coveralls, another test coverage service. 
For now, it seems better than Codacy. 
Coveralls has a more straightforward UI, is easy to integrate, and retains the old test coverage details.
You can check the latest coverage report with Coveralls.
https://coveralls.io/github/sfc-aqua/quisp

https://docs.google.com/presentation/d/1rRDltQPfhlwMaiUzHrBvVIk_i8MICMZNxYOpOGUazCc/edit#slide=id.g12525b9f1b8_0_0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/393)
<!-- Reviewable:end -->
