### PR TITLE
fix incorrect variable swapping in gateH

### DIFF
--- a/quisp/backends/ErrorTracking/Qubit.cc
+++ b/quisp/backends/ErrorTracking/Qubit.cc
@@ -369,7 +369,7 @@ void ErrorTrackingQubit::gateH() {
   applySingleQubitGateError(gate_err_h);
   bool z = has_z_error;
   has_z_error = has_x_error;
-  has_z_error = z;
+  has_x_error = z;
 }
 void ErrorTrackingQubit::gateCNOT(IQubit* const control_qubit) {
   // Need to add noise here later


### PR DESCRIPTION
Fixed the incorrect program inside gateH function in error tracking backend, by correctly swapping has_x_error and has_z_error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/466)
<!-- Reviewable:end -->
