### PR TITLE
ignore spdlog in pytest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,5 +49,6 @@
         "--ignore=googletest",
         "--ignore=eigen",
         "--ignore=scripts",
+        "--ignore=spdlog"
     ]
 }


### PR DESCRIPTION
fix this situation reported by @Naphann 
![](https://media.discordapp.net/attachments/915447580828254228/1075076717896544316/image.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/493)
<!-- Reviewable:end -->
