### PR TITLE
Setup devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,4 @@
-FROM ghcr.io/sfc-aqua/quisp:latest
-
-
-FROM mcr.microsoft.com/devcontainers/base:0-jammy
-
-
-RUN apt-get update && apt-get install -y --no-install-recommends net-tools iputils-ping openssh-client openssh-server gedit
+FROM ghcr.io/sfc-aqua/quisp-dev:latest
 
 RUN mkdir /var/run/sshd
 RUN echo 'root:coffeeplease' | chpasswd
@@ -15,23 +9,3 @@ ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 EXPOSE 22
 CMD ["/usr/sbin/sshd", "-D"]
-
-
-COPY --from=0 /root/omnetpp /usr/local/share/omnetpp
-
-ARG DEBIAN_FRONTEND=noninteractive
-ARG LLVM_VERSION=13
-ARG OMNETPP_VERSION=6.0.1
-ARG PYTHON_VERSION=3.9
-WORKDIR /root
-RUN wget https://raw.githubusercontent.com/sfc-aqua/omnetpp-dockerfiles/main/install.sh && chmod +x /root/install.sh && /root/install.sh dev
-RUN chmod -R 775 /usr/local/share/omnetpp
-RUN chown -R vscode /usr/local/share/omnetpp
-
-ENV QT_SELECT=5
-ENV OMNETPP_RELEASE=omnetpp-6.0
-ENV __omnetpp_root_dir=/usr/local/share/omnetpp
-ENV QT_LOGGING_RULES=*.debug=false;qt.qpa.*=false
-ENV PYTHONPATH=/usr/local/share/omnetpp/python
-ENV PATH=/usr/local/share/omnetpp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/root/.local/bin
-ENV LD_LIBRARY_PATH=/usr/local/share/omnetpp/lib

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/sfc-aqua/quisp:latest
 
 FROM mcr.microsoft.com/devcontainers/base:0-jammy
 
-COPY --from=0 /root/omnetpp /root/omnetpp
+COPY --from=0 /root/omnetpp /usr/local/share/omnetpp
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LLVM_VERSION=13
@@ -11,10 +11,13 @@ ARG OMNETPP_VERSION=6.0.1
 ARG PYTHON_VERSION=3.9
 WORKDIR /root
 RUN wget https://raw.githubusercontent.com/sfc-aqua/omnetpp-dockerfiles/main/install.sh && chmod +x /root/install.sh && /root/install.sh dev
+RUN chmod -R 775 /usr/local/share/omnetpp
+RUN chown -R vscode /usr/local/share/omnetpp
 
 ENV QT_SELECT=5
 ENV OMNETPP_RELEASE=omnetpp-6.0
-ENV __omnetpp_root_dir=/root/omnetpp
+ENV __omnetpp_root_dir=/usr/local/share/omnetpp
 ENV QT_LOGGING_RULES=*.debug=false;qt.qpa.*=false
-ENV PYTHONPATH=/root/omnetpp/python
-ENV PATH=/root/omnetpp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/root/.local/bin
+ENV PYTHONPATH=/usr/local/share/omnetpp/python
+ENV PATH=/usr/local/share/omnetpp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/root/.local/bin
+ENV LD_LIBRARY_PATH=/usr/local/share/omnetpp/lib

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/sfc-aqua/quisp:latest
+
+
+FROM mcr.microsoft.com/devcontainers/base:0-jammy
+
+COPY --from=0 /root/omnetpp /root/omnetpp
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LLVM_VERSION=13
+ARG OMNETPP_VERSION=6.0.1
+ARG PYTHON_VERSION=3.9
+WORKDIR /root
+RUN wget https://raw.githubusercontent.com/sfc-aqua/omnetpp-dockerfiles/main/install.sh && chmod +x /root/install.sh && /root/install.sh dev
+
+ENV QT_SELECT=5
+ENV OMNETPP_RELEASE=omnetpp-6.0
+ENV __omnetpp_root_dir=/root/omnetpp
+ENV QT_LOGGING_RULES=*.debug=false;qt.qpa.*=false
+ENV PYTHONPATH=/root/omnetpp/python
+ENV PATH=/root/omnetpp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/root/.local/bin

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,20 @@ FROM ghcr.io/sfc-aqua/quisp:latest
 
 FROM mcr.microsoft.com/devcontainers/base:0-jammy
 
