### PR TITLE
set sim-time-limit in unit tests

### DIFF
--- a/quisp/modules/Application/Application_test.cc
+++ b/quisp/modules/Application/Application_test.cc
@@ -106,6 +106,7 @@ TEST(AppTest, Init_Connection_Setup_Message_Send) {
   auto *mock_qnode = new TestQNode{123, 100, true};
   auto *mock_qnode2 = new TestQNode{456, 100, false};
   auto *app = new AppTestTarget{mock_qnode};
+  sim->setConfigValue("sim-time-limit", "5.1s");
 
   setParDouble(app, "request_generation_interval", 5);
   setParInt(app, "number_of_bellpair", 10);

--- a/quisp/test_utils/Configuration.cc
+++ b/quisp/test_utils/Configuration.cc
@@ -1,0 +1,21 @@
+#include "Configuration.h"
+
+namespace quisp_test::configuration {
+
+Configuration::Configuration() {
+  kvs = std::vector<TestKeyValue>();
+  auto kv = TestKeyValue{"sim-time-limit", "10.0s"};
+  kvs.push_back(kv);
+}
+const char *Configuration::getConfigValue(const char *key) const {
+  for (auto &kv : kvs) {
+    if (strcmp(kv.getKey(), key) == 0) {
+      return kv.getValue();
+    }
+  }
+  return nullptr;
+};
+const Configuration::KeyValue &Configuration::getConfigEntry(const char *key) const { return kvs.at(0); };
+
+const char *Configuration::getPerObjectConfigValue(const char *objectFullPath, const char *keySuffix) const { return nullptr; };
+}  // namespace quisp_test::configuration

--- a/quisp/test_utils/Configuration.h
+++ b/quisp/test_utils/Configuration.h
@@ -3,27 +3,19 @@
 #include <omnetpp.h>
 #include "KeyValue.h"
 
-namespace quisp_test {
-namespace configuration {
+namespace quisp_test::configuration {
 
 using key_value::TestKeyValue;
 
 class Configuration : public omnetpp::cConfiguration {
- private:
-  std::vector<TestKeyValue> kvs;
-
  public:
-  Configuration() {
-    kvs = std::vector<TestKeyValue>();
-    auto kv = TestKeyValue{};
-    kvs.push_back(kv);
-  }
-  virtual const char *getConfigValue(const char *key) const override { return nullptr; };
-  virtual const KeyValue &getConfigEntry(const char *key) const override { return kvs.at(0); };
-  virtual const char *getPerObjectConfigValue(const char *objectFullPath, const char *keySuffix) const override { return nullptr; };
+  Configuration();
+  virtual const char *getConfigValue(const char *key) const override;
+  virtual const KeyValue &getConfigEntry(const char *key) const override;
+  virtual const char *getPerObjectConfigValue(const char *objectFullPath, const char *keySuffix) const override;
   virtual const KeyValue &getPerObjectConfigEntry(const char *objectFullPath, const char *keySuffix) const override { return kvs.at(0); };
   virtual const char *substituteVariables(const char *value) const override { return nullptr; };
+  std::vector<TestKeyValue> kvs;
 };
 
-}  // namespace configuration
-}  // namespace quisp_test
+}  // namespace quisp_test::configuration

--- a/quisp/test_utils/KeyValue.h
+++ b/quisp/test_utils/KeyValue.h
@@ -2,16 +2,17 @@
 
 #include <omnetpp.h>
 
-namespace quisp_test {
-namespace key_value {
+namespace quisp_test::key_value {
 
 class TestKeyValue : public omnetpp::cConfiguration::KeyValue {
  public:
+  TestKeyValue(const char *key, const char *value) : key(key), value(value) {}
   TestKeyValue() {}
-  const char *getKey() const override { return ""; };
-  const char *getValue() const override { return ""; };
+  const char *key = "";
+  const char *value = "";
+  const char *getKey() const override { return key; };
+  const char *getValue() const override { return value; };
   const char *getBaseDirectory() const override { return ""; };
 };
 
-}  // namespace key_value
-}  // namespace quisp_test
+}  // namespace quisp_test::key_value

--- a/quisp/test_utils/Simulation.cc
+++ b/quisp/test_utils/Simulation.cc
@@ -1,10 +1,10 @@
 #include "Simulation.h"
 #include "omnetpp/cexception.h"
+#include "test_utils/Configuration.h"
 
 using namespace omnetpp;
 
-namespace quisp_test {
-namespace simulation {
+namespace quisp_test::simulation {
 
 /**
  * \brief simulation class for unit test.
@@ -35,15 +35,24 @@ bool TestSimulation::executeNextEvent() {
     cEvent *event = takeNextEvent();
     if (event) {
       executeEvent(event);
-      return true;
+      return false;
     };
   } catch (cTerminationException &e) {
   } catch (std::exception &e) {
     std::cerr << "ERROR: " << e.what() << std::endl;
     throw e;
   }
-  return false;
+  return true;
 }
 
-}  // namespace simulation
-}  // namespace quisp_test
+void TestSimulation::setConfigValue(const char *key, const char *value) {
+  auto *envir = getActiveEnvir();
+  auto *config = dynamic_cast<configuration::Configuration *>(envir->getConfig());
+  for (auto &kv : config->kvs) {
+    if (strcmp(kv.getKey(), key) == 0) {
+      kv.value = value;
+      return;
+    }
+  }
+}
+}  // namespace quisp_test::simulation

--- a/quisp/test_utils/Simulation.h
+++ b/quisp/test_utils/Simulation.h
@@ -2,8 +2,7 @@
 #include <omnetpp.h>
 #include "omnetpp/ceventheap.h"
 
-namespace quisp_test {
-namespace simulation {
+namespace quisp_test::simulation {
 
 using omnetpp::cEnvir;
 using omnetpp::cEvent;
@@ -11,11 +10,11 @@ using omnetpp::cSimulation;
 
 class TestSimulation : public cSimulation {
  public:
-  TestSimulation(const char *name, cEnvir *env);
+  TestSimulation(const char* name, cEnvir* env);
   void finishNetworkSetup();
   void run();
+  void setConfigValue(const char* key, const char* value);
   bool executeNextEvent();
 };
 
-}  // namespace simulation
-}  // namespace quisp_test
+}  // namespace quisp_test::simulation

--- a/quisp/test_utils/StaticEnv.cc
+++ b/quisp/test_utils/StaticEnv.cc
@@ -4,13 +4,12 @@
 #include "omnetpp/cownedobject.h"
 #include "omnetpp/csimulation.h"
 
-namespace quisp_test {
-namespace env {
+namespace quisp_test::env {
 using configuration::Configuration;
 
-StaticEnv::StaticEnv() {}
+StaticEnv::StaticEnv() : config(new Configuration) {}
 
-cConfiguration *StaticEnv::getConfig() { return new Configuration(); }
+cConfiguration *StaticEnv::getConfig() { return config; }
 std::string StaticEnv::gets(const char *prompt, const char *defaultreply) {
   unsupported();
   return "";
@@ -55,5 +54,4 @@ void StaticEnv::resetSimulation() {
   }
 }
 
-}  // namespace env
-}  // namespace quisp_test
+}  // namespace quisp_test::env

--- a/quisp/test_utils/StaticEnv.h
+++ b/quisp/test_utils/StaticEnv.h
@@ -2,9 +2,9 @@
 
 #include <omnetpp.h>
 #include "Configuration.h"
+#include "omnetpp/cconfiguration.h"
 
-namespace quisp_test {
-namespace env {
+namespace quisp_test::env {
 
 using namespace omnetpp;
 
@@ -148,7 +148,7 @@ class StaticEnv : public omnetpp::cEnvir {
   cSimulation *newSimulation();
   void resetSimulation();
   cRNG *rng = nullptr;
+  cConfiguration *config = nullptr;
 };
 
-}  // namespace env
-}  // namespace quisp_test
+}  // namespace quisp_test::env


### PR DESCRIPTION
this change allows developer to set the arbitrary simulation config value in unit tests.

* add `TestSimulation::setConfigValue` to set `sim-time-limit` for simulation
* fix `TestSimulation::executeNextEvent` bug
* set `sim-time-limit` in application test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/495)
<!-- Reviewable:end -->
