### PR TITLE
release back to pool on photon discard event

### DIFF
--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
@@ -103,6 +103,8 @@ void BellStateAnalyzer::processPhotonRecords() {
       batch_click_msg->appendClickResults(processIndistinguishPhotons(p, q));
     } else {
       batch_click_msg->appendClickResults({.success = false, .correction_operation = PauliOperator::I});
+      discardPhoton(p);
+      discardPhoton(q);
     }
   }
   first_port_records.clear();

--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
@@ -148,6 +148,8 @@ BSAClickResult BellStateAnalyzer::processIndistinguishPhotons(PhotonRecord &p, P
   if (!p.is_lost && !q.is_lost && isPsi && left_click && right_click) {
     bool isPsiPlus = dblrand() < 0.5;
     measureSuccessfully(p, q, isPsiPlus);
+    discardPhoton(p);
+    discardPhoton(q);
     return {.success = true, .correction_operation = isPsiPlus ? PauliOperator::X : PauliOperator::Y};
   }
 

--- a/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BellStateAnalyzer.cc
@@ -211,6 +211,6 @@ void BellStateAnalyzer::finish() {
   std::cout << "    " << no_error_count << ' ' << x_error_count << ' ' << y_error_count << ' ' << z_error_count << '\n';
 }
 
-void BellStateAnalyzer::discardPhoton(PhotonRecord &photon) { photon.qubit_ref->noiselessMeasureZ(); };
+void BellStateAnalyzer::discardPhoton(PhotonRecord &photon) { photon.qubit_ref->relaseBackToPool(); };
 
 }  // namespace quisp::modules

--- a/simulation_tests/test_link_generation_channel_error.py
+++ b/simulation_tests/test_link_generation_channel_error.py
@@ -12,16 +12,16 @@ async def test_ChannelXErrorSimpleMIM():
     print(worker.output)
     worker.print_results()
     assert worker.results["EndNode1<-->EndNode2"]["data"] == {
-        "Fidelity": 0.896712,
-        "Xerror": 0.103288,
-        "Zerror": -0.0103481,
-        "Yerror": 0.0103481,
+        "Fidelity": 0.906557,
+        "Xerror": 0.0934427,
+        "Zerror": -0.00237126,
+        "Yerror": 0.00237126,
     }
     assert worker.results["EndNode2<-->EndNode1"]["data"] == {
-        "Fidelity": 0.896712,
-        "Xerror": 0.103288,
-        "Zerror": -0.0103481,
-        "Yerror": 0.0103481,
+        "Fidelity": 0.906557,
+        "Xerror": 0.0934427,
+        "Zerror": -0.00237126,
+        "Yerror": 0.00237126,
     }
 
 
@@ -35,16 +35,16 @@ async def test_ChannelXErrorSimpleMM():
     print(worker.output)
     worker.print_results()
     assert worker.results["EndNode1<-->EndNode2"]["data"] == {
-        "Fidelity": 0.905137,
-        "Xerror": 0.0948629,
-        "Zerror": -0.00540325,
-        "Yerror": 0.00540325,
+        "Fidelity": 0.898293,
+        "Xerror": 0.101707,
+        "Zerror": 0.00698899,
+        "Yerror": -0.00698899,
     }
     assert worker.results["EndNode2<-->EndNode1"]["data"] == {
-        "Fidelity": 0.905137,
-        "Xerror": 0.0948629,
-        "Zerror": -0.00540325,
-        "Yerror": 0.00540325,
+        "Fidelity": 0.898293,
+        "Xerror": 0.101707,
+        "Zerror": 0.00698899,
+        "Yerror": -0.00698899,
     }
 
 
@@ -58,16 +58,16 @@ async def test_MIM_Werner_State_Channel():
     print(worker.output)
     worker.print_results()
     assert worker.results["EndNode1<-->EndNode2"]["data"] == {
-        "Fidelity": 0.694766,
-        "Xerror": 0.103959,
-        "Zerror": 0.100688,
-        "Yerror": 0.100587,
+        "Fidelity": 0.721372,
+        "Xerror": 0.083573,
+        "Zerror": 0.0860698,
+        "Yerror": 0.108985,
     }
     assert worker.results["EndNode2<-->EndNode1"]["data"] == {
-        "Fidelity": 0.694766,
-        "Xerror": 0.103959,
-        "Zerror": 0.100688,
-        "Yerror": 0.100587,
+        "Fidelity": 0.721372,
+        "Xerror": 0.083573,
+        "Zerror": 0.0860698,
+        "Yerror": 0.108985,
     }
 
 
@@ -81,14 +81,14 @@ async def test_MM_Werner_State_Channel():
     print(worker.output)
     worker.print_results()
     assert worker.results["EndNode1<-->EndNode2"]["data"] == {
-        "Fidelity": 0.700108,
-        "Xerror": 0.104376,
-        "Zerror": 0.0904865,
-        "Yerror": 0.105029,
+        "Fidelity": 0.689943,
+        "Xerror": 0.106828,
+        "Zerror": 0.103317,
+        "Yerror": 0.0999117,
     }
     assert worker.results["EndNode2<-->EndNode1"]["data"] == {
-        "Fidelity": 0.700108,
-        "Xerror": 0.104376,
-        "Zerror": 0.0904865,
-        "Yerror": 0.105029,
+        "Fidelity": 0.689943,
+        "Xerror": 0.106828,
+        "Zerror": 0.103317,
+        "Yerror": 0.0999117,
     }

--- a/simulation_tests/test_purification_single_x.py
+++ b/simulation_tests/test_purification_single_x.py
@@ -58,16 +58,16 @@ async def test_Single_X_Purification_MIM_Werner_State():
     print(worker.output)
     worker.print_results()
     assert worker.results["EndNode1<-->EndNode2"]["data"] == {
-        "Fidelity": 0.735104,
-        "Xerror": 0.0311294,
-        "Zerror": 0.197981,
-        "Yerror": 0.0357851,
+        "Fidelity": 0.739466,
+        "Xerror": 0.052239,
+        "Zerror": 0.20503,
+        "Yerror": 0.00326519,
     }
     assert worker.results["EndNode2<-->EndNode1"]["data"] == {
-        "Fidelity": 0.735104,
-        "Xerror": 0.0311294,
-        "Zerror": 0.197981,
-        "Yerror": 0.0357851,
+        "Fidelity": 0.739466,
+        "Xerror": 0.052239,
+        "Zerror": 0.20503,
+        "Yerror": 0.00326519,
     }
 
 
@@ -81,14 +81,14 @@ async def test_Single_X_Purification_MM_Werner_State():
     print(worker.output)
     worker.print_results()
     assert worker.results["EndNode1<-->EndNode2"]["data"] == {
-        "Fidelity": 0.747207,
-        "Xerror": 0.0251512,
-        "Zerror": 0.19216,
-        "Yerror": 0.0354823,
+        "Fidelity": 0.742061,
+        "Xerror": 0.027587,
+        "Zerror": 0.192103,
+        "Yerror": 0.0382493,
     }
     assert worker.results["EndNode2<-->EndNode1"]["data"] == {
-        "Fidelity": 0.747207,
-        "Xerror": 0.0251512,
-        "Zerror": 0.19216,
-        "Yerror": 0.0354823,
+        "Fidelity": 0.742061,
+        "Xerror": 0.027587,
+        "Zerror": 0.192103,
+        "Yerror": 0.0382493,
     }


### PR DESCRIPTION
This PR fixes the issue that the memory gets used up, resulting in a kill during some simulations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/531)
<!-- Reviewable:end -->
