### PR TITLE
Enable setting target nodes to traffic generator

### DIFF
--- a/quisp/modules/Application/Application.cc
+++ b/quisp/modules/Application/Application.cc
@@ -122,7 +122,7 @@ void Application::createEndNodeWeightMap() {
   if (!par("has_specific_recipients").boolValue()) {
     // set self weight to 0; so we don't create self traffic
     temp_end_node_weight_map[my_address] = 0;
-    end_node_weight_map = std::ref(temp_end_node_weight_map);
+    std::swap(end_node_weight_map, temp_end_node_weight_map);
     return;
   }
 

--- a/quisp/modules/Application/Application.cc
+++ b/quisp/modules/Application/Application.cc
@@ -106,24 +106,42 @@ void Application::handleMessage(cMessage *msg) {
  */
 void Application::createEndNodeWeightMap() {
   cTopology *topo = new cTopology("topo");
+  std::unordered_map<int, int> temp_end_node_weight_map;
 
   topo->extractByParameter("node_type", provider.getQNode()->par("node_type").str().c_str());
 
   for (int i = 0; i < topo->getNumNodes(); i++) {
     cModule *endnodeModule = topo->getNode(i)->getModule();
-
-    int addr = endnodeModule->par("address").intValue();
+    int address = endnodeModule->par("address").intValue();
     int weight = endnodeModule->par("mass").intValue();
 
-    if (addr == my_address) {
-      // set self weight to 0 to avoid creating connection request with self
-      end_node_weight_map[addr] = 0;
-    } else {
-      end_node_weight_map[addr] = weight;
-    }
+    temp_end_node_weight_map[address] = weight;
+  }
+  delete topo;
+
+  if (!par("has_specific_recipients").boolValue()) {
+    // set self weight to 0; so we don't create self traffic
+    temp_end_node_weight_map[my_address] = 0;
+    end_node_weight_map = std::ref(temp_end_node_weight_map);
+    return;
   }
 
-  delete topo;
+  auto recipient_addresses = ((cValueArray *)(par("possible_recipients").objectValue()))->asIntVector();
+
+  for (int address : recipient_addresses) {
+    if (temp_end_node_weight_map.find(address) == temp_end_node_weight_map.end()) {
+      error("possible recipints list contains non-existing address");
+    }
+    end_node_weight_map[address] = temp_end_node_weight_map[address];
+  }
+
+  // error checking
+  if (recipient_addresses.size() == 0) {
+    error("setting has_specific_recipients to true but given an empty array of recipients is not allowed");
+  }
+  if (end_node_weight_map[my_address] != 0) {
+    error("setting self as possible recipient is not allowed");
+  }
 }
 
 void Application::generateTraffic() {

--- a/quisp/modules/Application/Application.ned
+++ b/quisp/modules/Application/Application.ned
@@ -10,6 +10,8 @@ simple Application
         @display("i=block/app");
         volatile double request_generation_interval @unit(s) = default(exponential(5s)); // time between generating packets
         volatile int number_of_bellpair;
+        bool has_specific_recipients = default(false);
+        object possible_recipients = default([]);
 
     gates:
         input fromRouter @loose;

--- a/quisp/modules/Application/Application_test.cc
+++ b/quisp/modules/Application/Application_test.cc
@@ -205,7 +205,7 @@ TEST(AppTest, Specifying_Valid_Addresses_As_Recipients) {
   app->callInitialize();
 
   ASSERT_EQ(app->getAddress(), mock_qnode->address);
-  ASSERT_EQ(app->getEndNodeWeightMap().size(), 2); // self and 456
+  ASSERT_EQ(app->getEndNodeWeightMap().size(), 2);  // self and 456
   ASSERT_NE(app->getEndNodeWeightMap().find(123), app->getEndNodeWeightMap().end());
   ASSERT_NE(app->getEndNodeWeightMap().find(456), app->getEndNodeWeightMap().end());
   ASSERT_EQ(app->getEndNodeWeightMap().find(789), app->getEndNodeWeightMap().end());

--- a/quisp/modules/Application/Application_test.cc
+++ b/quisp/modules/Application/Application_test.cc
@@ -64,6 +64,7 @@ TEST(AppTest, Init_IsInitiator) {
 
   setParDouble(app, "request_generation_interval", 5);
   setParInt(app, "number_of_bellpair", 10);
+  setParBool(app, "has_specific_recipients", false);
 
   sim->registerComponent(app);
   app->callInitialize();
@@ -83,6 +84,7 @@ TEST(AppTest, Init_WeightMap_Generation) {
   auto *app = new AppTestTarget{mock_qnode};
   setParDouble(app, "request_generation_interval", 5);
   setParInt(app, "number_of_bellpair", 10);
+  setParBool(app, "has_specific_recipients", false);
 
   sim->registerComponent(app);
   app->callInitialize();
@@ -106,6 +108,7 @@ TEST(AppTest, Init_Connection_Setup_Message_Send) {
 
   setParDouble(app, "request_generation_interval", 5);
   setParInt(app, "number_of_bellpair", 10);
+  setParBool(app, "has_specific_recipients", false);
 
   sim->registerComponent(app);
   app->callInitialize();

--- a/quisp/test_utils/UtilFunctions.cc
+++ b/quisp/test_utils/UtilFunctions.cc
@@ -1,5 +1,6 @@
 #include "UtilFunctions.h"
 #include <omnetpp.h>
+#include <omnetpp/cobjectparimpl.h>
 #include "RNG.h"
 #include "StaticEnv.h"
 
@@ -53,6 +54,18 @@ void setParBool(cModule *module, const char *name, const bool val) {
   cParImpl *p = new cBoolParImpl();
   p->setName(name);
   p->setBoolValue(val);
+  p->setIsMutable(true);
+  module->addPar(p);
+}
+
+void setParObject(cModule *module, const char *name, cObject *val) {
+  if (module->findPar(name) != -1) {
+    module->par(name) = val;
+    return;
+  }
+  cParImpl *p = new cObjectParImpl();
+  p->setName(name);
+  p->setObjectValue(val);
   p->setIsMutable(true);
   module->addPar(p);
 }

--- a/quisp/test_utils/UtilFunctions.h
+++ b/quisp/test_utils/UtilFunctions.h
@@ -14,6 +14,7 @@ void setParInt(cModule *module, const char *name, const int val);
 void setParDouble(cModule *module, const char *name, const double val);
 void setParBool(cModule *module, const char *name, const bool val);
 void setParStr(cModule *module, const char *name, const char *val);
+void setParObject(cModule *module, const char *name, omnetpp::cObject *val);
 TestSimulation *prepareSimulation();
 TestSimulation *getTestSimulation();
 omnetpp::cEnvir *createStaticEnv();


### PR DESCRIPTION
Add functionality to set target nodes to application for traffic generator.

Example usecase

In `.ini` files, one can add

```
*.EndNode1.app.has_specific_recipients = true;
*.EndNode1.app.possible_recipients = [1, 2, 3]; // needs to be valid addresses inside the network
```

If `app.has_specific_recipients` is set to `false`. The behaviour of traffic generator will revert back to selecting a random node in the network as receiver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/460)
<!-- Reviewable:end -->
