### PR TITLE
Remove assert entangled

### DIFF
--- a/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/IRealTimeController.h
@@ -18,7 +18,6 @@ class IRealTimeController : public cSimpleModule {
   virtual void ReInitialize_StationaryQubit(qrsa::IQubitRecord* const qubit_record, bool consumed) = 0;
   virtual void applyXGate(qrsa::IQubitRecord* const qubit_record) = 0;
   virtual void applyZGate(qrsa::IQubitRecord* const qubit_record) = 0;
-  virtual void assertNoEntanglement(qrsa::IQubitRecord* const qubit_record) = 0;
 };
 }  // namespace modules
 }  // namespace quisp

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.cc
@@ -43,9 +43,5 @@ void RealTimeController::applyZGate(qrsa::IQubitRecord *const qubit_record) {
   auto *qubit = provider.getStationaryQubit(qubit_record);
   qubit->gateZ();
 }
-void RealTimeController::assertNoEntanglement(qrsa::IQubitRecord *const qubit_record) {
-  auto *qubit = provider.getStationaryQubit(qubit_record);
-  qubit->assertEntangledPartnerValid();
-}
 }  // namespace modules
 }  // namespace quisp

--- a/quisp/modules/QRSA/RealTimeController/RealTimeController.h
+++ b/quisp/modules/QRSA/RealTimeController/RealTimeController.h
@@ -33,7 +33,6 @@ class RealTimeController : public IRealTimeController {
 
   void applyXGate(qrsa::IQubitRecord* const qubit_record) override;
   void applyZGate(qrsa::IQubitRecord* const qubit_record) override;
-  void assertNoEntanglement(qrsa::IQubitRecord* const qubit_record) override;
   utils::ComponentProvider provider;
 };
 

--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -500,7 +500,6 @@ void RuleEngine::freeFailedQubits_and_AddAsResource(int destAddr, int internal_q
       // Keep the entangled qubits
       auto *qubit_record = qnic_store->getQubitRecord(qnic_type, qnic_index, it->second.qubit_index);
       IStationaryQubit *qubit = provider.getStationaryQubit(qubit_record);
-      qubit->assertEntangledPartnerValid();
       // Add qubit as available resource between NeighborQNodeAddress.
       bell_pair_store.insertEntangledQubit(neighborQNodeAddress, qubit_record);
     }

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -41,7 +41,6 @@ class MockQubit : public IStationaryQubit {
   MOCK_METHOD(quisp::types::MeasurementOutcome, measureRandomPauliBasis, (), (override));
   MOCK_METHOD(void, setEntangledPartnerInfo, (IStationaryQubit *), (override));
 
-  MOCK_METHOD(void, assertEntangledPartnerValid, (), (override));
   MOCK_METHOD(IQubit *const, getEntangledPartner, (), (const, override));
   MOCK_METHOD(IQubit *const, getBackendQubitRef, (), (const, override));
   MOCK_METHOD(int, getPartnerStationaryQubitAddress, (), (const, override));

--- a/quisp/test_utils/mock_modules/MockQubit.h
+++ b/quisp/test_utils/mock_modules/MockQubit.h
@@ -41,6 +41,7 @@ class MockQubit : public IStationaryQubit {
   MOCK_METHOD(quisp::types::MeasurementOutcome, measureRandomPauliBasis, (), (override));
   MOCK_METHOD(void, setEntangledPartnerInfo, (IStationaryQubit *), (override));
 
+  MOCK_METHOD(void, assertEntangledPartnerValid, (), (override));
   MOCK_METHOD(IQubit *const, getEntangledPartner, (), (const, override));
   MOCK_METHOD(IQubit *const, getBackendQubitRef, (), (const, override));
   MOCK_METHOD(int, getPartnerStationaryQubitAddress, (), (const, override));

--- a/quisp/test_utils/mock_modules/MockRealTimeController.h
+++ b/quisp/test_utils/mock_modules/MockRealTimeController.h
@@ -20,7 +20,6 @@ class MockRealTimeController : public quisp::modules::IRealTimeController {
   MOCK_METHOD(void, ReInitialize_StationaryQubit, (IQubitRecord* const qubit_record, bool consumed), (override));
   MOCK_METHOD(void, applyXGate, (IQubitRecord* const qubit_record), (override));
   MOCK_METHOD(void, applyZGate, (IQubitRecord* const qubit_record), (override));
-  MOCK_METHOD(void, assertNoEntanglement, (IQubitRecord* const qubit_record), (override));
 };
 }  // namespace realtime_controller
 }  // namespace mock_modules


### PR DESCRIPTION
Removed assertEntangledPartnerValid from rule engine and realtime controller. This PR solves issue #483 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/484)
<!-- Reviewable:end -->
