### PR TITLE
fix devcontainer port notation for running multiple devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,44 +1,40 @@
 {
 	"name": "QuISP Dev",
-
 	"containerEnv": {
 		"DOCKER_DEFAULT_PLATFORM": "$(echo $(uname) | tr '[:upper:]' '[:lower:]')/$(uname -i)"
 	},
-
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 	"remoteUser": "vscode",
 	"postStartCommand": "sudo service ssh start",
-
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		2222
+		2222, // SSH
+		5901, // VNC
+		6080 // noVNC
 	],
-
-	"appPort": ["2222:22", "5901:5901", "6080:6080"], // [SSH, VNC, noVNC]
-
 	"features": {
 		"ghcr.io/devcontainers/features/desktop-lite:1": {
 			"version": "latest"
 		}
 	},
-
 	/*"runArgs": ["--net-host", "--shm-size=1g"],
 	"remoteEnv": {
 		"DISPLAY": ":0"
 	},*/
-
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"ms-python.python",
+				"ms-toolsai.jupyter",
 				"ms-vscode-remote.remote-containers",
 				"llvm-vs-code-extensions.vscode-clangd",
 				"vadimcn.vscode-lldb",
-				"matepek.vscode-catch2-test-adapter"
+				"matepek.vscode-catch2-test-adapter",
+				"littlefoxteam.vscode-python-test-adapter"
 			]
 		}
 	}


### PR DESCRIPTION
when we run multiple devcontainers, the ports are conflicted.
this PR fixes it not to bind host machines same ports.

and also add default extensions in devcontainer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/489)
<!-- Reviewable:end -->
