### PR TITLE
clarify QNIC_id meaning in BSAController

### DIFF
--- a/quisp/modules/PhysicalConnection/BSA/BSAController.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BSAController.cc
@@ -22,7 +22,7 @@ void BSAController::initialize() {
   // if this BSA is internal set left to be self node
   if (strcmp(getParentModule()->getName(), "qnic_r") == 0) {
     address = provider.getQNode()->par("address").intValue();
-    left_qnic.address = provider.getQNode()->par("address").intValue();
+    left_qnic.parent_node_addr = provider.getQNode()->par("address").intValue();
     left_qnic.index = getParentModule()->par("self_qnic_index").intValue();
     left_qnic.type = QNIC_R;
   } else {
@@ -75,10 +75,10 @@ void BSAController::sendMeasurementResults(BatchClickEvent *batch_click_msg) {
     if (!batch_click_msg->getClickResults(index).success) continue;
     leftpk->appendSuccessIndex(index);
     leftpk->appendCorrectionOperation(PauliOperator::I);
-    leftpk->setNeighborAddress(right_qnic.address);
+    leftpk->setNeighborAddress(right_qnic.parent_node_addr);
     rightpk->appendSuccessIndex(index);
     rightpk->appendCorrectionOperation(batch_click_msg->getClickResults(index).correction_operation);
-    rightpk->setNeighborAddress(left_qnic.address);
+    rightpk->setNeighborAddress(left_qnic.parent_node_addr);
   }
   send(leftpk, "to_router");
   send(rightpk, "to_router");
@@ -88,7 +88,7 @@ void BSAController::sendMeasurementResults(BatchClickEvent *batch_click_msg) {
 }
 
 BSMTimingNotification *BSAController::generateFirstNotificationTiming(bool is_left) {
-  int destination = (is_left) ? left_qnic.address : right_qnic.address;
+  int destination = (is_left) ? left_qnic.parent_node_addr : right_qnic.parent_node_addr;
   int qnic_index = (is_left) ? left_qnic.index : right_qnic.index;
   auto qnic_type = (is_left) ? left_qnic.type : right_qnic.type;
   auto *notification_packet = new BSMTimingNotification();
@@ -108,7 +108,7 @@ BSMTimingNotification *BSAController::generateFirstNotificationTiming(bool is_le
 }
 
 CombinedBSAresults *BSAController::generateNextNotificationTiming(bool is_left) {
-  int destination = (is_left) ? left_qnic.address : right_qnic.address;
+  int destination = (is_left) ? left_qnic.parent_node_addr : right_qnic.parent_node_addr;
   int qnic_index = (is_left) ? left_qnic.index : right_qnic.index;
   auto qnic_type = (is_left) ? left_qnic.type : right_qnic.type;
   auto *notification_packet = new CombinedBSAresults();
@@ -204,12 +204,8 @@ simtime_t BSAController::getTravelTimeFromPort(int port) {
   return SimTime(distance / speed_of_light_in_channel);
 }
 
-QNIC_id BSAController::getExternalQNICInfoFromPort(int port) {
-  QNIC_id qid;
-  qid.address = getExternalAdressFromPort(port);
-  qid.index = getExternalQNICIndexFromPort(port);
-  qid.type = QNIC_E;
-  return qid;
+BSAController::QNicInfo BSAController::getExternalQNICInfoFromPort(int port) {
+  return QNicInfo{.type = QNIC_E, .index = getExternalQNICIndexFromPort(port), .parent_node_addr = getExternalAdressFromPort(port)};
 }
 
 void BSAController::cancelBSMTimeOut() {

--- a/quisp/modules/PhysicalConnection/BSA/BSAController.h
+++ b/quisp/modules/PhysicalConnection/BSA/BSAController.h
@@ -37,6 +37,13 @@ namespace quisp::modules {
  *  how many photons will arrive, when the first one will arrive, and what the iterval is.
  */
 class BSAController : public cSimpleModule {
+ private:
+  struct QNicInfo {
+    QNIC_type type;
+    int index;
+    int parent_node_addr;
+  };
+
  public:
   BSAController();
   ~BSAController();
@@ -56,13 +63,13 @@ class BSAController : public cSimpleModule {
   simtime_t calculateOffsetTimeFromDistance();
   simtime_t getTravelTimeFromPort(int port);
   double getExternalDistanceFromPort(int port);
-  QNIC_id getExternalQNICInfoFromPort(int port);
+  QNicInfo getExternalQNICInfoFromPort(int port);
   void sendMeasurementResults(BatchClickEvent* msg);
 
   // information for communications
   int address;
-  QNIC_id left_qnic;
-  QNIC_id right_qnic;
+  QNicInfo left_qnic;
+  QNicInfo right_qnic;
   simtime_t left_travel_time;
   simtime_t right_travel_time;
 


### PR DESCRIPTION
prev: #501 next: #503
the `QNIC` and `QNIC_id` is so confusing class for identifying QNIC and the `address` is used in two meanings:
1. `par("self_qnic_address")`
2. QNode address

In this PR, I added new class `QNicInfo` to clarify its meaning for BSA Controller internal usage.
```cpp
struct QNicInfo {
  QNIC_type type;
  int index;
  int parent_node_addr;
};
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/502)
<!-- Reviewable:end -->
