### PR TITLE
Remove various unused variables

### DIFF
--- a/quisp/backends/GraphState/Qubit.cc
+++ b/quisp/backends/GraphState/Qubit.cc
@@ -389,7 +389,7 @@ EigenvalueResult GraphStateQubit::graphMeasureZ(const EigenvalueResult eigenvalu
 
 void GraphStateQubit::setFree() {
   // force qubit to be in |0> state
-  auto result = this->graphMeasureZ();
+  this->graphMeasureZ();
   this->vertex_operator = CliffordOperator::H;
   updated_time = backend->getSimTime();
 }

--- a/quisp/modules/QNode.ned
+++ b/quisp/modules/QNode.ned
@@ -9,7 +9,6 @@ import modules.Common.*;
 module QNode
 {
     parameters:
-        int buffer_size = default(10);
         int address = default(0);
         int buffers = default(10); // default is defined as 10 in .ini file but can be changed independently in .ned file
         int mass = default(100);


### PR DESCRIPTION
This pull request removes two unused variables from QuISP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/517)
<!-- Reviewable:end -->