+
+RUN apt-get update && apt-get install -y --no-install-recommends net-tools iputils-ping openssh-client openssh-server gedit
+
+RUN mkdir /var/run/sshd
+RUN echo 'root:coffeeplease' | chpasswd
+RUN echo 'vscode:morecoffee' | chpasswd
+RUN sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]
+
+
 COPY --from=0 /root/omnetpp /usr/local/share/omnetpp
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,10 @@
 {
 	"name": "QuISP Dev",
+
+	"containerEnv": {
+		"DOCKER_DEFAULT_PLATFORM": "$(echo $(uname) | tr '[:upper:]' '[:lower:]')/$(uname -i)"
+	},
+
 	"build": {
 		"dockerfile": "Dockerfile"
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,14 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 	"remoteUser": "vscode",
+	"postStartCommand": "sudo service ssh start",
+
+	"forwardPorts": [
+		2222
+	],
+
+	"appPort": "2222:22",
+
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,21 @@
 {
 	"name": "QuISP Dev",
-	"build": {"dockerfile": "Dockerfile"},
-
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
-
-	"remoteUser": "root"
+	"remoteUser": "vscode",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode-remote.remote-containers",
+				"llvm-vs-code-extensions.vscode-clangd",
+				"vadimcn.vscode-lldb",
+				"matepek.vscode-catch2-test-adapter"
+			]
+		}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,18 @@
 		2222
 	],
 
-	"appPort": "2222:22",
+	"appPort": ["2222:22", "5901:5901", "6080:6080"], // [SSH, VNC, noVNC]
+
+	"features": {
+		"ghcr.io/devcontainers/features/desktop-lite:1": {
+			"version": "latest"
+		}
+	},
+
+	/*"runArgs": ["--net-host", "--shm-size=1g"],
+	"remoteEnv": {
+		"DISPLAY": ":0"
+	},*/
 
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+	"name": "QuISP Dev",
+	"build": {"dockerfile": "Dockerfile"},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	"remoteUser": "root"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,8 @@
 {
     "recommendations": [
         "llvm-vs-code-extensions.vscode-clangd"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,5 +4,29 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "UnitTests",
+            "program": "${workspaceFolder}/quisp/run_unit_test",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Simulation",
+            "program": "${workspaceFolder}/quisp/quisp_dbg",
+            "args": [
+                "-n",
+                "./networks:./channels:./modules",
+                "-i",
+                "./images",
+                "./networks/omnetpp.ini",
+                "-u",
+                "Qtenv"
+            ],
+            "cwd": "${workspaceFolder}/quisp"
+        },
     ],
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "build unit test",
             "type": "shell",
