### PR TITLE
Fix quantum channel delay

### DIFF
--- a/quisp/channels/QuantumChannel.cc
+++ b/quisp/channels/QuantumChannel.cc
@@ -114,7 +114,7 @@ cChannel::Result QuantumChannel::processMessage(cMessage *msg, const SendOptions
     q->setLost(true);
   }
 
-  return cChannel::Result();
+  return {false, getDelay(), 0};
 }
 
 void QuantumChannel::validateParameters() {

--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
@@ -25,7 +25,7 @@ void BellStateAnalyzer::initialize() {
   state = BSAState::Idle;
   darkcount_probability = par("darkcount_probability").doubleValue();
   detection_efficiency = par("detection_efficiency").doubleValue();
-  indistinguishability_window = par("indistinguishable_time_window").doubleValue();
+  indistinguishability_window = SimTime(par("indistinguishable_time_window").doubleValue() * 1000, SIMTIME_PS);
   collection_efficiency = par("collection_efficiency").doubleValue();
   backend = provider.getQuantumBackend();
   validateProperties();


### PR DESCRIPTION
This PR fixes the behaviour that the Bell pairs are generated too fast, due to the quantum channel having no delay.

The changes are made in this PR:
- introduce QuantumChannel delay from the distance which used to be overwritten from `processMessage` function
- fix the incorrect unit conversion for the indistinguishable time window for photon entanglement at BSA

This closes #528.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/529)
<!-- Reviewable:end -->
