### PR TITLE
Basic Traffic Generator 

### DIFF
--- a/quisp/messages/QNode_ipc_messages.msg
+++ b/quisp/messages/QNode_ipc_messages.msg
@@ -2,7 +2,9 @@ import base_messages;
 
 namespace quisp::messages;
 
-packet deleteThisModule{}
+packet DeleteThisModule{}
+
+packet GenerateTraffic{}
 
 packet ConditionNotSatisfied{}
 

--- a/quisp/modules/Application/Application.cc
+++ b/quisp/modules/Application/Application.cc
@@ -36,8 +36,6 @@ void Application::initialize() {
   my_address = provider.getQNode()->par("address");
   is_initiator = provider.getQNode()->par("isInitiator");
 
-  // WATCH_VECTOR(other_end_node_addresses);
-
   if (!is_initiator) {
     return;
   }
@@ -56,7 +54,7 @@ ConnectionSetupRequest *Application::createConnectionSetupRequest(int dest_addr,
   pk->setActual_destAddr(dest_addr);
   pk->setDestAddr(my_address);
   pk->setSrcAddr(my_address);
-  pk->setNum_measure(num_measure);
+  pk->setNum_measure(num_of_required_resources);
   pk->setKind(7);
   return pk;
 }
@@ -151,7 +149,7 @@ void Application::generateTraffic() {
     send_time = send_time + par("sendIaTime").doubleValue();
     scheduleAt(send_time, pk);
     EV_INFO << "Node " << my_address << " will initiate connection to " << dest_addr << " at " << send_time << " with " << num_request_bell_pair << " Bell pairs\n";
-  } 
+  }
 }
 
 }  // namespace modules