-            "command": "make run-unit-test",
+            "command": "make run-unit-test MODE=debug",
             "problemMatcher": [],
             "group": {
                 "kind": "build",
@@ -25,6 +25,12 @@
         },
         {
             "label": "clean",
+            "type": "shell",
+            "command": "make clean",
+            "problemMatcher": [],
+        },
+        {
+            "label": "distclean",
             "type": "shell",
             "command": "make clean",
             "problemMatcher": [],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,7 +32,7 @@
         {
             "label": "distclean",
             "type": "shell",
-            "command": "make clean",
+            "command": "make distclean",
             "problemMatcher": [],
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build unit test",
+            "type": "shell",
+            "command": "make run-unit-test",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "build quisp",
+            "type": "shell",
+            "command": "make exe MODE=debug",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make clean",
+            "problemMatcher": [],
+        },
+        {
+            "label": "format",
+            "type": "shell",
+            "command": "make format",
+            "problemMatcher": [],
+        },
+        {
+            "label": "tidy",
+            "type": "shell",
+            "command": "make tidy",
+            "problemMatcher": [],
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 QUISP_MAKEFILE = "./quisp/Makefile"
-
+NPROC ?= $(shell nproc)
 .PHONY: all tidy format ci makefile-exe makefile-lib checkmakefile googletest clean test coverage coverage-report help quispr
 
 all: makefile-exe
-	$(MAKE) -C quisp -j$(nproc)
+	$(MAKE) -C quisp -j$(NPROC)
 
 run-module-test: lib
 	cd module_tests && ./runtest
 
-run-unit-test: lib googletest
-	$(MAKE) -C quisp run-unit-test
+run-unit-test: makefile-lib googletest
+	$(MAKE) -C quisp run-unit-test -j$(NPROC)
 
 test: run-module-test run-unit-test
 
 exe: makefile-exe
-	$(MAKE) -C quisp -j$(nproc)
+	$(MAKE) -C quisp -j$(NPROC)
 
 lib: makefile-lib
-	$(MAKE) -C quisp -j$(nproc)
+	$(MAKE) -C quisp -j$(NPROC)
 
 msgheaders: checkmakefile
 	$(MAKE) -C quisp msgheaders


### PR DESCRIPTION
This PR allows us to use devcontainer in VSCode, so you don't need to set up OMNeT++ anymore.

https://code.visualstudio.com/docs/devcontainers/containers

## steps on local
1. install and run [docker](https://www.docker.com/get-started/) host. you can confirm it by `$ docker ps`
2. open quisp with vscode
3. perform the task "Dev Containers: Rebuild and Reopen in Container"
<img width="643" alt="Screen Shot 2022-11-04 at 15 01 58" src="https://user-images.githubusercontent.com/3610296/199903021-b3e67432-abeb-42f5-9ba6-14a79f930320.png">

## steps on Codespaces
1. open the QuISP repository and switch to this branch
2. create codespace
<img width="539" alt="Screen Shot 2022-11-15 at 13 25 24" src="https://user-images.githubusercontent.com/3610296/201826106-a4aa64ce-23e1-42c9-a613-90a353f2cc7f.png">
3. wait 
<img width="836" alt="Screen Shot 2022-11-15 at 13 29 56" src="https://user-images.githubusercontent.com/3610296/201826618-d4323832-4f02-4129-82dc-fd1d2795cd36.png">
4. go to the ports config menu (it's right next to the terminal tab). From there, temporarily port forward the PORT 6080. Then the Codespace will kindly generate the access url, forwarding to the port we set. Click that and you're good to go.
<img width="1126" alt="Screen Shot 2022-11-15 at 13 38 21" src="https://user-images.githubusercontent.com/3610296/201827739-8db97a7e-889b-472b-a610-87184455aef6.png">
<img width="375" alt="Screen Shot 2022-11-15 at 13 38 30" src="https://user-images.githubusercontent.com/3610296/201827735-337b4d67-1e2d-4d1e-aea6-4c50d120e2f7.png">

5. go to the VNC tab and send `vscode` for password. then you can see the IDE

6. oepn OMNeT++ IDE by `$ omnetpp` on the integrated terminal


7. set `/workspaces/quisp` for launch and following steps on the [wiki](https://github.com/sfc-aqua/quisp/wiki/Building-QuISP-with-OMNeT-IDE#start-omnet-ide-and-configure-a-workspace-for-quisp) 
<img width="828" alt="Screen Shot 2022-11-15 at 13 41 54" src="https://user-images.githubusercontent.com/3610296/201828108-8b62b9c9-f0cb-4b1b-84e8-6539303c5de4.png">


## limitations
* No bash's git-completion.
* With GitHub Codespaces, Building quisp on OMNeT++ IDE will crash the IDE. Build QuISP with GNU Make

## Security Considerations
the codespaces port forwarding is secure, if you want to access to the generated URL, GitHub requires you to authenticate through GitHub. see also https://docs.github.com/ja/codespaces/codespaces-reference/security-in-github-codespaces

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/439)
<!-- Reviewable:end -->
