### PR TITLE
Speedup stationary qubit

### DIFF
--- a/quisp/backends/ErrorTracking/types.h
+++ b/quisp/backends/ErrorTracking/types.h
@@ -1,3 +1,4 @@
+#include <modules/QNIC/StationaryQubit/IStationaryQubit.h>
 #include <Eigen/Eigen>
 #include <complex>
 
@@ -137,6 +138,14 @@ struct MeasurementErrorModel {
     y_error_rate = y;
     z_error_rate = z;
   }
+};
+
+struct GOD_error_model {
+  bool has_X_error;
+  bool has_Z_error;
+  bool has_EX_error;
+  bool has_RE_error;
+  bool has_CM_error;
 };
 
 // Matrices of single qubit errors. Used when conducting tomography.

--- a/quisp/backends/ErrorTracking/types.h
+++ b/quisp/backends/ErrorTracking/types.h
@@ -141,11 +141,11 @@ struct MeasurementErrorModel {
 };
 
 struct GodErrorState {
-  bool has_X_error;
-  bool has_Z_error;
-  bool has_EX_error;
-  bool has_RE_error;
-  bool has_CM_error;
+  bool has_x_error;
+  bool has_z_error;
+  bool has_excitation_error;
+  bool has_relaxation_error;
+  bool has_completely_mixed_error;
 };
 
 // Matrices of single qubit errors. Used when conducting tomography.

--- a/quisp/backends/ErrorTracking/types.h
+++ b/quisp/backends/ErrorTracking/types.h
@@ -140,7 +140,7 @@ struct MeasurementErrorModel {
   }
 };
 