--- a/quisp/modules/Application/Application.cc
+++ b/quisp/modules/Application/Application.cc
@@ -136,7 +136,7 @@ void Application::generateTraffic() {
 
   auto generate_up_to_time = simTime() + 100;
   // if max_sim_time is not defined generate traffic for the next 100s for now
-  if (max_sim_time == 0) {
+  if (max_sim_time != 0) {
     generate_up_to_time = max_sim_time;
     cancelAndDelete(generateTrafficMsg);
   }
@@ -150,14 +150,15 @@ void Application::generateTraffic() {
   std::mt19937 gen;
   gen.seed(time(0));  // if you want different results from different runs
 
-  simtime_t send_time = simTime();
+  simtime_t send_time = simTime() + par("sendIaTime").doubleValue();
 
   while (send_time < generate_up_to_time) {
     int dest_addr = addresses[dist(gen)];
     int num_request_bell_pair = par("numberOfBellpair").intValue();
     ConnectionSetupRequest *pk = createConnectionSetupRequest(dest_addr, num_request_bell_pair);
-    send_time = send_time + par("sendIaTime").doubleValue();
     EV_INFO << "Node " << my_address << " will initiate connection to " << dest_addr << " at " << send_time << " with " << num_request_bell_pair << " Bell pairs\n";
+    scheduleAt(send_time, pk);
+    send_time = send_time + par("sendIaTime").doubleValue();
   }
 }
 

--- a/quisp/modules/Application/Application.h
+++ b/quisp/modules/Application/Application.h
@@ -28,8 +28,10 @@ class Application : public IApplication, public Logger::LoggerBase {
 
  protected:
   int my_address;
+  bool is_initiator;
 
   std::vector<int> other_end_node_addresses;
+  std::unordered_map<int, int> end_node_weight_map;
   bool is_e2e_connection; /**< Does this simulation require end-to-end connection setup?*/
   int number_of_resources;
   int num_measure; /**< The number of measurement between end nodes.*/
@@ -43,6 +45,8 @@ class Application : public IApplication, public Logger::LoggerBase {
   void handleMessage(cMessage *msg) override;
 
   void storeEndNodeAddresses();
+  void createEndNodeWeightMap();
+  void generateTraffic();
   int getOneRandomEndNodeAddress();
 
   messages::ConnectionSetupRequest *createConnectionSetupRequest(int dest_addr, int num_of_required_resources);

--- a/quisp/modules/Application/Application.h
+++ b/quisp/modules/Application/Application.h
@@ -26,6 +26,9 @@ class Application : public IApplication, public Logger::LoggerBase {
   Application();
   ~Application() {}
 
+ private:
+  cMessage *generateTrafficMsg;
+
  protected:
   int my_address;
   bool is_initiator;

--- a/quisp/modules/Application/Application.h
+++ b/quisp/modules/Application/Application.h
@@ -30,24 +30,13 @@ class Application : public IApplication, public Logger::LoggerBase {
   int my_address;
   bool is_initiator;
 
-  std::vector<int> other_end_node_addresses;
   std::unordered_map<int, int> end_node_weight_map;
-  bool is_e2e_connection; /**< Does this simulation require end-to-end connection setup?*/
-  int number_of_resources;
-  int num_measure; /**< The number of measurement between end nodes.*/
-  int traffic_pattern; /**< A type of traffic generation.
-                        * - 0: No traffic
-                        * - 1: From one end node node to random partner node (1 to 1)
-                        * - 2: From all end nodes to random partner nodes (n to n)
-                        */
 
   void initialize() override;
   void handleMessage(cMessage *msg) override;
 
-  void storeEndNodeAddresses();
   void createEndNodeWeightMap();
   void generateTraffic();
-  int getOneRandomEndNodeAddress();
 
   messages::ConnectionSetupRequest *createConnectionSetupRequest(int dest_addr, int num_of_required_resources);
   utils::ComponentProvider provider;

--- a/quisp/modules/Application/Application.ned
+++ b/quisp/modules/Application/Application.ned
@@ -9,13 +9,8 @@ simple Application
     parameters:
         @display("i=block/app");
         int address;
-        volatile double sendIaTime @unit(s) = default(exponential(1s)); // time between generating packets
-        string Other_endnodes_table = "";
-        bool EndToEndConnection = default(false);
-        // removing default here forces app to ask
-        // int TrafficPattern = default(1);
-        int TrafficPattern;
-        int LoneInitiatorAddress;
+        volatile double sendIaTime @unit(s) = default(exponential(5s)); // time between generating packets
+        volatile int numberOfBellpair = default(intuniform(10, 100));
         int distant_measure_count = default(7000);
 
     gates:

--- a/quisp/modules/Application/Application_test.cc
+++ b/quisp/modules/Application/Application_test.cc
@@ -4,6 +4,7 @@
 #include <messages/classical_messages.h>
 #include <omnetpp.h>
 #include <test_utils/TestUtils.h>
+#include <unordered_map>
 
 namespace {
 
@@ -37,106 +38,60 @@ class AppTestTarget : public quisp::modules::Application {
     setComponentType(new TestModuleType("test qnode"));
   }
   virtual ~AppTestTarget() { EVCB.gateDeleted(toRouterGate); }
-  std::vector<int> getOtherEndNodeAdresses() { return this->other_end_node_addresses; }
+  std::unordered_map<int, int> getEndNodeWeightMap() { return this->end_node_weight_map; }
   int getAddress() { return this->my_address; }
 
   TestGate *toRouterGate;
 };
 
-TEST(AppTest, InitSimple) {
+TEST(AppTest, Init_IsNotInitiator) {
   auto *sim = prepareSimulation();
-  auto *mock_qnode = new TestQNode{123};
+  auto *mock_qnode = new TestQNode{123, 100, false};
   auto *app = new AppTestTarget{mock_qnode};
-  setParBool(app, "EndToEndConnection", true);
-  setParInt(app, "num_measure", 1);
-  setParInt(app, "TrafficPattern", 0);
-  setParInt(app, "distant_measure_count", 100);
-  setParInt(app, "LoneInitiatorAddress", 0);
 
   sim->registerComponent(app);
   app->callInitialize();
 
   ASSERT_EQ(app->getAddress(), mock_qnode->address);
-  ASSERT_EQ(app->getOtherEndNodeAdresses().size(), 0);
+  ASSERT_EQ(app->getEndNodeWeightMap().size(), 0);
 }
 
-TEST(AppTest, Init_OneConnection_NoSender) {
+TEST(AppTest, Init_IsInitiator) {
   auto *sim = prepareSimulation();
-  auto *mock_qnode = new TestQNode{123};
+  auto *mock_qnode = new TestQNode{123, 100, true};
   auto *app = new AppTestTarget{mock_qnode};
-  setParBool(app, "EndToEndConnection", true);
-  setParInt(app, "NumberOfResources", 5);
-  setParInt(app, "num_measure", 1);
-  setParInt(app, "TrafficPattern", 1);
-  setParInt(app, "distant_measure_count", 100);
-  setParInt(app, "LoneInitiatorAddress", 0);
+
+  setParBool(mock_qnode, "isInitiator", true);
 
   sim->registerComponent(app);
   app->callInitialize();
 
   ASSERT_EQ(app->getAddress(), mock_qnode->address);
-  ASSERT_EQ(app->getOtherEndNodeAdresses().size(), 0);
+  ASSERT_EQ(app->getEndNodeWeightMap().size(), 1);
+  ASSERT_NE(app->getEndNodeWeightMap().find(123), app->getEndNodeWeightMap().end());
+  ASSERT_EQ(app->getEndNodeWeightMap()[123], 0);
 }
 
-TEST(AppTest, Init_OneConnection_Sender) {
+TEST(AppTest, Init_WeightMap_Generation) {
   auto *sim = prepareSimulation();
-  auto *mock_qnode = new TestQNode{123};
+  auto *mock_qnode = new TestQNode{123, 321, true};
+  auto *mock_qnode2 = new TestQNode{456, 654, false};
+  auto *mock_qnode3 = new TestQNode{789, 987, false};
 
   auto *app = new AppTestTarget{mock_qnode};
-  setParBool(app, "EndToEndConnection", true);
-  setParInt(app, "NumberOfResources", 5);
-  setParInt(app, "num_measure", 1);
-  setParInt(app, "TrafficPattern", 1);
-  setParInt(app, "distant_measure_count", 100);
-  setParInt(app, "LoneInitiatorAddress", mock_qnode->address);
-  sim->registerComponent(app);
 
-  auto *mock_qnode2 = new TestQNode{456};
+  sim->registerComponent(app);
   app->callInitialize();
 
   ASSERT_EQ(app->getAddress(), mock_qnode->address);
-  ASSERT_EQ(app->getOtherEndNodeAdresses().size(), 1);
+  ASSERT_EQ(app->getEndNodeWeightMap().size(), 3);
+  ASSERT_NE(app->getEndNodeWeightMap().find(123), app->getEndNodeWeightMap().end());
+  ASSERT_NE(app->getEndNodeWeightMap().find(456), app->getEndNodeWeightMap().end());
+  ASSERT_NE(app->getEndNodeWeightMap().find(789), app->getEndNodeWeightMap().end());
 
-  sim->run();
-  // assert app sent one message to "toRouter" gate
-  ASSERT_EQ(app->toRouterGate->messages.size(), 1);
-
-  auto *msg = app->toRouterGate->messages.at(0);
-  ASSERT_NE(msg, nullptr);
-
-  auto *pkt = dynamic_cast<ConnectionSetupRequest *>(msg);
-  ASSERT_EQ(pkt->getActual_srcAddr(), 123);
-  ASSERT_EQ(pkt->getActual_destAddr(), mock_qnode2->address);
-  ASSERT_EQ(pkt->getSrcAddr(), 123);
-  ASSERT_EQ(pkt->getDestAddr(), 123);
-}
-
-TEST(AppTest, Init_OneConnection_Sender_TrafficPattern2) {
-  auto *sim = prepareSimulation();
-  auto *mock_qnode = new TestQNode{123};
-  auto *mock_qnode2 = new TestQNode{456};
-  auto *app = new AppTestTarget{mock_qnode};
-  setParBool(app, "EndToEndConnection", true);
-  setParInt(app, "num_measure", 1);
-  setParInt(app, "TrafficPattern", 2);
-  setParInt(app, "distant_measure_count", 100);
-  setParInt(app, "LoneInitiatorAddress", 123);
-  sim->registerComponent(app);
-
-  app->callInitialize();
-  ASSERT_EQ(app->getAddress(), 123);
-  ASSERT_EQ(app->getOtherEndNodeAdresses().size(), 1);
-
-  sim->run();
-  ASSERT_EQ(app->toRouterGate->messages.size(), 1);
-
-  auto *msg = app->toRouterGate->messages.at(0);
-  ASSERT_NE(msg, nullptr);
-  auto *pkt = dynamic_cast<ConnectionSetupRequest *>(msg);
-  ASSERT_EQ(pkt->getActual_srcAddr(), 123);
-  ASSERT_EQ(pkt->getActual_destAddr(), mock_qnode2->address);
-  ASSERT_EQ(pkt->getSrcAddr(), 123);
-  ASSERT_EQ(pkt->getDestAddr(), 123);
+  ASSERT_EQ(app->getEndNodeWeightMap()[123], 0);
+  ASSERT_EQ(app->getEndNodeWeightMap()[456], 654);
+  ASSERT_EQ(app->getEndNodeWeightMap()[789], 987);
 }
 
 }  // namespace

--- a/quisp/modules/QNode.ned
+++ b/quisp/modules/QNode.ned
@@ -12,8 +12,9 @@ module QNode
         int bufferSize = default(10);
         int address = default(0);
         int buffers = default(10); //default is defined as 10 in .ini file but can be changed independently in .ned file
+        int mass = default(100);
+        bool isInitiator = default(false);
         @display("bgl=4");
-        //int numQNIC = 1;
 
         string includeInTopo = "yes";
         string nodeType = default("none");

--- a/quisp/networks/quisp_tutorial.ini
+++ b/quisp/networks/quisp_tutorial.ini
@@ -3,12 +3,12 @@
 **.EndToEndConnection = true
 # when to start the links firing
 **.Initial_notification_timing_buffer = 10 s
+sim-time-limit = 100s
 
 
 [Config Tutorial_MM]
 #from topology_linear_network.ned
 network = Linear_One_MM
-sim-time-limit = 100s
 
 [Config Tutorial_MIM]
 #from topology_linear_network.ned
@@ -25,7 +25,6 @@ network = Linear_One_MIM
 [Config Three_HOM_star]
 # from topology_star_network.ned
 network = Three_HOM_star
-sim-time-limit = 100s
 output-vector-file = "./omtest.vec"
 
 [Config Realistic_Layer2_Simple_MIM_MM_all_in_one]
@@ -38,4 +37,3 @@ network= Realistic_Layer2_Star_Sep
 [Config Tutorial_Big_Q_Network]
 #from topology_complex_network.ned
 network = ispMap_1239_node_23_48
-sim-time-limit = 100s

--- a/quisp/networks/quisp_tutorial.ini
+++ b/quisp/networks/quisp_tutorial.ini
@@ -8,6 +8,7 @@
 [Config Tutorial_MM]
 #from topology_linear_network.ned
 network = Linear_One_MM
+sim-time-limit = 100s
 
 [Config Tutorial_MIM]
 #from topology_linear_network.ned
@@ -24,6 +25,7 @@ network = Linear_One_MIM
 [Config Three_HOM_star]
 # from topology_star_network.ned
 network = Three_HOM_star
+sim-time-limit = 100s
 output-vector-file = "./omtest.vec"
 
 [Config Realistic_Layer2_Simple_MIM_MM_all_in_one]
@@ -36,3 +38,4 @@ network= Realistic_Layer2_Star_Sep
 [Config Tutorial_Big_Q_Network]
 #from topology_complex_network.ned
 network = ispMap_1239_node_23_48
+sim-time-limit = 100s

--- a/quisp/networks/topology_dumbell_network.ini
+++ b/quisp/networks/topology_dumbell_network.ini
@@ -45,8 +45,11 @@ image-path = "./quisp/images"
 **.LoneInitiatorAddress = 1
 
 [Config Dumbell_MM_Topology]
+sim-time-limit = 100s
 network= topology_dumbell_MM
 seed-set = ${0..24}
+*.EndNode1.isInitiator = true
+*.EndNode2.isInitiator = true
 **.num_measure = 7000
 **.buffers = 100
 **.tomography_output_filename = "Dumbell_MM_output"

--- a/quisp/networks/topology_dumbell_network.ini
+++ b/quisp/networks/topology_dumbell_network.ini
@@ -1,6 +1,7 @@
 [General]
 seed-set = ${runnumber}   # this is the default =0 results in the same seed every time
 image-path = "./quisp/images"
+sim-time-limit = 100s
 
 # Qnic
 #**.buffers = intuniform(7,7) 
@@ -45,7 +46,6 @@ image-path = "./quisp/images"
 **.LoneInitiatorAddress = 1
 
 [Config Dumbell_MM_Topology]
-sim-time-limit = 100s
 network= topology_dumbell_MM
 seed-set = ${0..24}
 *.EndNode1.isInitiator = true

--- a/quisp/test_utils/QNode.cc
+++ b/quisp/test_utils/QNode.cc
@@ -11,9 +11,11 @@ using quisp_test::utils::setParBool;
 using quisp_test::utils::setParInt;
 using quisp_test::utils::setParStr;
 
-TestQNode::TestQNode(int addr) : omnetpp::cModule(), address(addr) {
+TestQNode::TestQNode(int addr, int mass, bool is_initiator) : omnetpp::cModule(), address(addr), mass(mass), is_initiator(is_initiator) {
   setParInt(this, "address", addr);
+  setParInt(this, "mass", mass);
   setParStr(this, "nodeType", "qnode");
+  setParBool(this, "isInitiator", is_initiator);
   setComponentType(new TestModuleType("test qnode"));
   setName("TestQNode");
   auto *sim = getTestSimulation();

--- a/quisp/test_utils/QNode.h
+++ b/quisp/test_utils/QNode.h
@@ -7,8 +7,10 @@ namespace qnode {
 
 class TestQNode : public omnetpp::cModule {
  public:
-  explicit TestQNode(int addr);
+  explicit TestQNode(int addr, int mass, bool is_initiator);
   int address;
+  int mass;
+  bool is_initiator;
 };
 }  // namespace qnode
 }  // namespace quisp_test


### PR DESCRIPTION
This changes introduce a new way to generate traffic inside the network. While it is still basic, it is able to generate the same traffic as previous version and more. 

Changes to QNode module:
- it now has 2 additional parameters; `mass` and `isInitiator`
- when the isInitiator is set to true, it will generate traffic defined in Application module

Changes to Application module:
- It now has one new parameter; numberOfBellPairs. 
- remove redundant parameters

**How traffic is generated:**
If the `QNode.isInitiator` is set to `true` connection request will be randomly generated based on the `QNode.Application.sendIaTime` which is a volatile double and the number of Bell pairs requested will be sampled from uniform distribution (10, 100). These two value can be set in `.ini` file if default value is not to be used by users.

Destination is selected based on the mass parameter each QNode has (discrete distribution). 

**How to set parameter to get previous traffic pattern**:

1. No request at all -  set all `QNode.isInitiator` to false (this remove the need for `is_e2e_connection`)
2. One node to be initiator and one node to be responder - set initiator node `isInitiator` to true and responder node to have non-zero mass while other end nodes to have 0 mass.
3. One node to be initiator and randomly select responder - same as (2) but set mass to reflect how the responder should be select
4. All-to-all - set every `QNode.isInitiator` to true and select mass to represent how responders should be sampled
5. Number of request per simulation can be set from `QNode.Application.sendIaTime` 


Additional constraints on this PR:
- Now all simulation must have `sim-time-limit` set to non-zero value otherwise application will output error due to unable to determine how many request will be generated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/437)
<!-- Reviewable:end -->
