### PR TITLE
fix tomography output filename

### DIFF
--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -60,7 +60,7 @@ void HardwareMonitor::initialize(int stage) {
   /*This keeps which node is connected to which local qnic.*/
   tomography_output_filename = par("tomography_output_filename").str();
   // remove double quotes at the beginning and end
-  tomography_output_filename = tomography_output_filename.substr(1, tomography_output_filename.length() - 3);
+  tomography_output_filename = tomography_output_filename.substr(1, tomography_output_filename.length() - 2);
   file_dir_name = par("file_dir_name").str();
   do_link_level_tomography = par("link_tomography");
   num_purification = par("initial_purification");


### PR DESCRIPTION
When we were initializing HardwareMonitor.cc, we failed in removing double quotes from tomography_output_filename.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/440)
<!-- Reviewable:end -->