-struct GOD_error_model {
+struct GodErrorState {
   bool has_X_error;
   bool has_Z_error;
   bool has_EX_error;

--- a/quisp/modules/PhysicalConnection/EPPS/EntangledPhotonPairSource.cc
+++ b/quisp/modules/PhysicalConnection/EPPS/EntangledPhotonPairSource.cc
@@ -30,7 +30,7 @@ PhotonicQubit *EntangledPhotonPairSource::generateEntangledPhotons() {
   // PhotonicQubit *photon_two = new PhotonicQubit();
   // photon_one->addPar("gate") = 0;
   // photon_two->addPar("gate") = 1;
-  // photon->setStationaryQubitEntangledWith(stationaryQubit_address);
+  // photon->setStationaryQubitEntangledWith(stationary_qubit_address);
   // entangledPhotons *qubits;
   // qubits->qubitTwo = photon_two;
   // qubits->qubitOne = photon_one;

--- a/quisp/modules/QNIC.ned
+++ b/quisp/modules/QNIC.ned
@@ -41,7 +41,7 @@ module QNIC
             x_position_graphics = 70 + 80*index;  // use submodule index to generate different IDs
             //@display("p=$x_position_graphics,40,,circle");
             @display("t=Id $stationary_qubit_address;i=block/circle,blue;p=150,100,m,5,60,60"); // modify display string
-            std = parent.emission_std;
+            emission_jittering_standard_deviation = parent.emission_std;
         }
 
         lens: PhotonicSwitch {

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -219,7 +219,7 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   virtual void relax() = 0;
 
   /*GOD parameters*/
-  GOD_error_model GOD_err;
+  GOD_error_model GOD_err{.has_X_error = false, .has_Z_error = false, .has_EX_error = false, .has_RE_error = false, .has_CM_error = false};
   virtual void setEntangledPartnerInfo(IStationaryQubit *partner) = 0;
   virtual void setCompletelyMixedDensityMatrix() = 0;
   virtual void addXerror() = 0;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -120,7 +120,7 @@ struct MeasurementErrorModel {
   double z_error_rate;
 };
 
-struct GOD_error_model {
+struct GodErrorState {
   bool has_X_error;
   bool has_Z_error;
   bool has_EX_error;
@@ -219,7 +219,7 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   virtual void relax() = 0;
 
   /*GOD parameters*/
-  GOD_error_model GOD_err{.has_X_error = false, .has_Z_error = false, .has_EX_error = false, .has_RE_error = false, .has_CM_error = false};
+  GodErrorState GOD_err{.has_X_error = false, .has_Z_error = false, .has_EX_error = false, .has_RE_error = false, .has_CM_error = false};
   virtual void setEntangledPartnerInfo(IStationaryQubit *partner) = 0;
   virtual void setCompletelyMixedDensityMatrix() = 0;
   virtual void addXerror() = 0;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -121,11 +121,11 @@ struct MeasurementErrorModel {
 };
 
 struct GodErrorState {
-  bool has_X_error = false;
-  bool has_Z_error = false;
-  bool has_EX_error = false;
-  bool has_RE_error = false;
-  bool has_CM_error = false;
+  bool has_x_error = false;
+  bool has_z_error = false;
+  bool has_excitation_error = false;
+  bool has_relaxation_error = false;
+  bool has_completely_mixed_error = false;
 };
 
 // Matrices of single qubit errors. Used when conducting tomography.
@@ -219,7 +219,7 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   virtual void relax() = 0;
 
   /*GOD parameters*/
-  GodErrorState GOD_err;
+  GodErrorState god_err;
   virtual void setEntangledPartnerInfo(IStationaryQubit *partner) = 0;
   virtual void setCompletelyMixedDensityMatrix() = 0;
   virtual void addXerror() = 0;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -246,7 +246,7 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   omnetpp::simtime_t updated_time = -1;
 
   /** Standard deviation */
-  double std;
+  double emission_jittering_standard_deviation;
 
   SingleGateErrorModel Hgate_error;
   SingleGateErrorModel Xgate_error;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -115,9 +115,9 @@ struct memory_error_model {
 };
 
 struct MeasurementErrorModel {
-  double X_error_rate;
-  double Y_error_rate;
-  double Z_error_rate;
+  double x_error_rate;
+  double y_error_rate;
+  double z_error_rate;
 };
 
 struct GOD_error_model {

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -115,9 +115,9 @@ struct memory_error_model {
 };
 
 struct MeasurementErrorModel {
-  double x_error_rate;
-  double y_error_rate;
-  double z_error_rate;
+  double X_error_rate;
+  double Y_error_rate;
+  double Z_error_rate;
 };
 
 // Matrices of single qubit errors. Used when conducting tomography.

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -121,11 +121,11 @@ struct MeasurementErrorModel {
 };
 
 struct GodErrorState {
-  bool has_X_error;
-  bool has_Z_error;
-  bool has_EX_error;
-  bool has_RE_error;
-  bool has_CM_error;
+  bool has_X_error = false;
+  bool has_Z_error = false;
+  bool has_EX_error = false;
+  bool has_RE_error = false;
+  bool has_CM_error = false;
 };
 
 // Matrices of single qubit errors. Used when conducting tomography.
@@ -219,7 +219,7 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   virtual void relax() = 0;
 
   /*GOD parameters*/
-  GodErrorState GOD_err{.has_X_error = false, .has_Z_error = false, .has_EX_error = false, .has_RE_error = false, .has_CM_error = false};
+  GodErrorState GOD_err;
   virtual void setEntangledPartnerInfo(IStationaryQubit *partner) = 0;
   virtual void setCompletelyMixedDensityMatrix() = 0;
   virtual void addXerror() = 0;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -120,6 +120,14 @@ struct MeasurementErrorModel {
   double Z_error_rate;
 };
 
+struct GOD_error_model {
+  bool has_X_error;
+  bool has_Z_error;
+  bool has_EX_error;
+  bool has_RE_error;
+  bool has_CM_error;
+};
+
 // Matrices of single qubit errors. Used when conducting tomography.
 struct single_qubit_error {
   Eigen::Matrix2cd X;  // double 2*2 matrix
@@ -211,6 +219,7 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   virtual void relax() = 0;
 
   /*GOD parameters*/
+  GOD_error_model GOD_err;
   virtual void setEntangledPartnerInfo(IStationaryQubit *partner) = 0;
   virtual void setCompletelyMixedDensityMatrix() = 0;
   virtual void addXerror() = 0;
@@ -221,6 +230,10 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   int qnic_address;
   int qnic_type;
   int qnic_index;
+  int GOD_entangled_stationaryQubit_address;
+  int GOD_entangled_node_address;
+  int GOD_entangled_qnic_address;
+  int GOD_entangled_qnic_type;
 
   int action_index;
   bool no_density_matrix_nullptr_entangled_partner_ok;

--- a/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/IStationaryQubit.h
@@ -225,15 +225,15 @@ class IStationaryQubit : public omnetpp::cSimpleModule {
   virtual void addXerror() = 0;
   virtual void addZerror() = 0;
 
-  int stationaryQubit_address;
+  int stationary_qubit_address;
   int node_address;
   int qnic_address;
   int qnic_type;
   int qnic_index;
-  int GOD_entangled_stationaryQubit_address;
-  int GOD_entangled_node_address;
-  int GOD_entangled_qnic_address;
-  int GOD_entangled_qnic_type;
+  int god_entangled_stationary_qubit_address;
+  int god_entangled_node_address;
+  int god_entangled_qnic_address;
+  int god_entangled_qnic_type;
 
   int action_index;
   bool no_density_matrix_nullptr_entangled_partner_ok;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -237,9 +237,9 @@ void StationaryQubit::setTwoQubitGateErrorCeilings(TwoQubitGateErrorModel &model
 }
 
 void StationaryQubit::setMeasurementErrorModel(MeasurementErrorModel &model) {
-  model.X_error_rate = par("X_measurement_error_rate").doubleValue();
-  model.Y_error_rate = par("Y_measurement_error_rate").doubleValue();
-  model.Z_error_rate = par("Z_measurement_error_rate").doubleValue();
+  model.x_error_rate = par("X_measurement_error_rate").doubleValue();
+  model.y_error_rate = par("Y_measurement_error_rate").doubleValue();
+  model.z_error_rate = par("Z_measurement_error_rate").doubleValue();
 }
 
 MeasureXResult StationaryQubit::correlationMeasureX() {

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -59,11 +59,11 @@ void StationaryQubit::initialize() {
     0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.completely_mixed_rate, memory_err.completely_mixed_rate,
     0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, memory_err.relaxation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.relaxation_error_rate;
   // clang-format on
-  god_err.has_x_error = par("god_x_error").boolValue();
-  god_err.has_z_error = par("god_z_error").boolValue();
-  god_err.has_excitation_error = par("god_excitation_error").boolValue();
-  god_err.has_relaxation_error = par("god_relaxation_error").boolValue();
-  god_err.has_completely_mixed_error = par("god_completely_mixed_error").boolValue();
+  god_err.has_x_error = false;
+  god_err.has_z_error = false;
+  god_err.has_excitation_error = false;
+  god_err.has_relaxation_error = false;
+  god_err.has_completely_mixed_error = false;
   setSingleQubitGateErrorModel(Hgate_error, "h_gate");
   setSingleQubitGateErrorModel(Xgate_error, "x_gate");
   setSingleQubitGateErrorModel(Zgate_error, "z_gate");

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -123,6 +123,7 @@ void StationaryQubit::initialize() {
   WATCH(god_err.has_excitation_error);
   WATCH(god_err.has_relaxation_error);
   WATCH(god_err.has_completely_mixed_error);
+  WATCH(is_busy);
 }
 
 void StationaryQubit::finish() {}
@@ -361,7 +362,6 @@ void StationaryQubit::setBusy() {
   updated_time = simTime();  // Should be no error at this time.
   if (hasGUI()) {
     getDisplayString().setTagArg("i", 1, "red");
-    par("is_busy") = true;
   }
 }
 
@@ -397,7 +397,6 @@ void StationaryQubit::setFree(bool consumed) {
   entangled_partner = nullptr;
   EV_DEBUG << "Freeing this qubit!!!" << this << " at qnode: " << node_address << " qnic_type: " << qnic_type << " qnic_index: " << qnic_index << "\n";
   if (hasGUI()) {
-    par("is_busy") = false;
     par("god_entangled_stationary_qubit_address") = -1;
     par("god_entangled_node_address") = -1;
     par("god_entangled_qnic_address") = -1;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -100,7 +100,7 @@ void StationaryQubit::initialize() {
   qnic_address = par("qnic_address");
   qnic_type = par("qnic_type");
   qnic_index = par("qnic_index");
-  std = par("std");
+  emission_jittering_standard_deviation = par("emission_jittering_standard_deviation").doubleValue();
   setFree(false);
 
   /* e^(t/T1) energy relaxation, e^(t/T2) phase relaxation. Want to use only 1/10 of T1 and T2 in general.*/
@@ -470,7 +470,7 @@ void StationaryQubit::emitPhoton(int pulse) {
   if (pulse & STATIONARYQUBIT_PULSE_BEGIN) pk->setFirst(true);
   if (pulse & STATIONARYQUBIT_PULSE_END) pk->setLast(true);
   if (pulse & STATIONARYQUBIT_PULSE_BOUND) pk->setKind(3);
-  float jitter_timing = normal(0, std);
+  float jitter_timing = normal(0, emission_jittering_standard_deviation);
   float abso = fabs(jitter_timing);
   scheduleAt(simTime() + abso, pk);  // cannot send back in time, so only positive lag
 }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -59,15 +59,15 @@ void StationaryQubit::initialize() {
     0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.completely_mixed_rate, memory_err.completely_mixed_rate,
     0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, memory_err.relaxation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.relaxation_error_rate;
   // clang-format on
-  GOD_err.has_X_error = par("GOD_Xerror").boolValue();
-  GOD_err.has_Z_error = par("GOD_Zerror").boolValue();
-  GOD_err.has_EX_error = par("GOD_EXerror").boolValue();
-  GOD_err.has_RE_error = par("GOD_REerror").boolValue();
-  GOD_err.has_CM_error = par("GOD_CMerror").boolValue();
-  setSingleQubitGateErrorModel(Hgate_error, "Hgate");
-  setSingleQubitGateErrorModel(Xgate_error, "Xgate");
-  setSingleQubitGateErrorModel(Zgate_error, "Zgate");
-  setTwoQubitGateErrorCeilings(CNOTgate_error, "CNOTgate");
+  GOD_err.has_X_error = par("god_x_error").boolValue();
+  GOD_err.has_Z_error = par("god_z_error").boolValue();
+  GOD_err.has_EX_error = par("god_excitation_error").boolValue();
+  GOD_err.has_RE_error = par("god_relaxation_error").boolValue();
+  GOD_err.has_CM_error = par("god_completely_mixed_error").boolValue();
+  setSingleQubitGateErrorModel(Hgate_error, "h_gate");
+  setSingleQubitGateErrorModel(Xgate_error, "x_gate");
+  setSingleQubitGateErrorModel(Zgate_error, "z_gate");
+  setTwoQubitGateErrorCeilings(CNOTgate_error, "cnot_gate");
   setMeasurementErrorModel(Measurement_error);
 
   // Set error matrices. This is used in the process of simulating tomography.
@@ -95,11 +95,11 @@ void StationaryQubit::initialize() {
   meas_op.identity << 1, 0, 0, 1;
 
   // Get parameters from omnet
-  GOD_entangled_stationaryQubit_address = par("GOD_entangled_stationaryQubit_address");
-  GOD_entangled_node_address = par("GOD_entangled_node_address");
-  GOD_entangled_qnic_address = par("GOD_entangled_qnic_address");
-  GOD_entangled_qnic_type = par("GOD_entangled_qnic_type");
-  stationaryQubit_address = par("stationaryQubit_address");
+  god_entangled_stationary_qubit_address = par("god_entangled_stationary_qubit_address");
+  god_entangled_node_address = par("god_entangled_node_address");
+  god_entangled_qnic_address = par("god_entangled_qnic_address");
+  god_entangled_qnic_type = par("god_entangled_qnic_type");
+  stationary_qubit_address = par("stationary_qubit_address");
   node_address = par("node_address");
   qnic_address = par("qnic_address");
   qnic_type = par("qnic_type");
@@ -113,7 +113,7 @@ void StationaryQubit::initialize() {
   vertex_operator = CliffordOperator::H;
 
   auto *backend = provider.getQuantumBackend();
-  // qubit_ref = backend->getQubit({node_address, qnic_index, qnic_type, stationaryQubit_address});
+  // qubit_ref = backend->getQubit({node_address, qnic_index, qnic_type, stationary_qubit_address});
 }
 
 void StationaryQubit::finish() {}
@@ -237,9 +237,9 @@ void StationaryQubit::setTwoQubitGateErrorCeilings(TwoQubitGateErrorModel &model
 }
 
 void StationaryQubit::setMeasurementErrorModel(MeasurementErrorModel &model) {
-  model.x_error_rate = par("X_measurement_error_rate").doubleValue();
-  model.y_error_rate = par("Y_measurement_error_rate").doubleValue();
-  model.z_error_rate = par("Z_measurement_error_rate").doubleValue();
+  model.x_error_rate = par("x_measurement_error_rate").doubleValue();
+  model.y_error_rate = par("y_measurement_error_rate").doubleValue();
+  model.z_error_rate = par("z_measurement_error_rate").doubleValue();
 }
 
 MeasureXResult StationaryQubit::correlationMeasureX() {
@@ -355,7 +355,7 @@ void StationaryQubit::setBusy() {
     getDisplayString().setTagArg("i", 1, "red");
     par("photon_emitted_at") = emitted_time.dbl();
     par("last_updated_at") = updated_time.dbl();
-    par("isBusy") = true;
+    par("is_busy") = true;
   }
 }
 
@@ -379,10 +379,10 @@ void StationaryQubit::setFree(bool consumed) {
   GOD_dm_Xerror = false;
   Density_Matrix_Collapsed << -111, -111, -111, -111;
   no_density_matrix_nullptr_entangled_partner_ok = false;
-  GOD_entangled_stationaryQubit_address = -1;
-  GOD_entangled_node_address = -1;
-  GOD_entangled_qnic_address = -1;
-  GOD_entangled_qnic_type = -1;
+  god_entangled_stationary_qubit_address = -1;
+  god_entangled_node_address = -1;
+  god_entangled_qnic_address = -1;
+  god_entangled_qnic_type = -1;
   GOD_err.has_X_error = false;
   GOD_err.has_Z_error = false;
   GOD_err.has_EX_error = false;
@@ -394,16 +394,16 @@ void StationaryQubit::setFree(bool consumed) {
   if (hasGUI()) {
     par("photon_emitted_at") = emitted_time.dbl();
     par("last_updated_at") = updated_time.dbl();
-    par("isBusy") = false;
-    par("GOD_entangled_stationaryQubit_address") = -1;
-    par("GOD_entangled_node_address") = -1;
-    par("GOD_entangled_qnic_address") = -1;
-    par("GOD_entangled_qnic_type") = -1;
-    par("GOD_Xerror") = false;
-    par("GOD_Zerror") = false;
-    par("GOD_EXerror") = false;
-    par("GOD_REerror") = false;
-    par("GOD_CMerror") = false;
+    par("is_busy") = false;
+    par("god_entangled_stationary_qubit_address") = -1;
+    par("god_entangled_node_address") = -1;
+    par("god_entangled_qnic_address") = -1;
+    par("god_entangled_qnic_type") = -1;
+    par("god_x_error") = false;
+    par("god_z_error") = false;
+    par("god_excitation_error") = false;
+    par("god_relaxation_error") = false;
+    par("god_completely_mixed_error") = false;
     if (consumed) {
       bubble("Consumed!");
       getDisplayString().setTagArg("i", 1, "yellow");
@@ -459,8 +459,8 @@ PhotonicQubit *StationaryQubit::generateEntangledPhoton() {
   // qnic_address != qnic_index. qnic_index is not unique because there are 3 types.
   photon->setQNICEntangledWith(qnic_address);
 
-  // stationaryQubit_address = StationaryQubit's index
-  photon->setStationaryQubitEntangledWith(stationaryQubit_address);
+  // stationary_qubit_address = StationaryQubit's index
+  photon->setStationaryQubitEntangledWith(stationary_qubit_address);
   photon->setQNICtypeEntangledWith(qnic_type);
   photon->setEntangled_with(this);
   return photon;
@@ -507,11 +507,11 @@ void StationaryQubit::setCompletelyMixedDensityMatrix() {
   this->GOD_dm_Xerror = false;
   this->GOD_dm_Zerror = false;
   if (hasGUI()) {
-    par("GOD_Xerror") = false;
-    par("GOD_Zerror") = false;
-    par("GOD_EXerror") = false;
-    par("GOD_REerror") = false;
-    par("GOD_CMerror") = true;
+    par("god_x_error") = false;
+    par("god_z_error") = false;
+    par("god_excitation_error") = false;
+    par("god_relaxation_error") = false;
+    par("god_completely_mixed_error") = true;
     bubble("Completely mixed. darkcount");
     getDisplayString().setTagArg("i", 1, "black");
   }
@@ -532,11 +532,11 @@ void StationaryQubit::setExcitedDensityMatrix() {
   GOD_dm_Zerror = false;
 
   if (hasGUI()) {
-    par("GOD_Xerror") = false;
-    par("GOD_Zerror") = false;
-    par("GOD_EXerror") = true;
-    par("GOD_REerror") = false;
-    par("GOD_CMerror") = false;
+    par("god_x_error") = false;
+    par("god_z_error") = false;
+    par("god_excitation_error") = true;
+    par("god_relaxation_error") = false;
+    par("god_completely_mixed_error") = false;
     bubble("Completely mixed. darkcount");
     getDisplayString().setTagArg("i", 1, "white");
   }
@@ -563,11 +563,11 @@ void StationaryQubit::setRelaxedDensityMatrix() {
   GOD_dm_Xerror = false;
   GOD_dm_Zerror = false;
   if (hasGUI()) {
-    par("GOD_Xerror") = false;
-    par("GOD_Zerror") = false;
-    par("GOD_EXerror") = false;
-    par("GOD_REerror") = true;
-    par("GOD_CMerror") = false;
+    par("god_x_error") = false;
+    par("god_z_error") = false;
+    par("god_excitation_error") = false;
+    par("god_relaxation_error") = true;
+    par("god_completely_mixed_error") = false;
     bubble("Completely mixed. darkcount");
     getDisplayString().setTagArg("i", 1, "white");
   }
@@ -585,16 +585,16 @@ void StationaryQubit::setEntangledPartnerInfo(IStationaryQubit *partner) {
   // When BSA succeeds, this method gets invoked to store entangled partner information.
   // This will also be sent classically to the partner node afterwards.
   entangled_partner = partner;
-  GOD_entangled_stationaryQubit_address = partner->stationaryQubit_address;
-  GOD_entangled_node_address = partner->node_address;
-  GOD_entangled_qnic_address = partner->qnic_address;
-  GOD_entangled_qnic_type = partner->qnic_type;
+  god_entangled_stationary_qubit_address = partner->stationary_qubit_address;
+  god_entangled_node_address = partner->node_address;
+  god_entangled_qnic_address = partner->qnic_address;
+  god_entangled_qnic_type = partner->qnic_type;
   // For GUI
   if (hasGUI()) {
-    par("GOD_entangled_stationaryQubit_address") = partner->stationaryQubit_address;
-    par("GOD_entangled_node_address") = partner->node_address;
-    par("GOD_entangled_qnic_address") = partner->qnic_address;
-    par("GOD_entangled_qnic_type") = partner->qnic_type;
+    par("god_entangled_stationary_qubit_address") = partner->stationary_qubit_address;
+    par("god_entangled_node_address") = partner->node_address;
+    par("god_entangled_qnic_address") = partner->qnic_address;
+    par("god_entangled_qnic_type") = partner->qnic_type;
   }
 }
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -960,7 +960,8 @@ measurement_outcome StationaryQubit::measure_density_independent() {
     if (this->entangled_partner->excited_or_relaxed && !this->entangled_partner->god_err.has_excitation_error && !this->entangled_partner->god_err.has_relaxation_error) {
       error("Partner Re/Ex track wrong\n");
     }
-    if (this->entangled_partner->god_err.has_completely_mixed_error || this->entangled_partner->god_err.has_relaxation_error || this->entangled_partner->god_err.has_excitation_error) {
+    if (this->entangled_partner->god_err.has_completely_mixed_error || this->entangled_partner->god_err.has_relaxation_error ||
+        this->entangled_partner->god_err.has_excitation_error) {
       // error("Partner CM/Re/Ex track wrong\n");
     }
   }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -342,12 +342,12 @@ void StationaryQubit::setBusy() {
   is_busy = true;
   emitted_time = simTime();
   updated_time = simTime();  // Should be no error at this time.
-  par("photon_emitted_at") = emitted_time.dbl();
-  par("last_updated_at") = updated_time.dbl();
-  par("is_busy") = true;
   // GUI part
   if (hasGUI()) {
     getDisplayString().setTagArg("i", 1, "red");
+    par("photon_emitted_at") = emitted_time.dbl();
+    par("last_updated_at") = updated_time.dbl();
+    par("isBusy") = true;
   }
 }
 
@@ -371,19 +371,23 @@ void StationaryQubit::setFree(bool consumed) {
   GOD_dm_Xerror = false;
   Density_Matrix_Collapsed << -111, -111, -111, -111;
   no_density_matrix_nullptr_entangled_partner_ok = false;
-  par("photon_emitted_at") = emitted_time.dbl();
-  par("last_updated_at") = updated_time.dbl();
-  par("god_x_error") = false;
-  par("god_z_error") = false;
-  par("god_completely_mixed_error") = false;
-  par("god_excitation_error") = false;
-  par("god_relaxation_error") = false;
-  par("god_completely_mixed_error") = false;
-  par("is_busy") = false;
-  par("god_entangled_stationary_qubit_address") = -1;
-  par("god_entangled_node_address") = -1;
-  par("god_entangled_qnic_address") = -1;
-  par("god_entangled_qnic_type") = -1;
+  if (hasGUI()) {
+    par("photon_emitted_at") = emitted_time.dbl();
+    par("last_updated_at") = updated_time.dbl();
+    par("isBusy") = false;
+    par("GOD_entangled_stationaryQubit_address") = -1;
+    par("GOD_entangled_node_address") = -1;
+    par("GOD_entangled_qnic_address") = -1;
+    par("GOD_entangled_qnic_type") = -1;
+  }
+  // TODO: replace all par occurences to boolean
+  par("GOD_Xerror") = false;
+  par("GOD_Zerror") = false;
+  par("GOD_CMerror") = false;
+  par("GOD_EXerror") = false;
+  par("GOD_REerror") = false;
+  par("GOD_CMerror") = false;
+
   entangled_partner = nullptr;
   EV_DEBUG << "Freeing this qubit!!!" << this << " at qnode: " << node_address << " qnic_type: " << qnic_type << " qnic_index: " << qnic_index << "\n";
   // GUI part
@@ -554,10 +558,12 @@ void StationaryQubit::setEntangledPartnerInfo(IStationaryQubit *partner) {
   // When BSA succeeds, this method gets invoked to store entangled partner information.
   // This will also be sent classically to the partner node afterwards.
   entangled_partner = partner;
-  par("god_entangled_stationary_qubit_address") = partner->par("stationary_qubit_address");
-  par("god_entangled_node_address") = partner->par("node_address");
-  par("god_entangled_qnic_address") = partner->par("qnic_address");
-  par("god_entangled_qnic_type") = partner->par("qnic_type");
+  if (hasGUI()) {
+    par("GOD_entangled_stationaryQubit_address") = partner->par("stationaryQubit_address");
+    par("GOD_entangled_node_address") = partner->par("node_address");
+    par("GOD_entangled_qnic_address") = partner->par("qnic_address");
+    par("GOD_entangled_qnic_type") = partner->par("qnic_type");
+  }
 }
 
 /* Add another X error. If an X error already exists, then they cancel out */

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -59,11 +59,11 @@ void StationaryQubit::initialize() {
     0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.completely_mixed_rate, memory_err.completely_mixed_rate,
     0,                          0,                         0,                         0,                          memory_err.excitation_error_rate, memory_err.relaxation_error_rate, 1 - memory_err.excitation_error_rate - memory_err.relaxation_error_rate;
   // clang-format on
-  GOD_err.has_X_error = par("GOD_Xerror");
-  GOD_err.has_Z_error = par("GOD_Zerror");
-  GOD_err.has_EX_error = par("GOD_EXerror");
-  GOD_err.has_RE_error = par("GOD_REerror");
-  GOD_err.has_CM_error = par("GOD_CMerror");
+  GOD_err.has_X_error = par("GOD_Xerror").boolValue();
+  GOD_err.has_Z_error = par("GOD_Zerror").boolValue();
+  GOD_err.has_EX_error = par("GOD_EXerror").boolValue();
+  GOD_err.has_RE_error = par("GOD_REerror").boolValue();
+  GOD_err.has_CM_error = par("GOD_CMerror").boolValue();
   setSingleQubitGateErrorModel(Hgate_error, "Hgate");
   setSingleQubitGateErrorModel(Xgate_error, "Xgate");
   setSingleQubitGateErrorModel(Zgate_error, "Zgate");

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -229,30 +229,30 @@ void StationaryQubit::setTwoQubitGateErrorCeilings(TwoQubitGateErrorModel &model
 }
 
 void StationaryQubit::setMeasurementErrorModel(MeasurementErrorModel &model) {
-  model.x_error_rate = par("x_measurement_error_rate").doubleValue();
-  model.y_error_rate = par("y_measurement_error_rate").doubleValue();
-  model.z_error_rate = par("z_measurement_error_rate").doubleValue();
+  model.X_error_rate = par("X_measurement_error_rate").doubleValue();
+  model.Y_error_rate = par("Y_measurement_error_rate").doubleValue();
+  model.Z_error_rate = par("Z_measurement_error_rate").doubleValue();
 }
 
 MeasureXResult StationaryQubit::correlationMeasureX() {
-  bool error = par("god_z_error").boolValue();
-  if (dblrand() < Measurement_error.x_error_rate) {
+  bool error = par("GOD_Zerror").boolValue();
+  if (dblrand() < Measurement_error.X_error_rate) {
     error = !error;
   }
   return error ? MeasureXResult::HAS_Z_ERROR : MeasureXResult::NO_Z_ERROR;
 }
 
 MeasureYResult StationaryQubit::correlationMeasureY() {
-  bool error = par("god_z_error").boolValue() != par("god_x_error").boolValue();
-  if (dblrand() < Measurement_error.y_error_rate) {
+  bool error = par("GOD_Zerror").boolValue() != par("GOD_Xerror").boolValue();
+  if (dblrand() < Measurement_error.Y_error_rate) {
     error = !error;
   }
   return error ? MeasureYResult::HAS_XZ_ERROR : MeasureYResult::NO_XZ_ERROR;
 }
 
 MeasureZResult StationaryQubit::correlationMeasureZ() {
-  bool error = par("god_x_error").boolValue();
-  if (dblrand() < Measurement_error.x_error_rate) {
+  bool error = par("GOD_Xerror").boolValue();
+  if (dblrand() < Measurement_error.X_error_rate) {
     error = !error;
   }
   return error ? MeasureZResult::HAS_X_ERROR : MeasureZResult::NO_X_ERROR;
@@ -271,7 +271,7 @@ EigenvalueResult StationaryQubit::localMeasureX() {
       this->entangled_partner->addZerror();
     }
   }
-  if (dblrand() < this->Measurement_error.x_error_rate) {
+  if (dblrand() < this->Measurement_error.X_error_rate) {
     result = result == EigenvalueResult::PLUS_ONE ? EigenvalueResult::MINUS_ONE : EigenvalueResult::PLUS_ONE;
   }
   return result;
@@ -295,7 +295,7 @@ EigenvalueResult StationaryQubit::localMeasureZ() {
       this->entangled_partner->addXerror();
     }
   }
-  if (dblrand() < this->Measurement_error.z_error_rate) {
+  if (dblrand() < this->Measurement_error.Z_error_rate) {
     result = result == EigenvalueResult::PLUS_ONE ? EigenvalueResult::MINUS_ONE : EigenvalueResult::PLUS_ONE;
   }
   return result;
@@ -371,6 +371,7 @@ void StationaryQubit::setFree(bool consumed) {
   GOD_dm_Xerror = false;
   Density_Matrix_Collapsed << -111, -111, -111, -111;
   no_density_matrix_nullptr_entangled_partner_ok = false;
+  // GUI part
   if (hasGUI()) {
     par("photon_emitted_at") = emitted_time.dbl();
     par("last_updated_at") = updated_time.dbl();
@@ -380,7 +381,7 @@ void StationaryQubit::setFree(bool consumed) {
     par("GOD_entangled_qnic_address") = -1;
     par("GOD_entangled_qnic_type") = -1;
   }
-  // TODO: replace all par occurences to boolean
+  // TODO: replace all par occurences
   par("GOD_Xerror") = false;
   par("GOD_Zerror") = false;
   par("GOD_CMerror") = false;
@@ -411,7 +412,7 @@ void StationaryQubit::Lock(unsigned long rs_id, int rule_id, int action_id) {
   locked_ruleset_id = rs_id;  // Used to identify what this qubit is locked for.
   locked_rule_id = rule_id;
   action_index = action_id;
-
+  // GUI part
   if (hasGUI()) {
     bubble("Locked!");
     getDisplayString().setTagArg("i", 1, "purple");
@@ -558,12 +559,10 @@ void StationaryQubit::setEntangledPartnerInfo(IStationaryQubit *partner) {
   // When BSA succeeds, this method gets invoked to store entangled partner information.
   // This will also be sent classically to the partner node afterwards.
   entangled_partner = partner;
-  if (hasGUI()) {
-    par("GOD_entangled_stationaryQubit_address") = partner->par("stationaryQubit_address");
-    par("GOD_entangled_node_address") = partner->par("node_address");
-    par("GOD_entangled_qnic_address") = partner->par("qnic_address");
-    par("GOD_entangled_qnic_type") = partner->par("qnic_type");
-  }
+  par("GOD_entangled_stationaryQubit_address") = partner->stationaryQubit_address;
+  par("GOD_entangled_node_address") = partner->node_address;
+  par("GOD_entangled_qnic_address") = partner->qnic_address;
+  par("GOD_entangled_qnic_type") = partner->qnic_type;
 }
 
 /* Add another X error. If an X error already exists, then they cancel out */
@@ -1020,9 +1019,9 @@ measurement_outcome StationaryQubit::measure_density_independent() {
 
   // add measurement error
   auto rand_num = dblrand();
-  if (this_measurement.basis == meas_op.X_basis.basis && rand_num < Measurement_error.x_error_rate ||
-      this_measurement.basis == meas_op.Y_basis.basis && rand_num < Measurement_error.y_error_rate ||
-      this_measurement.basis == meas_op.Z_basis.basis && rand_num < Measurement_error.z_error_rate) {
+  if (this_measurement.basis == meas_op.X_basis.basis && rand_num < Measurement_error.X_error_rate ||
+      this_measurement.basis == meas_op.Y_basis.basis && rand_num < Measurement_error.Y_error_rate ||
+      this_measurement.basis == meas_op.Z_basis.basis && rand_num < Measurement_error.Z_error_rate) {
     Output_is_plus = !Output_is_plus;
   }
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -95,10 +95,6 @@ void StationaryQubit::initialize() {
   meas_op.identity << 1, 0, 0, 1;
 
   // Get parameters from omnet
-  god_entangled_stationary_qubit_address = par("god_entangled_stationary_qubit_address");
-  god_entangled_node_address = par("god_entangled_node_address");
-  god_entangled_qnic_address = par("god_entangled_qnic_address");
-  god_entangled_qnic_type = par("god_entangled_qnic_type");
   stationary_qubit_address = par("stationary_qubit_address");
   node_address = par("node_address");
   qnic_address = par("qnic_address");
@@ -397,10 +393,6 @@ void StationaryQubit::setFree(bool consumed) {
   entangled_partner = nullptr;
   EV_DEBUG << "Freeing this qubit!!!" << this << " at qnode: " << node_address << " qnic_type: " << qnic_type << " qnic_index: " << qnic_index << "\n";
   if (hasGUI()) {
-    par("god_entangled_stationary_qubit_address") = -1;
-    par("god_entangled_node_address") = -1;
-    par("god_entangled_qnic_address") = -1;
-    par("god_entangled_qnic_type") = -1;
     if (consumed) {
       bubble("Consumed!");
       getDisplayString().setTagArg("i", 1, "yellow");
@@ -564,12 +556,6 @@ void StationaryQubit::setEntangledPartnerInfo(IStationaryQubit *partner) {
   god_entangled_node_address = partner->node_address;
   god_entangled_qnic_address = partner->qnic_address;
   god_entangled_qnic_type = partner->qnic_type;
-  if (hasGUI()) {
-    par("god_entangled_stationary_qubit_address") = partner->stationary_qubit_address;
-    par("god_entangled_node_address") = partner->node_address;
-    par("god_entangled_qnic_address") = partner->qnic_address;
-    par("god_entangled_qnic_type") = partner->qnic_type;
-  }
 }
 
 /* Add another X error. If an X error already exists, then they cancel out */

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -350,7 +350,6 @@ void StationaryQubit::setBusy() {
   is_busy = true;
   emitted_time = simTime();
   updated_time = simTime();  // Should be no error at this time.
-  // GUI part
   if (hasGUI()) {
     getDisplayString().setTagArg("i", 1, "red");
     par("photon_emitted_at") = emitted_time.dbl();
@@ -390,7 +389,6 @@ void StationaryQubit::setFree(bool consumed) {
   god_err.has_completely_mixed_error = false;
   entangled_partner = nullptr;
   EV_DEBUG << "Freeing this qubit!!!" << this << " at qnode: " << node_address << " qnic_type: " << qnic_type << " qnic_index: " << qnic_index << "\n";
-  // GUI part
   if (hasGUI()) {
     par("photon_emitted_at") = emitted_time.dbl();
     par("last_updated_at") = updated_time.dbl();
@@ -423,7 +421,6 @@ void StationaryQubit::Lock(unsigned long rs_id, int rule_id, int action_id) {
   locked_ruleset_id = rs_id;  // Used to identify what this qubit is locked for.
   locked_rule_id = rule_id;
   action_index = action_id;
-  // GUI part
   if (hasGUI()) {
     bubble("Locked!");
     getDisplayString().setTagArg("i", 1, "purple");
@@ -435,7 +432,6 @@ void StationaryQubit::Unlock() {
   locked_ruleset_id = -1;  // Used to identify what this qubit is locked for.
   locked_rule_id = -1;
   action_index = -1;
-  // GUI part
   if (hasGUI()) {
     bubble("Unlocked!");
     getDisplayString().setTagArg("i", 1, "pink");
@@ -530,7 +526,6 @@ void StationaryQubit::setExcitedDensityMatrix() {
   god_err.has_z_error = false;
   GOD_dm_Xerror = false;
   GOD_dm_Zerror = false;
-
   if (hasGUI()) {
     par("god_x_error") = false;
     par("god_z_error") = false;
@@ -544,7 +539,6 @@ void StationaryQubit::setExcitedDensityMatrix() {
   if (this->entangled_partner != nullptr) {  // If it used to be entangled...
     // error("What?");
     this->entangled_partner->updated_time = simTime();
-    // For GUI
     if (hasGUI()) this->entangled_partner->par("last_updated_at") = simTime().dbl();
     // This also eliminates the entanglement information.
     this->entangled_partner->setCompletelyMixedDensityMatrix();
@@ -589,7 +583,6 @@ void StationaryQubit::setEntangledPartnerInfo(IStationaryQubit *partner) {
   god_entangled_node_address = partner->node_address;
   god_entangled_qnic_address = partner->qnic_address;
   god_entangled_qnic_type = partner->qnic_type;
-  // For GUI
   if (hasGUI()) {
     par("god_entangled_stationary_qubit_address") = partner->stationary_qubit_address;
     par("god_entangled_node_address") = partner->node_address;
@@ -767,7 +760,6 @@ void StationaryQubit::applyMemoryError() {
     }
   }
   updated_time = simTime();
-  // For GUI
   if (hasGUI()) {
     par("last_updated_at") = simTime().dbl();
     par("GOD_X_Error") = god_err.has_x_error;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -33,7 +33,6 @@ class StationaryQubit : public IStationaryQubit {
  protected:
   std::unordered_set<StationaryQubit *> neighbors;
   types::CliffordOperator vertex_operator;
-
   void applyClifford(types::CliffordOperator op);
   void applyRightClifford(types::CliffordOperator op);
   bool isNeighbor(StationaryQubit *another_qubit);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.h
@@ -148,12 +148,6 @@ class StationaryQubit : public IStationaryQubit {
   TwoQubitGateErrorModel CNOTgate_error;
   MeasurementErrorModel Measurement_error;
   memory_error_model memory_err;
-  double memory_No_error_ceil;
-  double memory_X_error_ceil;
-  double memory_Y_error_ceil;
-  double memory_Z_error_ceil;
-  double memory_Excitation_error_ceil;
-  double memory_Relaxation_error_ceil;
 
   single_qubit_error Pauli;
   measurement_operators meas_op;

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -16,31 +16,13 @@ simple StationaryQubit
 
         // ZZZ -- these are volatile elements of the object (module) state
         // and should be private data members of the class object
-        int god_entangled_stationary_qubit_address @mutable = default(-1);
-        int god_entangled_node_address @mutable = default(-1);
-        int god_entangled_qnic_address @mutable = default(-1);
-        int god_entangled_qnic_type @mutable = default(-1);
-
-        // ZZZ -- these are volatile elements of the object (module) state
-        // and should be private data members of the class object
         int x_position_graphics;		// can this be usefully set in a .ned file?
-        bool is_busy @mutable = default(false);
         double std @mutable = default(0);
 
         // ZZZ -- this is a volatile element of the object (module) state
         // and should be private data member of the class object
         // n.b.: this should be _software's_ idea of what the fidelity is?
         double fidelity @mutable = default(-1.0);
-
-        // ZZZ -- these are volatile elements of the object (module) state
-        // and should be private data members of the class object
-        // n.b.: these represent the _hardware_ state, and aren't directly
-        // accessible to repeater software (qrsa)
-        bool god_x_error @mutable = false;//Physical error on qubit
-        bool god_z_error @mutable = false;//Physical error on qubit
-        bool god_excitation_error @mutable = false;//Physical error on qubit
-        bool god_relaxation_error @mutable = false;//Physical error on qubit
-        bool god_completely_mixed_error @mutable = false;//Physical error on qubit
 
         // ZZZ -- these are configured at boot time
         // characteristics of the hardware

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -84,9 +84,6 @@ simple StationaryQubit
         double x_measurement_error_rate = default(0);
         double y_measurement_error_rate = default(0);
         double z_measurement_error_rate = default(0);
-        //int ruleset_id = default(-1);
-        //int rule_id = default(-1);
-        //int action_index = default(-1);
     gates:
         inout tolens_quantum_port;
 }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -24,8 +24,6 @@ simple StationaryQubit
         // ZZZ -- these are volatile elements of the object (module) state
         // and should be private data members of the class object
         int x_position_graphics;		// can this be usefully set in a .ned file?
-        double photon_emitted_at @mutable = default(-1);
-        double last_updated_at @mutable = default(-1);
         bool is_busy @mutable = default(false);
         double std @mutable = default(0);
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -19,11 +19,6 @@ simple StationaryQubit
         int x_position_graphics;		// can this be usefully set in a .ned file?
         double std @mutable = default(0);
 
-        // ZZZ -- this is a volatile element of the object (module) state
-        // and should be private data member of the class object
-        // n.b.: this should be _software's_ idea of what the fidelity is?
-        double fidelity @mutable = default(-1.0);
-
         // ZZZ -- these are configured at boot time
         // characteristics of the hardware
         // could eventually change over time if we model dynamic

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -57,9 +57,9 @@ simple StationaryQubit
         // characteristics of the hardware
         // could eventually change over time if we model dynamic
         // changes to the device
-        double memory_Z_error_rate = default(0);
-        double memory_X_error_rate = default(0);
-        double memory_Y_error_rate = default(0);
+        double memory_z_error_rate = default(0);
+        double memory_x_error_rate = default(0);
+        double memory_y_error_rate = default(0);
         double memory_energy_excitation_rate = default(0);
         double memory_energy_relaxation_rate = default(0);
         double memory_completely_mixed_rate = default(0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -17,7 +17,7 @@ simple StationaryQubit
         // ZZZ -- these are volatile elements of the object (module) state
         // and should be private data members of the class object
         int x_position_graphics;		// can this be usefully set in a .ned file?
-        double std @mutable = default(0);
+        double emission_jittering_standard_deviation = default(0);
 
         // ZZZ -- these are configured at boot time
         // characteristics of the hardware

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -57,9 +57,9 @@ simple StationaryQubit
         // characteristics of the hardware
         // could eventually change over time if we model dynamic
         // changes to the device
-        double memory_z_error_rate = default(0);
-        double memory_x_error_rate = default(0);
-        double memory_y_error_rate = default(0);
+        double memory_Z_error_rate = default(0);
+        double memory_X_error_rate = default(0);
+        double memory_Y_error_rate = default(0);
         double memory_energy_excitation_rate = default(0);
         double memory_energy_relaxation_rate = default(0);
         double memory_completely_mixed_rate = default(0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -84,8 +84,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
-
-    setParDouble(this, "fidelity", -1.0);
   }
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -83,7 +83,7 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_address", 1);
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
-    setParDouble(this, "std", 0.5);
+    setParDouble(this, "emission_jittering_standard_deviation", 0.5);
   }
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -316,20 +316,20 @@ TEST(StatQubitGateErrorTest, do_nothing_single_qubit_gate) {
 
   qubit->callInitialize();
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
 
   qubit->applySingleQubitGateError(qubit->Xgate_error);
 
   EXPECT_EQ(qubit->updated_time, SimTime(0, SIMTIME_US));
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
 }
 
 TEST(StatQubitGateErrorTest, do_nothing_two_qubit_gate) {
@@ -346,30 +346,30 @@ TEST(StatQubitGateErrorTest, do_nothing_two_qubit_gate) {
   qubit2->callInitialize();
   qubit->reset();
   qubit2->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
-  qubit2->GOD_err.has_X_error = true;
-  qubit2->GOD_err.has_Z_error = true;
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
+  qubit2->god_err.has_x_error = true;
+  qubit2->god_err.has_z_error = true;
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit2->god_err.has_x_error);
+  EXPECT_TRUE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
 
   qubit->applyTwoQubitGateError(qubit->CNOTgate_error, qubit2);
 
   EXPECT_EQ(qubit->updated_time, SimTime(0, SIMTIME_US));
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit2->god_err.has_x_error);
+  EXPECT_TRUE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
 }
 
 TEST(StatQubitGateErrorTest, apply_single_qubit_gate_error) {
@@ -385,41 +385,41 @@ TEST(StatQubitGateErrorTest, apply_single_qubit_gate_error) {
   qubit->reset();
   rng->doubleValue = 0.35;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // X error
   qubit->reset();
   rng->doubleValue = 0.45;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Z error
   qubit->reset();
   rng->doubleValue = 0.65;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Y error
   qubit->reset();
   rng->doubleValue = 0.85;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 TEST(StatQubitGateErrorTest, apply_two_qubit_gate_error) {
@@ -441,159 +441,159 @@ TEST(StatQubitGateErrorTest, apply_two_qubit_gate_error) {
   qubit2->reset();
   rng->doubleValue = 0.05;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit1->god_err.has_x_error);
+  EXPECT_FALSE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_FALSE(qubit2->god_err.has_x_error);
+  EXPECT_FALSE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // IX error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.15;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit1->god_err.has_x_error);
+  EXPECT_FALSE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_FALSE(qubit2->god_err.has_x_error);
+  EXPECT_FALSE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // XI error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.25;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit1->god_err.has_x_error);
+  EXPECT_FALSE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_TRUE(qubit2->god_err.has_x_error);
+  EXPECT_FALSE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // XX error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.35;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit1->god_err.has_x_error);
+  EXPECT_FALSE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_TRUE(qubit2->god_err.has_x_error);
+  EXPECT_FALSE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // IZ error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.45;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit1->god_err.has_x_error);
+  EXPECT_TRUE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_FALSE(qubit2->god_err.has_x_error);
+  EXPECT_FALSE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // ZI error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.55;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit1->god_err.has_x_error);
+  EXPECT_FALSE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_FALSE(qubit2->god_err.has_x_error);
+  EXPECT_TRUE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // ZZ error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.65;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit1->god_err.has_x_error);
+  EXPECT_TRUE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_FALSE(qubit2->god_err.has_x_error);
+  EXPECT_TRUE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // IY error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.75;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit1->god_err.has_x_error);
+  EXPECT_TRUE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_FALSE(qubit2->god_err.has_x_error);
+  EXPECT_FALSE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // YI error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.85;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit1->god_err.has_x_error);
+  EXPECT_FALSE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_TRUE(qubit2->god_err.has_x_error);
+  EXPECT_TRUE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 
   // YY error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.95;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit1->god_err.has_x_error);
+  EXPECT_TRUE(qubit1->god_err.has_z_error);
+  EXPECT_FALSE(qubit1->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit1->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit1->god_err.has_completely_mixed_error);
+  EXPECT_TRUE(qubit2->god_err.has_x_error);
+  EXPECT_TRUE(qubit2->god_err.has_z_error);
+  EXPECT_FALSE(qubit2->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit2->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit2->god_err.has_completely_mixed_error);
 }
 }  // namespace

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -85,10 +85,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParInt(this, "god_entangled_stationary_qubit_address", 0);
-    setParInt(this, "god_entangled_node_address", 0);
-    setParInt(this, "god_entangled_qnic_address", 0);
-    setParInt(this, "god_entangled_qnic_type", 0);
     setParDouble(this, "fidelity", -1.0);
   }
 };

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -85,8 +85,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParDouble(this, "photon_emitted_at", 0.0);
-    setParDouble(this, "last_updated_at", 0.0);
     setParBool(this, "god_x_error", false);
     setParBool(this, "god_z_error", false);
     setParBool(this, "god_completely_mixed_error", false);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -316,20 +316,20 @@ TEST(StatQubitGateErrorTest, do_nothing_single_qubit_gate) {
 
   qubit->callInitialize();
   qubit->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(qubit->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit->par("god_excitation_error"));
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
 
   qubit->applySingleQubitGateError(qubit->Xgate_error);
 
   EXPECT_EQ(qubit->updated_time, SimTime(0, SIMTIME_US));
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(qubit->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit->par("god_excitation_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
 }
 
 TEST(StatQubitGateErrorTest, do_nothing_two_qubit_gate) {
@@ -346,30 +346,30 @@ TEST(StatQubitGateErrorTest, do_nothing_two_qubit_gate) {
   qubit2->callInitialize();
   qubit->reset();
   qubit2->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
-  qubit2->par("god_x_error") = true;
-  qubit2->par("god_z_error") = true;
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(qubit->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit->par("god_excitation_error"));
-  EXPECT_TRUE(qubit2->par("god_x_error"));
-  EXPECT_TRUE(qubit2->par("god_z_error"));
-  EXPECT_FALSE(qubit2->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit2->par("god_excitation_error"));
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
+  qubit2->GOD_err.has_X_error = true;
+  qubit2->GOD_err.has_Z_error = true;
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
 
   qubit->applyTwoQubitGateError(qubit->CNOTgate_error, qubit2);
 
   EXPECT_EQ(qubit->updated_time, SimTime(0, SIMTIME_US));
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(qubit->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit->par("god_excitation_error"));
-  EXPECT_TRUE(qubit2->par("god_x_error"));
-  EXPECT_TRUE(qubit2->par("god_z_error"));
-  EXPECT_FALSE(qubit2->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit2->par("god_excitation_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
 }
 
 TEST(StatQubitGateErrorTest, apply_single_qubit_gate_error) {
@@ -385,41 +385,41 @@ TEST(StatQubitGateErrorTest, apply_single_qubit_gate_error) {
   qubit->reset();
   rng->doubleValue = 0.35;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // X error
   qubit->reset();
   rng->doubleValue = 0.45;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Z error
   qubit->reset();
   rng->doubleValue = 0.65;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Y error
   qubit->reset();
   rng->doubleValue = 0.85;
   qubit->applySingleQubitGateError(qubit->Xgate_error);
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 TEST(StatQubitGateErrorTest, apply_two_qubit_gate_error) {
@@ -441,159 +441,159 @@ TEST(StatQubitGateErrorTest, apply_two_qubit_gate_error) {
   qubit2->reset();
   rng->doubleValue = 0.05;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // IX error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.15;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // XI error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.25;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // XX error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.35;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // IZ error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.45;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // ZI error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.55;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // ZZ error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.65;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // IY error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.75;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // YI error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.85;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_FALSE(qubit1->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit1->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 
   // YY error
   qubit1->reset();
   qubit2->reset();
   rng->doubleValue = 0.95;
   qubit1->applyTwoQubitGateError(qubit1->CNOTgate_error, qubit2);
-  EXPECT_TRUE(qubit1->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit1->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit1->par("god_completely_mixed_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit2->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit2->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit1->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit1->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit1->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit2->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit2->GOD_err.has_CM_error);
 }
 }  // namespace

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_gate_error_test.cc
@@ -85,12 +85,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParBool(this, "god_x_error", false);
-    setParBool(this, "god_z_error", false);
-    setParBool(this, "god_completely_mixed_error", false);
-    setParBool(this, "god_excitation_error", false);
-    setParBool(this, "god_relaxation_error", false);
-    setParBool(this, "is_busy", false);
     setParInt(this, "god_entangled_stationary_qubit_address", 0);
     setParInt(this, "god_entangled_node_address", 0);
     setParInt(this, "god_entangled_qnic_address", 0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
@@ -82,8 +82,6 @@ class StatQubitFixture : public StationaryQubit {
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
-
-    setParDouble(this, "fidelity", -1.0);
   }
 
   std::unordered_set<StationaryQubit *> getNeighborSet() { return this->neighbors; }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
@@ -82,13 +82,7 @@ class StatQubitFixture : public StationaryQubit {
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
-
-    setParBool(this, "god_x_error", false);
-    setParBool(this, "god_z_error", false);
-    setParBool(this, "god_completely_mixed_error", false);
-    setParBool(this, "god_excitation_error", false);
-    setParBool(this, "god_relaxation_error", false);
-    setParBool(this, "is_busy", false);
+    
     setParInt(this, "god_entangled_stationary_qubit_address", 0);
     setParInt(this, "god_entangled_node_address", 0);
     setParInt(this, "god_entangled_qnic_address", 0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
@@ -82,7 +82,7 @@ class StatQubitFixture : public StationaryQubit {
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
-    
+
     setParInt(this, "god_entangled_stationary_qubit_address", 0);
     setParInt(this, "god_entangled_node_address", 0);
     setParInt(this, "god_entangled_qnic_address", 0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
@@ -83,10 +83,6 @@ class StatQubitFixture : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParInt(this, "god_entangled_stationary_qubit_address", 0);
-    setParInt(this, "god_entangled_node_address", 0);
-    setParInt(this, "god_entangled_qnic_address", 0);
-    setParInt(this, "god_entangled_qnic_type", 0);
     setParDouble(this, "fidelity", -1.0);
   }
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
@@ -83,8 +83,6 @@ class StatQubitFixture : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParDouble(this, "photon_emitted_at", 0.0);
-    setParDouble(this, "last_updated_at", 0.0);
     setParBool(this, "god_x_error", false);
     setParBool(this, "god_z_error", false);
     setParBool(this, "god_completely_mixed_error", false);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_internal_stabilizer_graph_test.cc
@@ -81,7 +81,7 @@ class StatQubitFixture : public StationaryQubit {
     setParInt(this, "qnic_address", 1);
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
-    setParDouble(this, "std", 0.5);
+    setParDouble(this, "emission_jittering_standard_deviation", 0.5);
   }
 
   std::unordered_set<StationaryQubit *> getNeighborSet() { return this->neighbors; }

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -37,9 +37,9 @@ class StatQubitTarget : public StationaryQubit {
     provider.setStrategy(std::make_unique<Strategy>());
   }
   void reset() {
-    this->GOD_err.has_X_error = false;
-    this->GOD_err.has_Z_error = false;
-    // this->GOD_err.has_Y_error = false; not implemeted yet
+    this->god_err.has_x_error = false;
+    this->god_err.has_z_error = false;
+    // this->god_err.has_Y_error = false; not implemeted yet
   }
   void fillParams() {
     setParDouble(this, "emission_success_probability", 0.5);
@@ -269,59 +269,59 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -329,10 +329,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -340,10 +340,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 }
 
 TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
@@ -361,59 +361,59 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -421,10 +421,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_TRUE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -432,10 +432,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 }
 
 TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
@@ -452,59 +452,59 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -512,10 +512,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -523,10 +523,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 }
 
 TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
@@ -544,59 +544,59 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -604,10 +604,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -615,10 +615,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(another_qubit->god_err.has_x_error);
+  EXPECT_FALSE(another_qubit->god_err.has_z_error);
 }
 
 }  // end namespace

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -92,10 +92,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParInt(this, "god_entangled_stationary_qubit_address", 0);
-    setParInt(this, "god_entangled_node_address", 0);
-    setParInt(this, "god_entangled_qnic_address", 0);
-    setParInt(this, "god_entangled_qnic_type", 0);
     setParDouble(this, "fidelity", -1.0);
   }
 };

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -91,8 +91,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
-
-    setParDouble(this, "fidelity", -1.0);
   }
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -92,8 +92,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParDouble(this, "photon_emitted_at", 0.0);
-    setParDouble(this, "last_updated_at", 0.0);
     setParBool(this, "god_x_error", false);
     setParBool(this, "god_z_error", false);
     setParBool(this, "god_completely_mixed_error", false);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -37,8 +37,9 @@ class StatQubitTarget : public StationaryQubit {
     provider.setStrategy(std::make_unique<Strategy>());
   }
   void reset() {
-    setParBool(this, "god_x_error", false);
-    setParBool(this, "god_z_error", false);
+    this->GOD_err.has_X_error = false;
+    this->GOD_err.has_Z_error = false;
+    // this->GOD_err.has_Y_error = false; not implemeted yet
   }
   void fillParams() {
     setParDouble(this, "emission_success_probability", 0.5);
@@ -268,59 +269,59 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -328,10 +329,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -339,10 +340,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 }
 
 TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
@@ -360,59 +361,59 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -420,10 +421,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_TRUE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -431,10 +432,10 @@ TEST(StatQubitMeasurementTest, localXMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureX(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 }
 
 TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
@@ -451,59 +452,59 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -511,10 +512,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -522,10 +523,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithoutError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 }
 
 TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
@@ -543,59 +544,59 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
 
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addZerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_FALSE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_FALSE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -603,10 +604,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.7;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::MINUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_TRUE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 
   qubit->reset();
   another_qubit->reset();
@@ -614,10 +615,10 @@ TEST(StatQubitMeasurementTest, localZMeasurementWithError) {
   qubit->addXerror();
   rng->doubleValue = 0.3;
   EXPECT_EQ(qubit->localMeasureZ(), quisp::types::EigenvalueResult::PLUS_ONE);
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(another_qubit->par("god_x_error"));
-  EXPECT_FALSE(another_qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(another_qubit->GOD_err.has_Z_error);
 }
 
 }  // end namespace

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -92,12 +92,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParBool(this, "god_x_error", false);
-    setParBool(this, "god_z_error", false);
-    setParBool(this, "god_completely_mixed_error", false);
-    setParBool(this, "god_excitation_error", false);
-    setParBool(this, "god_relaxation_error", false);
-    setParBool(this, "is_busy", false);
     setParInt(this, "god_entangled_stationary_qubit_address", 0);
     setParInt(this, "god_entangled_node_address", 0);
     setParInt(this, "god_entangled_qnic_address", 0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_measurement_test.cc
@@ -90,7 +90,7 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_address", 1);
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
-    setParDouble(this, "std", 0.5);
+    setParDouble(this, "emission_jittering_standard_deviation", 0.5);
   }
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -78,12 +78,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParBool(this, "god_x_error", false);
-    setParBool(this, "god_z_error", false);
-    setParBool(this, "god_completely_mixed_error", false);
-    setParBool(this, "god_excitation_error", false);
-    setParBool(this, "god_relaxation_error", false);
-    setParBool(this, "is_busy", false);
     setParInt(this, "god_entangled_stationary_qubit_address", 0);
     setParInt(this, "god_entangled_node_address", 0);
     setParInt(this, "god_entangled_qnic_address", 0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -102,12 +102,12 @@ TEST(StatQubitMemoryErrorTest, do_nothing) {
 
   qubit->callInitialize();
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
 
   // if current time and updated_time are same, do nothing
   EXPECT_EQ(qubit->updated_time, SimTime(0));
@@ -115,10 +115,10 @@ TEST(StatQubitMemoryErrorTest, do_nothing) {
   qubit->applyMemoryError();
 
   EXPECT_EQ(qubit->updated_time, SimTime(0, SIMTIME_US));
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
 }
 TEST(StatQubitMemoryErrorTest, update_timestamp) {
   auto *sim = prepareSimulation();
@@ -158,51 +158,51 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_no_error) {
   qubit->reset();
   rng->doubleValue = 0.55;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Z error
   rng->doubleValue = 0.65;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Y error
   rng->doubleValue = 0.75;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_x_error) {
@@ -227,58 +227,58 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_x_error) {
 
   // X error
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   rng->doubleValue = 0.55;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Z error
   rng->doubleValue = 0.65;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Y error
   rng->doubleValue = 0.75;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_z_error) {
@@ -303,58 +303,58 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_z_error) {
 
   // X error
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   rng->doubleValue = 0.55;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Z error
   rng->doubleValue = 0.65;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Y error
   rng->doubleValue = 0.75;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
+  qubit->god_err.has_x_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_y_error) {
@@ -379,63 +379,63 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_y_error) {
 
   // X error
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
   rng->doubleValue = 0.15;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Z error
   rng->doubleValue = 0.25;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Y error
   rng->doubleValue = 0.5;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_excitation_error) {
@@ -460,58 +460,58 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_excitation_error) {
 
   // X error
   qubit->reset();
-  qubit->GOD_err.has_EX_error = true;
+  qubit->god_err.has_excitation_error = true;
   rng->doubleValue = 0.15;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Z error
   rng->doubleValue = 0.25;
   qubit->reset();
-  qubit->GOD_err.has_EX_error = true;
+  qubit->god_err.has_excitation_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Y error
   rng->doubleValue = 0.5;
   qubit->reset();
-  qubit->GOD_err.has_EX_error = true;
+  qubit->god_err.has_excitation_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->GOD_err.has_EX_error = true;
+  qubit->god_err.has_excitation_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->GOD_err.has_EX_error = true;
+  qubit->god_err.has_excitation_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_relaxation_error) {
@@ -537,24 +537,24 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_relaxation_error) {
   // Excitation error
   rng->doubleValue = 0.05;
   qubit->reset();
-  qubit->GOD_err.has_RE_error = true;
+  qubit->god_err.has_relaxation_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_TRUE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->GOD_err.has_RE_error = true;
+  qubit->god_err.has_relaxation_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_TRUE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 }  // namespace

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -77,8 +77,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
-
-    setParDouble(this, "fidelity", -1.0);
   }
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -76,7 +76,7 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_address", 1);
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
-    setParDouble(this, "std", 0.5);
+    setParDouble(this, "emission_jittering_standard_deviation", 0.5);
   }
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -78,8 +78,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParDouble(this, "photon_emitted_at", 0.0);
-    setParDouble(this, "last_updated_at", 0.0);
     setParBool(this, "god_x_error", false);
     setParBool(this, "god_z_error", false);
     setParBool(this, "god_completely_mixed_error", false);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -78,10 +78,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParInt(this, "god_entangled_stationary_qubit_address", 0);
-    setParInt(this, "god_entangled_node_address", 0);
-    setParInt(this, "god_entangled_qnic_address", 0);
-    setParInt(this, "god_entangled_qnic_type", 0);
     setParDouble(this, "fidelity", -1.0);
   }
 };

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_memory_error_test.cc
@@ -102,12 +102,12 @@ TEST(StatQubitMemoryErrorTest, do_nothing) {
 
   qubit->callInitialize();
   qubit->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(qubit->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit->par("god_excitation_error"));
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
 
   // if current time and updated_time are same, do nothing
   EXPECT_EQ(qubit->updated_time, SimTime(0));
@@ -115,10 +115,10 @@ TEST(StatQubitMemoryErrorTest, do_nothing) {
   qubit->applyMemoryError();
 
   EXPECT_EQ(qubit->updated_time, SimTime(0, SIMTIME_US));
-  EXPECT_TRUE(qubit->par("god_x_error"));
-  EXPECT_TRUE(qubit->par("god_z_error"));
-  EXPECT_FALSE(qubit->par("god_relaxation_error"));
-  EXPECT_FALSE(qubit->par("god_excitation_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
 }
 TEST(StatQubitMemoryErrorTest, update_timestamp) {
   auto *sim = prepareSimulation();
@@ -158,51 +158,51 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_no_error) {
   qubit->reset();
   rng->doubleValue = 0.55;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Z error
   rng->doubleValue = 0.65;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Y error
   rng->doubleValue = 0.75;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_x_error) {
@@ -227,58 +227,58 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_x_error) {
 
   // X error
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   rng->doubleValue = 0.55;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Z error
   rng->doubleValue = 0.65;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Y error
   rng->doubleValue = 0.75;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_z_error) {
@@ -303,58 +303,58 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_z_error) {
 
   // X error
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   rng->doubleValue = 0.55;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Z error
   rng->doubleValue = 0.65;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Y error
   rng->doubleValue = 0.75;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->par("god_x_error") = true;
+  qubit->GOD_err.has_X_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_y_error) {
@@ -379,63 +379,63 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_y_error) {
 
   // X error
   qubit->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
   rng->doubleValue = 0.15;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Z error
   rng->doubleValue = 0.25;
   qubit->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Y error
   rng->doubleValue = 0.5;
   qubit->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
   qubit->applyMemoryError();
-  EXPECT_TRUE(qubit->par("god_x_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_excitation_error) {
@@ -460,58 +460,58 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_excitation_error) {
 
   // X error
   qubit->reset();
-  qubit->par("god_excitation_error") = true;
+  qubit->GOD_err.has_EX_error = true;
   rng->doubleValue = 0.15;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Z error
   rng->doubleValue = 0.25;
   qubit->reset();
-  qubit->par("god_excitation_error") = true;
+  qubit->GOD_err.has_EX_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Y error
   rng->doubleValue = 0.5;
   qubit->reset();
-  qubit->par("god_excitation_error") = true;
+  qubit->GOD_err.has_EX_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Excitation error
   rng->doubleValue = 0.85;
   qubit->reset();
-  qubit->par("god_excitation_error") = true;
+  qubit->GOD_err.has_EX_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->par("god_excitation_error") = true;
+  qubit->GOD_err.has_EX_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 TEST(StatQubitMemoryErrorTest, apply_memory_error_relaxation_error) {
@@ -537,24 +537,24 @@ TEST(StatQubitMemoryErrorTest, apply_memory_error_relaxation_error) {
   // Excitation error
   rng->doubleValue = 0.05;
   qubit->reset();
-  qubit->par("god_relaxation_error") = true;
+  qubit->GOD_err.has_RE_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 
   // Relaxation error
   rng->doubleValue = 0.95;
   qubit->reset();
-  qubit->par("god_relaxation_error") = true;
+  qubit->GOD_err.has_RE_error = true;
   qubit->applyMemoryError();
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_TRUE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_TRUE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 }  // namespace

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -150,11 +150,11 @@ TEST(StatQubitTest, setFree) {
   sim->registerComponent(qubit);
   qubit->fillParams();
   qubit->callInitialize();
-  qubit->GOD_err.has_X_error = true;
-  qubit->GOD_err.has_Z_error = true;
-  qubit->GOD_err.has_EX_error = true;
-  qubit->GOD_err.has_RE_error = true;
-  qubit->GOD_err.has_CM_error = true;
+  qubit->god_err.has_x_error = true;
+  qubit->god_err.has_z_error = true;
+  qubit->god_err.has_excitation_error = true;
+  qubit->god_err.has_relaxation_error = true;
+  qubit->god_err.has_completely_mixed_error = true;
 
   qubit->setFree(true);
   EXPECT_EQ(qubit->updated_time, simTime());
@@ -165,11 +165,11 @@ TEST(StatQubitTest, setFree) {
   EXPECT_EQ(qubit->updated_time, simTime());
 
   // check the qubit reset properly
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
-  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
-  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
-  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
+  EXPECT_FALSE(qubit->god_err.has_excitation_error);
+  EXPECT_FALSE(qubit->god_err.has_relaxation_error);
+  EXPECT_FALSE(qubit->god_err.has_completely_mixed_error);
 }
 
 TEST(StatQubitTest, setFreeUpdatesTime) {
@@ -195,11 +195,11 @@ TEST(StatQubitTest, addXError) {
   auto *qubit = new StatQubitTarget{};
   qubit->fillParams();
   sim->registerComponent(qubit);
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
   qubit->addXerror();
-  EXPECT_TRUE(qubit->GOD_err.has_X_error);
+  EXPECT_TRUE(qubit->god_err.has_x_error);
   qubit->addXerror();
-  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->god_err.has_x_error);
 }
 
 TEST(StatQubitTest, addZError) {
@@ -207,11 +207,11 @@ TEST(StatQubitTest, addZError) {
   auto *qubit = new StatQubitTarget{};
   qubit->fillParams();
   sim->registerComponent(qubit);
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
   qubit->addZerror();
-  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
+  EXPECT_TRUE(qubit->god_err.has_z_error);
   qubit->addZerror();
-  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->god_err.has_z_error);
 }
 
 TEST(StatQubitTest, getErrorMatrixTest) {

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -82,12 +82,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParBool(this, "god_x_error", false);
-    setParBool(this, "god_z_error", false);
-    setParBool(this, "god_completely_mixed_error", false);
-    setParBool(this, "god_excitation_error", false);
-    setParBool(this, "god_relaxation_error", false);
-    setParBool(this, "is_busy", false);
     setParInt(this, "god_entangled_stationary_qubit_address", 0);
     setParInt(this, "god_entangled_node_address", 0);
     setParInt(this, "god_entangled_qnic_address", 0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -82,8 +82,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParDouble(this, "photon_emitted_at", 0.0);
-    setParDouble(this, "last_updated_at", 0.0);
     setParBool(this, "god_x_error", false);
     setParBool(this, "god_z_error", false);
     setParBool(this, "god_completely_mixed_error", false);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -150,11 +150,11 @@ TEST(StatQubitTest, setFree) {
   sim->registerComponent(qubit);
   qubit->fillParams();
   qubit->callInitialize();
-  qubit->par("god_x_error") = true;
-  qubit->par("god_z_error") = true;
-  qubit->par("god_excitation_error") = true;
-  qubit->par("god_relaxation_error") = true;
-  qubit->par("god_completely_mixed_error") = true;
+  qubit->GOD_err.has_X_error = true;
+  qubit->GOD_err.has_Z_error = true;
+  qubit->GOD_err.has_EX_error = true;
+  qubit->GOD_err.has_RE_error = true;
+  qubit->GOD_err.has_CM_error = true;
 
   qubit->setFree(true);
   EXPECT_EQ(qubit->updated_time, simTime());
@@ -165,11 +165,11 @@ TEST(StatQubitTest, setFree) {
   EXPECT_EQ(qubit->updated_time, simTime());
 
   // check the qubit reset properly
-  EXPECT_FALSE(qubit->par("god_x_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_z_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_excitation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_relaxation_error").boolValue());
-  EXPECT_FALSE(qubit->par("god_completely_mixed_error").boolValue());
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
+  EXPECT_FALSE(qubit->GOD_err.has_EX_error);
+  EXPECT_FALSE(qubit->GOD_err.has_RE_error);
+  EXPECT_FALSE(qubit->GOD_err.has_CM_error);
 }
 
 TEST(StatQubitTest, setFreeUpdatesTime) {
@@ -195,11 +195,11 @@ TEST(StatQubitTest, addXError) {
   auto *qubit = new StatQubitTarget{};
   qubit->fillParams();
   sim->registerComponent(qubit);
-  EXPECT_FALSE(qubit->par("god_x_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
   qubit->addXerror();
-  EXPECT_TRUE(qubit->par("god_x_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_X_error);
   qubit->addXerror();
-  EXPECT_FALSE(qubit->par("god_x_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_X_error);
 }
 
 TEST(StatQubitTest, addZError) {
@@ -207,11 +207,11 @@ TEST(StatQubitTest, addZError) {
   auto *qubit = new StatQubitTarget{};
   qubit->fillParams();
   sim->registerComponent(qubit);
-  EXPECT_FALSE(qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
   qubit->addZerror();
-  EXPECT_TRUE(qubit->par("god_z_error"));
+  EXPECT_TRUE(qubit->GOD_err.has_Z_error);
   qubit->addZerror();
-  EXPECT_FALSE(qubit->par("god_z_error"));
+  EXPECT_FALSE(qubit->GOD_err.has_Z_error);
 }
 
 TEST(StatQubitTest, getErrorMatrixTest) {

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -80,7 +80,7 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_address", 1);
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
-    setParDouble(this, "std", 0.5);
+    setParDouble(this, "emission_jittering_standard_deviation", 0.5);
   }
 };
 

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -82,10 +82,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParInt(this, "god_entangled_stationary_qubit_address", 0);
-    setParInt(this, "god_entangled_node_address", 0);
-    setParInt(this, "god_entangled_qnic_address", 0);
-    setParInt(this, "god_entangled_qnic_type", 0);
     setParDouble(this, "fidelity", -1.0);
   }
 };

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -81,8 +81,6 @@ class StatQubitTarget : public StationaryQubit {
     setParInt(this, "qnic_type", 0);
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
-
-    setParDouble(this, "fidelity", -1.0);
   }
 };
 

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -675,8 +675,8 @@ void RuleEngine::Unlock_resource_and_discard(unsigned long ruleset_id, int rule_
           // Purification failed, discard resource.
           qubit->Unlock();
           QNIC_type qt = (QNIC_type)qubit->qnic_type;
-          qubit->par("god_x_error") = false;
-          qubit->par("god_z_error") = false;
+          qubit->GOD_err.has_X_error = false;
+          qubit->GOD_err.has_Z_error = false;
           // remove from current rule
           (*rule)->resources.erase(qubit_record);
           freeConsumedResource(qubit->qnic_index, qubit, qt);  // Remove from entangled resource list.

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -675,8 +675,8 @@ void RuleEngine::Unlock_resource_and_discard(unsigned long ruleset_id, int rule_
           // Purification failed, discard resource.
           qubit->Unlock();
           QNIC_type qt = (QNIC_type)qubit->qnic_type;
-          qubit->GOD_err.has_X_error = false;
-          qubit->GOD_err.has_Z_error = false;
+          qubit->god_err.has_x_error = false;
+          qubit->god_err.has_z_error = false;
           // remove from current rule
           (*rule)->resources.erase(qubit_record);
           freeConsumedResource(qubit->qnic_index, qubit, qt);  // Remove from entangled resource list.

--- a/quisp/rules/Active/actions/SwappingAction.cc
+++ b/quisp/rules/Active/actions/SwappingAction.cc
@@ -56,8 +56,8 @@ cPacket *SwappingAction::run(cModule *re) {
   right_qubit->CNOT_gate(left_qubit);
 
   // TODO This is a little bit cheating. This must be tracked!
-  int lindex = left_partner_qubit->stationaryQubit_address;
-  int rindex = right_partner_qubit->stationaryQubit_address;
+  int lindex = left_partner_qubit->stationary_qubit_address;
+  int rindex = right_partner_qubit->stationary_qubit_address;
 
   auto left_measure = left_qubit->localMeasureX();
   auto right_measure = right_qubit->localMeasureZ();

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -113,8 +113,6 @@ class MockQubit : public IStationaryQubit {
     setParInt(this, "qnic_index", 0);
     setParDouble(this, "std", 0.5);
 
-    setParDouble(this, "photon_emitted_at", 0.0);
-    setParDouble(this, "last_updated_at", 0.0);
     setParBool(this, "god_x_error", false);
     setParBool(this, "god_z_error", false);
     setParBool(this, "god_completely_mixed_error", false);


### PR DESCRIPTION
This PR speeds up StationaryQubit by eliminating the usage of par() as normal variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/443)
<!-- Reviewable:end -->
