### PR TITLE
Delete QNIC_id struct

### DIFF
--- a/module_tests/routingdaemon/RoutingDaemon.test
+++ b/module_tests/routingdaemon/RoutingDaemon.test
@@ -121,15 +121,13 @@ using namespace omnetpp;
 using namespace quisp::messages;
 namespace RoutingDaemon {
 
-class TestRoutingDaemon : public quisp::modules::RoutingDaemon {
+class TestRoutingDaemon : public quisp::modules::routing_daemon::RoutingDaemon {
  public:
   TestRoutingDaemon() : RoutingDaemon() {}
   void finish() override {
     int other_node_addr = 3 - myAddress;
-    if (qrtable[other_node_addr].pointer == nullptr) 
-      printf("FAIL: routing table is not updated and the the pointer is nullptr\n");
-    if (qrtable[other_node_addr].address != myAddress) 
-      printf("FAIL: in the routing table, the value is %d but the expected value is %d\n", qrtable[other_node_addr].address, myAddress);
+    if (qrtable[other_node_addr] != myAddress)
+      printf("FAIL: in the routing table, the value is %d but the expected value is %d\n", qrtable[other_node_addr], myAddress);
   }
 };
 Define_Module(TestRoutingDaemon);

--- a/quisp/messages/base_messages.msg
+++ b/quisp/messages/base_messages.msg
@@ -4,7 +4,7 @@ cplusplus  {{
     #include <rules/RuleSet.h>
     #include <nlohmann/json.hpp>
     using quisp::rules::RuleSet;
-    using quisp::modules::QNIC_pair_info;
+    using quisp::modules::QNicPairInfo;
     using nlohmann::json;
 }}
 
@@ -13,7 +13,7 @@ class QNIC_type {
     @opaque;
 };
 
-class QNIC_pair_info {
+class QNicPairInfo {
     @existingClass;
     @opaque;
 };

--- a/quisp/messages/connection_setup_messages.msg
+++ b/quisp/messages/connection_setup_messages.msg
@@ -12,7 +12,7 @@ packet ConnectionSetupRequest extends Header
     int number_of_required_Bellpairs;
     int stack_of_QNodeIndexes[];
     int stack_of_linkCosts[];
-    QNIC_pair_info stack_of_QNICs[];
+    QNicPairInfo stack_of_QNICs[];
 }
 
 packet RejectConnectionSetupRequest extends Header

--- a/quisp/modules/QNIC.h
+++ b/quisp/modules/QNIC.h
@@ -33,26 +33,19 @@ static const char* QNIC_names[QNIC_N] = {
     "qnic_rp",
 };
 
-typedef struct {
+struct QNIC {
   QNIC_type type;
   int index;
+  // QNIC's self_qnic_address
   int address;
-  bool isReserved;
-} QNIC_id;
+  // Pointer to that particular QNIC.
+  cModule* pointer = nullptr;
+};
 
-typedef struct {
-  QNIC_id fst;
-  QNIC_id snd;
-} QNIC_pair_info;
-
-typedef struct QNIC : QNIC_id {
-  cModule* pointer;  // Pointer to that particular QNIC.
-  int address;
-} QNIC;
-
-// Table to check the qnic is reserved or not.
-typedef std::map<int, std::map<int, bool>> QNIC_reservation_table;
-
+struct QNIC_pair_info {
+  QNIC fst;
+  QNIC snd;
+};
 }  // namespace quisp::modules
 
 namespace std {

--- a/quisp/modules/QNIC.h
+++ b/quisp/modules/QNIC.h
@@ -4,11 +4,12 @@
  *
  *  \brief QNIC
  */
-#ifndef QUISP_MODULES_QNIC_H_
-#define QUISP_MODULES_QNIC_H_
+
+#pragma once
 
 #include <omnetpp.h>
 #include <nlohmann/json.hpp>
+
 using namespace omnetpp;
 
 namespace quisp::modules {
@@ -60,5 +61,3 @@ class hash<pair<quisp::modules::QNIC_type, int>> {
   std::size_t operator()(pair<quisp::modules::QNIC_type, int> const& key) const noexcept { return std::hash<int>()((int)key.first * 10000 + key.second); }
 };
 }  // namespace std
-
-#endif  // QUISP_MODULES_QNIC_H_

--- a/quisp/modules/QNIC.h
+++ b/quisp/modules/QNIC.h
@@ -43,10 +43,7 @@ struct QNIC {
   cModule* pointer = nullptr;
 };
 
-struct QNIC_pair_info {
-  QNIC fst;
-  QNIC snd;
-};
+using QNicPairInfo = std::pair<QNIC, QNIC>;
 }  // namespace quisp::modules
 
 namespace std {

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager.cc
@@ -308,7 +308,7 @@ void ConnectionManager::tryRelayRequestToNextHop(ConnectionSetupRequest *req) {
   req->setStack_of_linkCosts(num_accumulated_costs, outbound_info->quantum_link_cost);
   req->setStack_of_QNICsArraySize(num_accumulated_pair_info + 1);
 
-  QNIC_pair_info pair_info = {.fst = inbound_info->qnic, .snd = outbound_info->qnic};
+  QNicPairInfo pair_info{inbound_info->qnic, outbound_info->qnic};
   req->setStack_of_QNICs(num_accumulated_pair_info, pair_info);
 
   reserveQnic(inbound_info->qnic.address);
@@ -420,7 +420,7 @@ void ConnectionManager::queueApplicationRequest(ConnectionSetupRequest *req) {
   req->setStack_of_linkCosts(num_accumulated_costs, outbound_info->quantum_link_cost);
   req->setStack_of_QNICsArraySize(num_accumulated_pair_info + 1);
 
-  QNIC_pair_info pair_info = {.fst = inbound_info->qnic, .snd = outbound_info->qnic};
+  QNicPairInfo pair_info{inbound_info->qnic, outbound_info->qnic};
   req->setStack_of_QNICs(num_accumulated_pair_info, pair_info);
 
   auto &request_queue = connection_setup_buffer[outbound_qnic_address];

--- a/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/ConnectionManager_test.cc
@@ -140,9 +140,9 @@ TEST(ConnectionManagerTest, RespondToRequest) {
   req->setStack_of_QNodeIndexes(0, 2);
   req->setStack_of_QNodeIndexes(1, 3);
   req->setStack_of_QNodeIndexes(2, 4);
-  req->setStack_of_QNICs(0, QNIC_pair_info{.fst = NULL_CONNECTION_SETUP_INFO.qnic, .snd = {.type = QNIC_E, .index = 11, .address = 101}});
-  req->setStack_of_QNICs(1, QNIC_pair_info{.fst = {.type = QNIC_E, .index = 12, .address = 102}, .snd = {.type = QNIC_E, .index = 13, .address = 103}});
-  req->setStack_of_QNICs(2, QNIC_pair_info{.fst = {.type = QNIC_E, .index = 14, .address = 104}, .snd = {.type = QNIC_E, .index = 15, .address = 105}});
+  req->setStack_of_QNICs(0, QNicPairInfo{NULL_CONNECTION_SETUP_INFO.qnic, {.type = QNIC_E, .index = 11, .address = 101}});
+  req->setStack_of_QNICs(1, QNicPairInfo{{.type = QNIC_E, .index = 12, .address = 102}, {.type = QNIC_E, .index = 13, .address = 103}});
+  req->setStack_of_QNICs(2, QNicPairInfo{{.type = QNIC_E, .index = 14, .address = 104}, {.type = QNIC_E, .index = 15, .address = 105}});
   EXPECT_CALL(*routing_daemon, findQNicAddrByDestAddr(4)).Times(1).WillOnce(Return(106));
 
   sim->setContext(connection_manager);

--- a/quisp/modules/QRSA/ConnectionManager/RuleSetGenerator_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/RuleSetGenerator_test.cc
@@ -101,9 +101,9 @@ TEST_F(RuleSetGeneratorTest, Simple) {
   req->setStack_of_QNodeIndexes(0, 2);
   req->setStack_of_QNodeIndexes(1, 3);
   req->setStack_of_QNodeIndexes(2, 4);
-  req->setStack_of_QNICs(0, QNIC_pair_info{.fst = NULL_CONNECTION_SETUP_INFO.qnic, .snd = {.type = QNIC_E, .index = 11, .address = 101}});
-  req->setStack_of_QNICs(1, QNIC_pair_info{.fst = {.type = QNIC_E, .index = 12, .address = 102}, .snd = {.type = QNIC_E, .index = 13, .address = 103}});
-  req->setStack_of_QNICs(2, QNIC_pair_info{.fst = {.type = QNIC_E, .index = 14, .address = 104}, .snd = {.type = QNIC_E, .index = 15, .address = 105}});
+  req->setStack_of_QNICs(0, QNicPairInfo{NULL_CONNECTION_SETUP_INFO.qnic, {.type = QNIC_E, .index = 11, .address = 101}});
+  req->setStack_of_QNICs(1, QNicPairInfo{{.type = QNIC_E, .index = 12, .address = 102}, {.type = QNIC_E, .index = 13, .address = 103}});
+  req->setStack_of_QNICs(2, QNicPairInfo{{.type = QNIC_E, .index = 14, .address = 104}, {.type = QNIC_E, .index = 15, .address = 105}});
   auto rulesets = rsg->generateRuleSets(req, 1234);
   EXPECT_EQ(rulesets.size(), 4);
   {

--- a/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
@@ -24,7 +24,7 @@ struct InterfaceInfo {
 };
 
 struct ConnectionSetupInfo {
-  QNIC_id qnic;
+  QNIC qnic;
   int neighbor_address;
   int quantum_link_cost;
 };

--- a/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/IHardwareMonitor.h
@@ -3,7 +3,7 @@
 #include <omnetpp.h>
 #include <memory>
 
-#include <modules/QNIC.h>
+#include "modules/QNIC.h"
 
 using namespace omnetpp;
 

--- a/quisp/modules/QRSA/RoutingDaemon/IRoutingDaemon.h
+++ b/quisp/modules/QRSA/RoutingDaemon/IRoutingDaemon.h
@@ -1,19 +1,14 @@
-#ifndef MODULES_IROUTING_DAEMON_H_
-#define MODULES_IROUTING_DAEMON_H_
+#pragma once
 
-#include "omnetpp/csimplemodule.h"
+#include <omnetpp.h>
 
 using omnetpp::cSimpleModule;
 
-namespace quisp {
-namespace modules {
+namespace quisp::modules {
 
 class IRoutingDaemon : public cSimpleModule {
  public:
   virtual int getNumEndNodes() = 0;
   virtual int findQNicAddrByDestAddr(int destAddr) = 0;
 };
-}  // namespace modules
-}  // namespace quisp
-
-#endif
+}  // namespace quisp::modules

--- a/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.cc
+++ b/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.cc
@@ -4,8 +4,10 @@
  *  \brief RoutingDaemon
  */
 #include "RoutingDaemon.h"
-#include <messages/classical_messages.h>
+
 #include <vector>
+
+#include "messages/classical_messages.h"
 
 using namespace omnetpp;
 

--- a/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.cc
+++ b/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.cc
@@ -5,15 +5,11 @@
  */
 #include "RoutingDaemon.h"
 #include <messages/classical_messages.h>
-#include <omnetpp.h>
 #include <vector>
 
 using namespace omnetpp;
 
-namespace quisp {
-namespace modules {
-
-Define_Module(RoutingDaemon);
+namespace quisp::modules::routing_daemon {
 
 /**
  *
@@ -133,7 +129,7 @@ void RoutingDaemon::generateRoutingTable(cTopology *topo) {
     cGate *parentModuleGate = this_node->getPath(0)->getLocalGate();
     int destAddr = node->getModule()->par("address");
 
-    qrtable[destAddr] = getQNicInfoOf(parentModuleGate);
+    qrtable[destAddr] = getQNicAddr(parentModuleGate);
 
     if (!strstr(parentModuleGate->getFullName(), "quantum")) {
       error("Quantum routing table referring to classical gates...");
@@ -141,15 +137,9 @@ void RoutingDaemon::generateRoutingTable(cTopology *topo) {
   }
 }
 
-QNIC RoutingDaemon::getQNicInfoOf(const cGate *const module_gate) {
+int RoutingDaemon::getQNicAddr(const cGate *const module_gate) {
   const auto module = module_gate->getPreviousGate()->getOwnerModule();
-  QNIC qnic;
-  qnic.address = module->par("self_qnic_address");
-  qnic.type = (QNIC_type)module->par("self_qnic_type").intValue();
-  qnic.index = module->getIndex();
-  qnic.pointer = module;
-
-  return qnic;
+  return module->par("self_qnic_address").intValue();
 }
 
 /**
@@ -164,7 +154,7 @@ int RoutingDaemon::findQNicAddrByDestAddr(int destAddr) {
     EV << "Quantum: address " << destAddr << " unreachable from this node \n";
     return -1;
   }
-  return it->second.address;
+  return it->second;
 }
 
 int RoutingDaemon::getNumEndNodes() {
@@ -190,5 +180,5 @@ int RoutingDaemon::getNumEndNodes() {
  **/
 void RoutingDaemon::handleMessage(cMessage *msg) {}
 
-}  // namespace modules
-}  // namespace quisp
+Define_Module(RoutingDaemon);
+}  // namespace quisp::modules::routing_daemon

--- a/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.h
+++ b/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.h
@@ -7,8 +7,9 @@
 
 #pragma once
 
-#include <modules/QNIC.h>
 #include "IRoutingDaemon.h"
+
+#include "modules/QNIC.h"
 
 /** \class RoutingDaemon RoutingDaemon.cc
  *

--- a/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.h
+++ b/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.h
@@ -5,8 +5,7 @@
  *      Author: takaakimatsuo
  */
 
-#ifndef MODULES_ROUTINGDAEMON_H_
-#define MODULES_ROUTINGDAEMON_H_
+#pragma once
 
 #include <modules/QNIC.h>
 #include "IRoutingDaemon.h"
@@ -15,14 +14,14 @@
  *
  *  \brief RoutingDaemon
  */
+namespace quisp::modules::routing_daemon {
 
-namespace quisp {
-namespace modules {
+// destaddr -> {self_qnic_address (unique)}
+using RoutingTable = std::map<int, int>;
 
 class RoutingDaemon : public IRoutingDaemon {
  protected:
   int myAddress;
-  typedef std::map<int, QNIC> RoutingTable;  // destaddr -> {gate_index (We need this to access qnic, but it is not unique because we have 3 types of qnics), qnic_address (unique)}
   RoutingTable qrtable;
 
   void updateChannelWeightsInTopology(cTopology* topo);
@@ -30,7 +29,7 @@ class RoutingDaemon : public IRoutingDaemon {
   double calculateSecPerBellPair(const cTopology::LinkOut* const outgoing_link);
 
   void generateRoutingTable(cTopology* topo);
-  QNIC getQNicInfoOf(const cGate* const parentModuleGate);
+  int getQNicAddr(const cGate* const parentModuleGate);
 
   void initialize(int stage) override;
   void handleMessage(cMessage* msg) override;
@@ -41,7 +40,4 @@ class RoutingDaemon : public IRoutingDaemon {
   int findQNicAddrByDestAddr(int destAddr) override;
 };
 
-}  // namespace modules
-}  // namespace quisp
-
-#endif /* MODULES_ROUTINGDAEMON_H_ */
+}  // namespace quisp::modules::routing_daemon

--- a/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.ned
+++ b/quisp/modules/QRSA/RoutingDaemon/RoutingDaemon.ned
@@ -1,11 +1,10 @@
 package modules.QRSA.RoutingDaemon;
-@namespace(quisp::modules);
+@namespace(quisp::modules::routing_daemon);
 
 simple RoutingDaemon
 {
     parameters:
         int address;
     gates:
-        //inout dummyQNICLink[];
 }
 


### PR DESCRIPTION
prev: #502 
`QNIC_id` was used in RoutingDaemon, but it only uses `QNIC_id.address` (this means self_qnic_address).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/503)
<!-- Reviewable:end -->
