### PR TITLE
Fix simple traffic generator bug

### DIFF
--- a/quisp/modules/Application/Application.cc
+++ b/quisp/modules/Application/Application.cc
@@ -41,9 +41,9 @@ void Application::initialize() {
   }
 
   createEndNodeWeightMap();
-  generateTraffic();
   generateTrafficMsg = new GenerateTraffic("GenerateTraffic");
   scheduleAt(simTime() + 100, generateTrafficMsg);
+  generateTraffic();
 }
 
 /**


### PR DESCRIPTION
Currently, the method `GenerateTraffic()` tries to delete the self message before it is actually created. 