### PR TITLE
use GITHUB_TOKEN instead of GHCR_PAT for external contributors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       image: ghcr.io/sfc-aqua/quisp-ci:latest
       credentials:
         username: quisp-bot
-        password: ${{ secrets.GHCR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: work around permission issue
         run: git config --global --add safe.directory /__w/quisp/quisp
@@ -38,7 +38,7 @@ jobs:
       image: ghcr.io/sfc-aqua/quisp-ci:latest
       credentials:
         username: quisp-bot
-        password: ${{ secrets.GHCR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: work around permission issue
         run: git config --global --add safe.directory /__w/quisp/quisp
@@ -63,7 +63,7 @@ jobs:
       image: ghcr.io/sfc-aqua/quisp-ci:latest
       credentials:
         username: quisp-bot
-        password: ${{ secrets.GHCR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: work around permission issue
         run: git config --global --add safe.directory /__w/quisp/quisp
@@ -85,7 +85,7 @@ jobs:
       image: ghcr.io/sfc-aqua/quisp-ci:latest
       credentials:
         username: quisp-bot
-        password: ${{ secrets.GHCR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: work around permission issue
         run: git config --global --add safe.directory /__w/quisp/quisp


### PR DESCRIPTION
https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/428)
<!-- Reviewable:end -->
