### PR TITLE
Make purification_type string and change numerical values

### DIFF
--- a/quisp/Perfect_FixedChannelOnly10_nTimes_separate_XXZPuri_Low_memErr.ini
+++ b/quisp/Perfect_FixedChannelOnly10_nTimes_separate_XXZPuri_Low_memErr.ini
@@ -113,7 +113,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -166,7 +166,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3SepXXZPuri_low_memErr]
@@ -190,7 +190,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4SepXXZPuri_low_memErr]
@@ -214,7 +214,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5SepXXZPuri_low_memErr]
@@ -238,7 +238,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_6SepXXZPuri_low_memErr]
@@ -262,7 +262,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -288,7 +288,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -313,6 +313,6 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 

--- a/quisp/Perfect_FixedChannelOnly10_nTimes_separate_XXZPuri_Low_memErr.ini
+++ b/quisp/Perfect_FixedChannelOnly10_nTimes_separate_XXZPuri_Low_memErr.ini
@@ -113,7 +113,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -166,7 +166,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3SepXXZPuri_low_memErr]
@@ -190,7 +190,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4SepXXZPuri_low_memErr]
@@ -214,7 +214,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5SepXXZPuri_low_memErr]
@@ -238,7 +238,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_6SepXXZPuri_low_memErr]
@@ -262,7 +262,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -288,7 +288,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -313,6 +313,6 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 

--- a/quisp/modules/QRSA/ConnectionManager/RuleSetGenerator_test.cc
+++ b/quisp/modules/QRSA/ConnectionManager/RuleSetGenerator_test.cc
@@ -204,7 +204,7 @@ TEST_F(RuleSetGeneratorTest, PurificationRule) {
 
   auto purification_rule = rsg->purifyRule(partner_addr, purification_type, 15);
   auto serialized = purification_rule->serialize_json();
-  //  rule_id is given by RuleSet and next_rule_id is given outside of Rule decration.
+  //  rule_id is given by RuleSet and next_rule_id is given outside of Rule declaration.
   json expected = R"({
    "name":"purification with 1",
    "send_tag": 15,

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -553,7 +553,6 @@ void HardwareMonitor::writeToFile_Topology_with_LinkCost(int qnic_id, double lin
               << this_node->getFullName() << "<--> QuantumChannel{ cost = " << link_cost << "; distance = " << dis << "km; fidelity = " << fidelity
               << "; bellpair_per_sec = " << bellpair_per_sec << ";} <-->" << neighbor_node->getFullName() << "\n";
   }
-std::cout<<"Purification Type: "<<purification_type;
 }
 
 /**

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -855,8 +855,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
                                                                     partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == "R1_Double_X-R2_Double_ZX--R1_Single_X-R2_Single_Z") {  // Predefined purification method
-      /// # Purification_type "R1_Double_X-R2_Double_ZX--R1_Single_X-R2_Single_Z": #
+    } else if (purification_type == "CR1_Double_X-CR2_Double_ZX--R1_Single_X-R2_Single_Z") {  // Predefined purification method
+      /// # Purification_type "CR1_Double_X-CR2_Double_ZX--R1_Single_X-R2_Single_Z": #
       /// - name: Switching (B)
       /// - rounds: n
       /// - input Bell pairs per round: 3 in first two rounds, then 2

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -61,7 +61,7 @@ void HardwareMonitor::initialize(int stage) {
   num_purification = par("initial_purification");
   X_Purification = par("x_purification");
   Z_Purification = par("z_purification");
-  purification_type = std::string(par("purification_type").stringValue());
+  purification_type = par("purification_type").stdstringValue();
   num_measure = par("num_measure");
   my_address = provider.getNodeAddr();
 

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.cc
@@ -61,7 +61,8 @@ void HardwareMonitor::initialize(int stage) {
   num_purification = par("initial_purification");
   X_Purification = par("x_purification");
   Z_Purification = par("z_purification");
-  purification_type = par("purification_type");
+  purification_type = par("purification_type").str();
+  purification_type = purification_type.substr(1, purification_type.length() - 2);
   num_measure = par("num_measure");
   my_address = provider.getNodeAddr();
 
@@ -562,7 +563,7 @@ work proceeds, a resource gets promoted from rule to rule (on
 purification success), so if you ask for three rounds of purification,
 it will emit three purification rules.
 
-For example, with 2002, the first instance of "first stage X
+For example, with "R1_Single_X-R1_Single_Z", the first instance of "first stage X
 purification" (Rule0) includes allocating the resources from the base
 pair pool, executing the purification circuit (including measurement),
 exchanging the result messages, comparing and either promoting or
@@ -611,8 +612,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
   std::vector<int> partners = {partner_address};
 
   if (num_purification > 0) {
-    if (purification_type == 2002) {  // Performs both X and Z purification for each n.
-      /// # Purification_type 2002: #
+    if (purification_type == "R1_Single_X-R1_Single_Z") {  // Performs both X and Z purification for each n.
+      /// # Purification_type "R1_Single_X-R1_Single_Z": #
       /// - name: Ss-Sp / perfect binary tree, even rounds
       /// - rounds: 2n
       /// - input Bell pairs per round: 2
@@ -625,7 +626,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// to switch basis, creating alternating
       /// rounds of X and Z purification.
       ///
-      /// The only difference between 2002 and 3003
+      /// The only difference between "R1_Single_X-R1_Single_Z" and "R1_Single_X-R2_Single_Z"
       /// is the semantics of initial_purification.
       /// Here, each iteration results in two rules,
       /// guaranteeing an even number of rounds.
@@ -650,8 +651,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
               constructCorrelationCheckRule("purification correlation check", PurType::SINGLE_SELECTION_Z_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == 3003) {
-      /// # Purification_type 3003: #
+    } else if (purification_type == "R1_Single_X-R2_Single_Z") {
+      /// # Purification_type "R1_Single_X-R2_Single_Z": #
       /// - name: Ss-Sp / perfect binary tree, odd or even rounds
       /// - rounds: n
       /// - input Bell pairs per round: 2
@@ -664,7 +665,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// to switch basis, creating alternating
       /// rounds of X and Z purification.
       ///
-      /// The only difference between 2002 and 3003
+      /// The only difference between "R1_Single_X-R1_Single_Z" and "R1_Single_X-R2_Single_Z"
       /// is the semantics of initial_purification.
       /// Here, each iteration results in one rule,
       /// X for even-numbered rounds (counting from zero),
@@ -688,8 +689,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
               constructCorrelationCheckRule("purification correlation check", PurType::SINGLE_SELECTION_Z_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == 1001) {
-      /// # Purification_type 1001: #
+    } else if (purification_type == "R1_Single_XZ") {
+      /// # Purification_type "R1_Single_XZ": #
       /// - name: Ss-Dp XZ Purification
       /// - rounds: n
       /// - input Bell pairs per round: 3
@@ -702,7 +703,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// CNOT(A,C), MEAS(C), CNOT(E,A), MEAS(E)
       /// then select after comparing outcomes.
       /// Note that bases are not flipped between rounds.
-      /// Similar to 1221.
+      /// Similar to "R1_Single_XZ-R2_Single_ZX".
       /// ![](../img/PhysRevA.100.052320-Fig12.png)
       for (int i = 0; i < num_purification; i++) {
         rule_name = "Double purification with: " + std::to_string(partner_address);
@@ -711,8 +712,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
         tomography_RuleSet->addRule(
             constructCorrelationCheckRule("purification correlation check", PurType::SINGLE_SELECTION_XZ_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
       }
-    } else if (purification_type == 1221) {
-      /// # Purification_type 1221: #
+    } else if (purification_type == "R1_Single_XZ-R2_Single_ZX") {
+      /// # Purification_type "R1_Single_XZ-R2_Single_ZX": #
       /// - name: Ss-Dp XZ, ZX alternating
       /// - rounds: n
       /// - input Bell pairs per round: 3
@@ -721,7 +722,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// of CNOTs reversed in alternating rounds
       /// - scheduling: symmetric tree
       /// ## description: ##
-      /// Almost the same as 1001, but first round
+      /// Almost the same as "R1_Single_XZ", but first round
       /// is XZ, second round is ZX.  Results in better alternating
       /// error suppression, but still not great.
       /// ![](../img/PhysRevA.100.052320-Fig12.png)
@@ -741,8 +742,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
               constructCorrelationCheckRule("purification correlation check", PurType::SINGLE_SELECTION_ZX_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == 1011) {
-      /// # Purification_type 1011: #
+    } else if (purification_type == "R1_Double_X") {
+      /// # Purification_type "R1_Double_X": #
       /// - name: Ds-Sp: Fujii-san's Double selection purification
       /// - rounds: n
       /// - input Bell pairs per round: 3
@@ -750,7 +751,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// - circuit: Fig. 13 in arXiv:1904.08605
       /// - scheduling: symmetric tree
       /// ## description: ##
-      /// Similar to 1001 and 1221 except that the control and target
+      /// Similar to "R1_Single_XZ" and "R1_Single_XZ-R2_Single_ZX" except that the control and target
       /// of the first CNOT are flipped, corresponding to Fujii-san's
       /// paper (PRA 80, 042308).
       /// Every round is identical.
@@ -763,8 +764,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
         tomography_RuleSet->addRule(
             constructCorrelationCheckRule("purification correlation check", PurType::DOUBLE_SELECTION_X_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
       }
-    } else if (purification_type == 1021) {  // Fujii-san's Double selection purification
-      /// # Purification_type 1021: #
+    } else if (purification_type == "R1_Double_X-R2_Double_Z") {  // Fujii-san's Double selection purification
+      /// # Purification_type "R1_Double_X-R2_Double_Z": #
       /// - name: Ds-Sp: Fujii-san's Double selection purification (alternating)
       /// - rounds: n
       /// - input Bell pairs per round: 3
@@ -773,7 +774,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// the order of the CNOTs alternates between rounds
       /// - scheduling: symmetric tree
       /// ## description: ##
-      /// Similar to 1011, almost corresponding to Fujii-san's paper (PRA 80,
+      /// Similar to "R1_Double_X", almost corresponding to Fujii-san's paper (PRA 80,
       /// 042308). Note there is no basis change between rounds, but that the
       /// first round is XZ, second is ZX.
       /// ![](../img/arxiv.1904.08605-Fig13.png)
@@ -793,8 +794,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
               constructCorrelationCheckRule("purification correlation check", PurType::DOUBLE_SELECTION_Z_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == 1031) {
-      /// # Purification_type 1031: #
+    } else if (purification_type == "R1_Double_XZ-R2_Double_ZX") {
+      /// # Purification_type "R1_Double_XZ-R2_Double_ZX": #
       /// - name: Ds-Dp: full double selection purification (alternating)
       /// - rounds: n
       /// - input Bell pairs per round: 5
@@ -803,7 +804,7 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
       /// the order of the CNOTs alternates between rounds
       /// - scheduling: symmetric tree
       /// ## description: ##
-      /// A combination of 1001 and 1011 (Figs. 12 & 13).  Resource requirements
+      /// A combination of "R1_Single_XZ" and "R1_Double_X" (Figs. 12 & 13).  Resource requirements
       /// are high; two rounds of this requires 25 Bell pairs.  With a low base
       /// Bell pair generation rate and realistic memory decoherence, this will
       /// be impractical.
@@ -815,17 +816,17 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
           rule = constructPurifyRule(rule_name, PurType::DOUBLE_SELECTION_XZ_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag);
           tomography_RuleSet->addRule(std::move(rule));
           tomography_RuleSet->addRule(
-              constructCorrelationCheckRule("purification correlation check", PurType::DOUBLE_SELECTION_X_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
+              constructCorrelationCheckRule("purification correlation check", PurType::DOUBLE_SELECTION_XZ_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
         } else {
           rule_name = "Double selection Dual action Inverse with: " + std::to_string(partner_address);
           rule = constructPurifyRule(rule_name, PurType::DOUBLE_SELECTION_ZX_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag);
           tomography_RuleSet->addRule(std::move(rule));
           tomography_RuleSet->addRule(
-              constructCorrelationCheckRule("purification correlation check", PurType::DOUBLE_SELECTION_Z_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
+              constructCorrelationCheckRule("purification correlation check", PurType::DOUBLE_SELECTION_ZX_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == 1061) {
-      /// # Purification_type 1061: #
+    } else if (purification_type == "R1_Double_X_Single_Z-R2_Double_Z_Single_X") {
+      /// # Purification_type "R1_Double_X_Single_Z-R2_Double_Z_Single_X": #
       /// - name: half double selection, half single selection
       /// - rounds: n
       /// - input Bell pairs per round: 4
@@ -854,8 +855,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
                                                                     partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == 5555) {  // Predefined purification method
-      /// # Purification_type 5555: #
+    } else if (purification_type == "R1_Double_X-R2_Double_ZX--R1_Single_X-R2_Single_Z") {  // Predefined purification method
+      /// # Purification_type "R1_Double_X-R2_Double_ZX--R1_Single_X-R2_Single_Z": #
       /// - name: Switching (B)
       /// - rounds: n
       /// - input Bell pairs per round: 3 in first two rounds, then 2
@@ -909,8 +910,8 @@ void HardwareMonitor::sendLinkTomographyRuleSet(int my_address, int partner_addr
               constructCorrelationCheckRule("purification correlation check", PurType::SINGLE_SELECTION_Z_PURIFICATION, partner_address, qnic_type, qnic_index, shared_tag++));
         }
       }
-    } else if (purification_type == 5556) {  // Predefined purification method
-      /// # Purification_type 5556: #
+    } else if (purification_type == "CR1_Double_X-R1_Single_Z-R2_Single_X") {  // Predefined purification method
+      /// # Purification_type "CR1_Double_X-R1_Single_Z-R2_Single_X": #
       /// - name: Switching (A)
       /// - rounds: n
       /// - input Bell pairs per round: 3 in first round, then 2

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
@@ -52,7 +52,7 @@ class HardwareMonitor : public IHardwareMonitor {
   int num_purification = 0;
   bool X_Purification = false;
   bool Z_Purification = false;
-  int purification_type = -1;
+  // int purification_type = -1;
   int num_measure;
   int num_end_nodes;
 
@@ -70,6 +70,7 @@ class HardwareMonitor : public IHardwareMonitor {
   LinkCostMap *tomography_runningtime_holder;
   std::string tomography_output_filename;
   std::string file_dir_name;
+  std::string purification_type;
 
  protected:
   void initialize(int stage) override;

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.h
@@ -52,7 +52,6 @@ class HardwareMonitor : public IHardwareMonitor {
   int num_purification = 0;
   bool X_Purification = false;
   bool Z_Purification = false;
-  // int purification_type = -1;
   int num_measure;
   int num_end_nodes;
 

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.ned
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor.ned
@@ -18,7 +18,7 @@ simple HardwareMonitor
         string file_dir_name = default("results/");
 	// purification control
         int initial_purification;
-        int purification_type;
+        string purification_type;
 	// these two are obsolete controls for purification
         bool x_purification = default(false);
         bool z_purification = default(false);

--- a/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor_test.cc
+++ b/quisp/modules/QRSA/HardwareMonitor/HardwareMonitor_test.cc
@@ -55,7 +55,7 @@ class HardwareMonitorTestTarget : public quisp::modules::HardwareMonitor {
     setParInt(this, "initial_purification", 0);
     setParBool(this, "x_purification", true);
     setParBool(this, "z_purification", true);
-    setParInt(this, "purification_type", 0);
+    setParStr(this, "purification_type", "");
     setParInt(this, "num_measure", 0);
 
     this->setName("hardware_monitor_test_target");

--- a/quisp/networks/omnetpp.ini
+++ b/quisp/networks/omnetpp.ini
@@ -124,7 +124,7 @@ seed-set = 0
 **.link_tomography = false
 **.EndToEndConnection = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 
 
@@ -154,7 +154,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X_Single_Z-R2_Double_Z_Single_X"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_SINGLE_Z_WITH_DOUBLE_Z_SINGLE_X"
 
 
 [Config Test__Layer2_Simple_MIM_MM_5km_DSXZPuri_low_memErr]
@@ -176,7 +176,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Realistic_Layer2_Simple_MIM_MM_all_in_one_Test]
 network = networks.Realistic_Layer2_Simple_MIM_MM_all_in_one
@@ -218,9 +218,9 @@ seed-set = 1
 **.link_tomography = false
 **.NumberOfResources = 1
 **.initial_purification = 0
-**.purification_type = 0
+**.purification_type = ""
 #**.initial_purification = 1
-#**.purification_type = "R1_Single_XZ"
+#**.purification_type = "N_SINGLE_XZ"
 
 
 
@@ -300,9 +300,9 @@ sim-time-limit = 100s
 **.link_tomography = false
 **.NumberOfResources = 1
 **.initial_purification = 0
-**.purification_type = 0
+**.purification_type = ""
 #**.initial_purification = 1
-#**.purification_type = "R1_Single_XZ"
+#**.purification_type = "N_SINGLE_XZ"
 
 
 [Config EntanglementSwapping_Realistic_Layer2_Simple_MIM_MM_Test]
@@ -345,7 +345,7 @@ seed-set = 1
 **.link_tomography = false
 **.NumberOfResources = 1
 **.initial_purification = 0
-**.purification_type = 0
+**.purification_type = ""
 
 
 [Config SimultaneousEntanglementSwapping_Realistic_Layer3_Simple_MM_MM_Test]
@@ -431,7 +431,7 @@ seed-set = 1
 **.link_tomography = false
 **.NumberOfResources = 1
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 **.num_remote_purification = 1
 
 
@@ -475,7 +475,7 @@ seed-set = 1
 **.NumberOfResources = 1
 **.initial_purification = 0
 **.num_remote_purification = 0
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config EntanglementSwapping_Purification_Star_Test]
@@ -517,7 +517,7 @@ seed-set = 1
 **.link_tomography = false
 **.NumberOfResources = 1
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_5km_Test]
@@ -553,7 +553,7 @@ seed-set = 1
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 
 
@@ -772,4 +772,4 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 10
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"

--- a/quisp/networks/omnetpp.ini
+++ b/quisp/networks/omnetpp.ini
@@ -124,7 +124,7 @@ seed-set = 0
 **.link_tomography = false
 **.EndToEndConnection = true
 **.initial_purification = 2
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 
 
@@ -154,7 +154,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1061
+**.purification_type = "R1_Double_X_Single_Z-R2_Double_Z_Single_X"
 
 
 [Config Test__Layer2_Simple_MIM_MM_5km_DSXZPuri_low_memErr]
@@ -176,7 +176,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Realistic_Layer2_Simple_MIM_MM_all_in_one_Test]
 network = networks.Realistic_Layer2_Simple_MIM_MM_all_in_one
@@ -220,7 +220,7 @@ seed-set = 1
 **.initial_purification = 0
 **.purification_type = 0
 #**.initial_purification = 1
-#**.purification_type = 1001
+#**.purification_type = "R1_Single_XZ"
 
 
 
@@ -302,7 +302,7 @@ sim-time-limit = 100s
 **.initial_purification = 0
 **.purification_type = 0
 #**.initial_purification = 1
-#**.purification_type = 1001
+#**.purification_type = "R1_Single_XZ"
 
 
 [Config EntanglementSwapping_Realistic_Layer2_Simple_MIM_MM_Test]
@@ -431,7 +431,7 @@ seed-set = 1
 **.link_tomography = false
 **.NumberOfResources = 1
 **.initial_purification = 1
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 **.num_remote_purification = 1
 
 
@@ -475,7 +475,7 @@ seed-set = 1
 **.NumberOfResources = 1
 **.initial_purification = 0
 **.num_remote_purification = 0
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 [Config EntanglementSwapping_Purification_Star_Test]
@@ -517,7 +517,7 @@ seed-set = 1
 **.link_tomography = false
 **.NumberOfResources = 1
 **.initial_purification = 1
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_5km_Test]
@@ -553,7 +553,7 @@ seed-set = 1
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 
 
@@ -772,4 +772,4 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 10
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"

--- a/quisp/simulations/Fixed5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
+++ b/quisp/simulations/Fixed5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
@@ -172,7 +172,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 
 
@@ -198,7 +198,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 
@@ -225,7 +225,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 
@@ -250,7 +250,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1061
+**.purification_type = "R1_Double_X_Single_Z-R2_Double_Z_Single_X"
 
 
 

--- a/quisp/simulations/Fixed5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
+++ b/quisp/simulations/Fixed5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
@@ -172,7 +172,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 
 
@@ -198,7 +198,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -225,7 +225,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 
@@ -250,7 +250,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X_Single_Z-R2_Double_Z_Single_X"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_SINGLE_Z_WITH_DOUBLE_Z_SINGLE_X"
 
 
 

--- a/quisp/simulations/Fixed7_5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
+++ b/quisp/simulations/Fixed7_5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
@@ -173,7 +173,7 @@ seed-set = ${0..24}
 **.link_tomography = true
 **.initial_purification = 1
 
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 
 
@@ -198,7 +198,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -224,7 +224,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 
@@ -252,4 +252,4 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X_Single_Z-R2_Double_Z_Single_X"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_SINGLE_Z_WITH_DOUBLE_Z_SINGLE_X"

--- a/quisp/simulations/Fixed7_5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
+++ b/quisp/simulations/Fixed7_5_No_X_XZ_XXZ_DSPuri_Low_memErr.ini
@@ -173,7 +173,7 @@ seed-set = ${0..24}
 **.link_tomography = true
 **.initial_purification = 1
 
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 
 
@@ -198,7 +198,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 
@@ -224,7 +224,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 
@@ -252,4 +252,4 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1061
+**.purification_type = "R1_Double_X_Single_Z-R2_Double_Z_Single_X"

--- a/quisp/simulations/Fixed_distances_DSXZPuri_Low_memErr.ini
+++ b/quisp/simulations/Fixed_distances_DSXZPuri_Low_memErr.ini
@@ -111,7 +111,7 @@ seed-set = ${14..19}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -137,7 +137,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_30km_DSXZPuri_low_memErr_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_30km
@@ -160,7 +160,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -186,7 +186,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -212,7 +212,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -238,7 +238,7 @@ seed-set = ${6..9}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -303,7 +303,7 @@ seed-set = ${21..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -328,7 +328,7 @@ seed-set = ${17..20}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -354,7 +354,7 @@ seed-set = ${13..16}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -379,7 +379,7 @@ seed-set = ${9..12}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_40km_DSXZPuri_low_memErr_4t8]
@@ -403,7 +403,7 @@ seed-set = ${4..8}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -428,7 +428,7 @@ seed-set = ${3}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -472,7 +472,7 @@ seed-set = ${23..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_21t22]
@@ -496,7 +496,7 @@ seed-set = ${21..22}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -522,7 +522,7 @@ seed-set = ${19..20}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_17t18]
@@ -546,7 +546,7 @@ seed-set = ${17..18}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -571,7 +571,7 @@ seed-set = ${15..16}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -596,7 +596,7 @@ seed-set = ${13..14}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -624,7 +624,7 @@ seed-set = ${11..12}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -651,7 +651,7 @@ seed-set = ${9..10}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -676,7 +676,7 @@ seed-set = ${7..8}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -701,7 +701,7 @@ seed-set = ${6}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_5]
@@ -725,7 +725,7 @@ seed-set = ${5}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_3t4]
@@ -749,7 +749,7 @@ seed-set = ${3..4}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -774,7 +774,7 @@ seed-set = ${2}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -815,7 +815,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_40km_DSXZPuri_low_memErr]
@@ -839,7 +839,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_30km_DSXZPuri_low_memErr]
@@ -863,7 +863,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_DSXZPuri_low_memErr]
@@ -887,7 +887,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -912,7 +912,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -937,7 +937,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_7_5km_DSXZPuri_low_memErr]
@@ -961,7 +961,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_5km_DSXZPuri_low_memErr]
@@ -985,5 +985,5 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 

--- a/quisp/simulations/Fixed_distances_DSXZPuri_Low_memErr.ini
+++ b/quisp/simulations/Fixed_distances_DSXZPuri_Low_memErr.ini
@@ -111,7 +111,7 @@ seed-set = ${14..19}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -137,7 +137,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_30km_DSXZPuri_low_memErr_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_30km
@@ -160,7 +160,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -186,7 +186,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -212,7 +212,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -238,7 +238,7 @@ seed-set = ${6..9}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -303,7 +303,7 @@ seed-set = ${21..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -328,7 +328,7 @@ seed-set = ${17..20}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -354,7 +354,7 @@ seed-set = ${13..16}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -379,7 +379,7 @@ seed-set = ${9..12}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_40km_DSXZPuri_low_memErr_4t8]
@@ -403,7 +403,7 @@ seed-set = ${4..8}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -428,7 +428,7 @@ seed-set = ${3}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -472,7 +472,7 @@ seed-set = ${23..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_21t22]
@@ -496,7 +496,7 @@ seed-set = ${21..22}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -522,7 +522,7 @@ seed-set = ${19..20}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_17t18]
@@ -546,7 +546,7 @@ seed-set = ${17..18}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -571,7 +571,7 @@ seed-set = ${15..16}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -596,7 +596,7 @@ seed-set = ${13..14}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -624,7 +624,7 @@ seed-set = ${11..12}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -651,7 +651,7 @@ seed-set = ${9..10}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -676,7 +676,7 @@ seed-set = ${7..8}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -701,7 +701,7 @@ seed-set = ${6}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_5]
@@ -725,7 +725,7 @@ seed-set = ${5}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_50km_DSXZPuri_low_memErr_3t4]
@@ -749,7 +749,7 @@ seed-set = ${3..4}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -774,7 +774,7 @@ seed-set = ${2}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -815,7 +815,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_40km_DSXZPuri_low_memErr]
@@ -839,7 +839,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_30km_DSXZPuri_low_memErr]
@@ -863,7 +863,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_DSXZPuri_low_memErr]
@@ -887,7 +887,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -912,7 +912,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -937,7 +937,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_7_5km_DSXZPuri_low_memErr]
@@ -961,7 +961,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_5km_DSXZPuri_low_memErr]
@@ -985,5 +985,5 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 

--- a/quisp/simulations/NoGateErr_Fixed_distances_DSXZPuri_Low_memErr.ini
+++ b/quisp/simulations/NoGateErr_Fixed_distances_DSXZPuri_Low_memErr.ini
@@ -124,7 +124,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -150,5 +150,5 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 

--- a/quisp/simulations/NoGateErr_Fixed_distances_DSXZPuri_Low_memErr.ini
+++ b/quisp/simulations/NoGateErr_Fixed_distances_DSXZPuri_Low_memErr.ini
@@ -124,7 +124,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -150,5 +150,5 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 

--- a/quisp/simulations/PerfectFixedChannelOnly20_nTimes_DS_DSinvPuri_Low_memEerr.ini
+++ b/quisp/simulations/PerfectFixedChannelOnly20_nTimes_DS_DSinvPuri_Low_memEerr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_1DSPuri_low_memErr]
@@ -138,7 +138,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSPuri_low_memErr]
@@ -162,7 +162,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSPuri_low_memErr]
@@ -186,7 +186,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSPuri_low_memErr]
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 
@@ -240,7 +240,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -263,7 +263,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr]
@@ -287,7 +287,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr6t10]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -310,7 +310,7 @@ seed-set = ${6..10}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr11t15]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -333,7 +333,7 @@ seed-set = ${11..15}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr16t20]
@@ -357,7 +357,7 @@ seed-set = ${16..20}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 
@@ -382,7 +382,7 @@ seed-set = ${21..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 
@@ -409,7 +409,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 
@@ -435,7 +435,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSinvPuri_low_memErr_5t9]
@@ -458,7 +458,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 
@@ -482,7 +482,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSinvPuri_low_memErr_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -504,7 +504,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSinvPuri_low_memErr_20t24]
@@ -527,7 +527,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSinvPuri_low_memErr]
@@ -551,5 +551,5 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1021
+**.purification_type = "R1_Double_X-R2_Double_Z"
 

--- a/quisp/simulations/PerfectFixedChannelOnly20_nTimes_DS_DSinvPuri_Low_memEerr.ini
+++ b/quisp/simulations/PerfectFixedChannelOnly20_nTimes_DS_DSinvPuri_Low_memEerr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_1DSPuri_low_memErr]
@@ -138,7 +138,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSPuri_low_memErr]
@@ -162,7 +162,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSPuri_low_memErr]
@@ -186,7 +186,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSPuri_low_memErr]
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 
@@ -240,7 +240,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -263,7 +263,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr]
@@ -287,7 +287,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr6t10]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -310,7 +310,7 @@ seed-set = ${6..10}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr11t15]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -333,7 +333,7 @@ seed-set = ${11..15}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSinvPuri_low_memErr16t20]
@@ -357,7 +357,7 @@ seed-set = ${16..20}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 
@@ -382,7 +382,7 @@ seed-set = ${21..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 
@@ -409,7 +409,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 
@@ -435,7 +435,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSinvPuri_low_memErr_5t9]
@@ -458,7 +458,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 
@@ -482,7 +482,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSinvPuri_low_memErr_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -504,7 +504,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSinvPuri_low_memErr_20t24]
@@ -527,7 +527,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSinvPuri_low_memErr]
@@ -551,5 +551,5 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_X-R2_Double_Z"
+**.purification_type = "N_ALTERNATE_DOUBLE_X_WITH_DOUBLE_Z"
 

--- a/quisp/simulations/PerfectGate10_No_X_XZ_DSPuri_Low_memErr_.ini
+++ b/quisp/simulations/PerfectGate10_No_X_XZ_DSPuri_Low_memErr_.ini
@@ -226,7 +226,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 
 
 

--- a/quisp/simulations/PerfectGate10_No_X_XZ_DSPuri_Low_memErr_.ini
+++ b/quisp/simulations/PerfectGate10_No_X_XZ_DSPuri_Low_memErr_.ini
@@ -226,7 +226,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 
 
 

--- a/quisp/simulations/Perfect_FixedChannel3X10_nTimes_DSXZinvPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannel3X10_nTimes_DSXZinvPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_1DSXZinvPuri_low_memErr_2]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -163,7 +163,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr_2]
@@ -187,7 +187,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr]
@@ -234,7 +234,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -260,7 +260,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_5t9]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -283,7 +283,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -308,7 +308,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -331,7 +331,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -354,7 +354,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_4DSXZinvPuri_low_memErr]
@@ -378,7 +378,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -403,7 +403,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -428,7 +428,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -454,7 +454,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -481,7 +481,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -506,7 +506,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -532,7 +532,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -557,7 +557,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr5t9]
@@ -581,7 +581,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr10t14]
@@ -605,7 +605,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr15t19]
@@ -629,7 +629,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr20t24]
@@ -653,6 +653,6 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 

--- a/quisp/simulations/Perfect_FixedChannel3X10_nTimes_DSXZinvPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannel3X10_nTimes_DSXZinvPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_1DSXZinvPuri_low_memErr_2]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -163,7 +163,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr_2]
@@ -187,7 +187,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr]
@@ -234,7 +234,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -260,7 +260,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_5t9]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -283,7 +283,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -308,7 +308,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -331,7 +331,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -354,7 +354,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_4DSXZinvPuri_low_memErr]
@@ -378,7 +378,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -403,7 +403,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -428,7 +428,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -454,7 +454,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -481,7 +481,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -506,7 +506,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -532,7 +532,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -557,7 +557,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr5t9]
@@ -581,7 +581,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr10t14]
@@ -605,7 +605,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr15t19]
@@ -629,7 +629,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config X3Channel_Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr20t24]
@@ -653,6 +653,6 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 

--- a/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_DSXZinvPuri_Low_memErr_CNOT02.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_DSXZinvPuri_Low_memErr_CNOT02.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_1DSXZinvPuri_low_memErr_CNOT02_2]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -163,7 +163,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr_CNOT02_2]
@@ -187,7 +187,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr_CNOT02]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02]
@@ -234,7 +234,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -260,7 +260,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02_5t9]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -283,7 +283,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -308,7 +308,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -331,7 +331,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -354,7 +354,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4DSXZinvPuri_low_memErr_CNOT02]
@@ -378,7 +378,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -403,7 +403,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -428,7 +428,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -454,7 +454,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -481,7 +481,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -506,7 +506,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -532,7 +532,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -557,7 +557,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT025t9]
@@ -581,7 +581,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT0210t14]
@@ -605,7 +605,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT0215t19]
@@ -629,7 +629,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT0220t24]
@@ -653,6 +653,6 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 

--- a/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_DSXZinvPuri_Low_memErr_CNOT02.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_DSXZinvPuri_Low_memErr_CNOT02.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_1DSXZinvPuri_low_memErr_CNOT02_2]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -163,7 +163,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr_CNOT02_2]
@@ -187,7 +187,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_2DSXZinvPuri_low_memErr_CNOT02]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02]
@@ -234,7 +234,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -260,7 +260,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02_5t9]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -283,7 +283,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -308,7 +308,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -331,7 +331,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3DSXZinvPuri_low_memErr_CNOT02_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -354,7 +354,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4DSXZinvPuri_low_memErr_CNOT02]
@@ -378,7 +378,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -403,7 +403,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -428,7 +428,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -454,7 +454,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -481,7 +481,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -506,7 +506,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -532,7 +532,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -557,7 +557,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT025t9]
@@ -581,7 +581,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT0210t14]
@@ -605,7 +605,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT0215t19]
@@ -629,7 +629,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5DSXZinvPuri_low_memErr_CNOT0220t24]
@@ -653,6 +653,6 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 

--- a/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XXZPuri_Low_memErr_50.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XXZPuri_Low_memErr_50.ini
@@ -113,7 +113,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -139,7 +139,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -165,7 +165,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3XXZPuri_low_memErr_50]
@@ -189,7 +189,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_0t4]
@@ -213,7 +213,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_5t9]
@@ -237,7 +237,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_10t14]
@@ -261,7 +261,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_15t19]
@@ -285,7 +285,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -308,7 +308,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -333,4 +333,4 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"

--- a/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XXZPuri_Low_memErr_50.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XXZPuri_Low_memErr_50.ini
@@ -113,7 +113,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 
@@ -139,7 +139,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 
@@ -165,7 +165,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3XXZPuri_low_memErr_50]
@@ -189,7 +189,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_0t4]
@@ -213,7 +213,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_5t9]
@@ -237,7 +237,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_10t14]
@@ -261,7 +261,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_15t19]
@@ -285,7 +285,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XXZPuri_low_memErr_50_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -308,7 +308,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 
 
 
@@ -333,4 +333,4 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"

--- a/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XZinvPuri_Low_memErr_CNOT02.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XZinvPuri_Low_memErr_CNOT02.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_2XZinvPuri_low_memErr_CNOT02]
@@ -164,7 +164,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3XZinvPuri_low_memErr_CNOT02]
@@ -188,7 +188,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XZinvPuri_low_memErr_CNOT02]
@@ -212,7 +212,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5XZinvPuri_low_memErr_CNOT020t4]
@@ -236,7 +236,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 
@@ -261,7 +261,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5XZinvPuri_low_memErr_CNOT0210t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -284,7 +284,7 @@ seed-set = ${10..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 
@@ -314,7 +314,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 
@@ -343,4 +343,4 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"

--- a/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XZinvPuri_Low_memErr_CNOT02.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly10_nTimes_XZinvPuri_Low_memErr_CNOT02.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_2XZinvPuri_low_memErr_CNOT02]
@@ -164,7 +164,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_3XZinvPuri_low_memErr_CNOT02]
@@ -188,7 +188,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_4XZinvPuri_low_memErr_CNOT02]
@@ -212,7 +212,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5XZinvPuri_low_memErr_CNOT020t4]
@@ -236,7 +236,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 
@@ -261,7 +261,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_10km_5XZinvPuri_low_memErr_CNOT0210t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM_10km
@@ -284,7 +284,7 @@ seed-set = ${10..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 
@@ -314,7 +314,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 
@@ -343,4 +343,4 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_1DSXZinvPuri_low_memErr_2]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -163,7 +163,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSXZinvPuri_low_memErr_2]
@@ -187,7 +187,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSXZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr]
@@ -234,7 +234,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_0t4]
@@ -258,7 +258,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_5t9]
@@ -282,7 +282,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_10t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -305,7 +305,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -328,7 +328,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_20t24]
@@ -352,7 +352,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -375,7 +375,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -400,7 +400,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -425,7 +425,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -451,7 +451,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -478,7 +478,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -503,7 +503,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -529,7 +529,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 
@@ -554,7 +554,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr5t9]
@@ -578,7 +578,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr10t14]
@@ -602,7 +602,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr15t19]
@@ -626,7 +626,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr20t24]
@@ -650,6 +650,6 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 
 

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_1DSXZinvPuri_low_memErr_2]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -163,7 +163,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSXZinvPuri_low_memErr_2]
@@ -187,7 +187,7 @@ seed-set = ${25..49}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSXZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -210,7 +210,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr]
@@ -234,7 +234,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_0t4]
@@ -258,7 +258,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_5t9]
@@ -282,7 +282,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_10t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -305,7 +305,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_15t19]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -328,7 +328,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3DSXZinvPuri_low_memErr_20t24]
@@ -352,7 +352,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -375,7 +375,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -400,7 +400,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -425,7 +425,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -451,7 +451,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -478,7 +478,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -503,7 +503,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -529,7 +529,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 
@@ -554,7 +554,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr5t9]
@@ -578,7 +578,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr10t14]
@@ -602,7 +602,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr15t19]
@@ -626,7 +626,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZinvPuri_low_memErr20t24]
@@ -650,6 +650,6 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 
 

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvWITHXZZXPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvWITHXZZXPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSXZ1WITHXZZXPuri_low_memErr]
@@ -164,7 +164,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 
 
@@ -189,7 +189,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 
 
@@ -214,7 +214,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZ1WITHXZZXPuri_low_memErr_6t10]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -237,7 +237,7 @@ seed-set = ${6..10}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZ1WITHXZZXPuri_low_memErr_11t15]
@@ -261,7 +261,7 @@ seed-set = ${11..15}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZ1WITHXZZXPuri_low_memErr_16t20]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -284,7 +284,7 @@ seed-set = ${16..20}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 
 
@@ -309,7 +309,7 @@ seed-set = ${21..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZ1WITHXZZXPuri_low_memErr]
@@ -333,6 +333,6 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
+**.purification_type = "1+N_DOUBLE_X_ALTERNATE_SINGLE_Z_WITH_SINGLE_X"
 
 

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvWITHXZZXPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_DSXZinvWITHXZZXPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2DSXZ1WITHXZZXPuri_low_memErr]
@@ -164,7 +164,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 
 
@@ -189,7 +189,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 
 
@@ -214,7 +214,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZ1WITHXZZXPuri_low_memErr_6t10]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -237,7 +237,7 @@ seed-set = ${6..10}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZ1WITHXZZXPuri_low_memErr_11t15]
@@ -261,7 +261,7 @@ seed-set = ${11..15}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4DSXZ1WITHXZZXPuri_low_memErr_16t20]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -284,7 +284,7 @@ seed-set = ${16..20}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 
 
@@ -309,7 +309,7 @@ seed-set = ${21..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5DSXZ1WITHXZZXPuri_low_memErr]
@@ -333,6 +333,6 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 5556
+**.purification_type = "CR1_Double_X-R1_Single_Z-R2_Single_X"
 
 

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_XZinvPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_XZinvPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2XZinvPuri_low_memErr]
@@ -164,7 +164,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr]
@@ -188,7 +188,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_3t6]
@@ -212,7 +212,7 @@ seed-set = ${3..6}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_7t10]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -235,7 +235,7 @@ seed-set = ${7..10}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_11t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -258,7 +258,7 @@ seed-set = ${11..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_15t18]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -281,7 +281,7 @@ seed-set = ${15..18}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_19t22]
@@ -305,7 +305,7 @@ seed-set = ${19..22}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_23t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -328,7 +328,7 @@ seed-set = ${23..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -351,7 +351,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_0t4]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -374,7 +374,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_5t9]
@@ -398,7 +398,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_10t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -421,7 +421,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_15t19]
@@ -445,7 +445,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_20t24]
@@ -469,7 +469,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 
 
 
@@ -494,4 +494,4 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_XZinvPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_XZinvPuri_Low_memErr.ini
@@ -114,7 +114,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_2XZinvPuri_low_memErr]
@@ -164,7 +164,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr]
@@ -188,7 +188,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_3t6]
@@ -212,7 +212,7 @@ seed-set = ${3..6}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_7t10]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -235,7 +235,7 @@ seed-set = ${7..10}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_11t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -258,7 +258,7 @@ seed-set = ${11..14}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_15t18]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -281,7 +281,7 @@ seed-set = ${15..18}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_19t22]
@@ -305,7 +305,7 @@ seed-set = ${19..22}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3XZinvPuri_low_memErr_23t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -328,7 +328,7 @@ seed-set = ${23..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -351,7 +351,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_0t4]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -374,7 +374,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_5t9]
@@ -398,7 +398,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_10t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -421,7 +421,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_15t19]
@@ -445,7 +445,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4XZinvPuri_low_memErr_20t24]
@@ -469,7 +469,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 
 
 
@@ -494,4 +494,4 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_separate_XXZPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_separate_XXZPuri_Low_memErr.ini
@@ -113,7 +113,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -166,7 +166,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3SepXXZPuri_low_memErr]
@@ -190,7 +190,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4SepXXZPuri_low_memErr]
@@ -214,7 +214,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5SepXXZPuri_low_memErr]
@@ -238,7 +238,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr]
@@ -262,7 +262,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_0t4]
@@ -286,7 +286,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_4t9]
@@ -310,7 +310,7 @@ seed-set = ${4..9}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_10t14]
@@ -334,7 +334,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_15t19]
@@ -358,7 +358,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -381,7 +381,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -404,7 +404,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_1t4]
@@ -428,7 +428,7 @@ seed-set = ${1..4}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_5t9]
@@ -452,7 +452,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_10t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -475,7 +475,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_15t19]
@@ -499,7 +499,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_20t24]
@@ -523,7 +523,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -548,7 +548,7 @@ seed-set = ${0..1}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -574,7 +574,7 @@ seed-set = ${2..3}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -599,7 +599,7 @@ seed-set = ${4..5}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -624,7 +624,7 @@ seed-set = ${6..7}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr8t9]
@@ -648,7 +648,7 @@ seed-set = ${8..9}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -674,7 +674,7 @@ seed-set = ${10..11}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr12t13]
@@ -698,7 +698,7 @@ seed-set = ${12..13}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr5t9]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -721,7 +721,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr10t14]
@@ -745,7 +745,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -773,7 +773,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 
 
 
@@ -800,5 +800,5 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 

--- a/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_separate_XXZPuri_Low_memErr.ini
+++ b/quisp/simulations/Perfect_FixedChannelOnly20_nTimes_separate_XXZPuri_Low_memErr.ini
@@ -113,7 +113,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -140,7 +140,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -166,7 +166,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_3SepXXZPuri_low_memErr]
@@ -190,7 +190,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 3
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_4SepXXZPuri_low_memErr]
@@ -214,7 +214,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 4
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_5SepXXZPuri_low_memErr]
@@ -238,7 +238,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 5
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr]
@@ -262,7 +262,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_0t4]
@@ -286,7 +286,7 @@ seed-set = ${0..4}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_4t9]
@@ -310,7 +310,7 @@ seed-set = ${4..9}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_10t14]
@@ -334,7 +334,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_15t19]
@@ -358,7 +358,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_6SepXXZPuri_low_memErr_20t24]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -381,7 +381,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 6
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -404,7 +404,7 @@ seed-set = ${0..24}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_1t4]
@@ -428,7 +428,7 @@ seed-set = ${1..4}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_5t9]
@@ -452,7 +452,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_10t14]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -475,7 +475,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_15t19]
@@ -499,7 +499,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_7SepXXZPuri_low_memErr_20t24]
@@ -523,7 +523,7 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 7
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -548,7 +548,7 @@ seed-set = ${0..1}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -574,7 +574,7 @@ seed-set = ${2..3}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -599,7 +599,7 @@ seed-set = ${4..5}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -624,7 +624,7 @@ seed-set = ${6..7}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr8t9]
@@ -648,7 +648,7 @@ seed-set = ${8..9}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -674,7 +674,7 @@ seed-set = ${10..11}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr12t13]
@@ -698,7 +698,7 @@ seed-set = ${12..13}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr5t9]
 network = networks.Realistic_Layer2_Simple_MIM_MM
@@ -721,7 +721,7 @@ seed-set = ${5..9}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 [Config Measurement7000_Layer2_Simple_MIM_MM_20km_8SepXXZPuri_low_memErr10t14]
@@ -745,7 +745,7 @@ seed-set = ${10..14}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -773,7 +773,7 @@ seed-set = ${15..19}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 
 
@@ -800,5 +800,5 @@ seed-set = ${20..24}
 
 **.link_tomography = true
 **.initial_purification = 8
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 

--- a/quisp/simulations/bsa_perf.ini
+++ b/quisp/simulations/bsa_perf.ini
@@ -63,7 +63,7 @@ network = networks.Realistic_Layer2_Simple_MIM_MM_5km
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.EndToEndConnection = false

--- a/quisp/simulations/bsa_perf.ini
+++ b/quisp/simulations/bsa_perf.ini
@@ -63,7 +63,7 @@ network = networks.Realistic_Layer2_Simple_MIM_MM_5km
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.EndToEndConnection = false

--- a/quisp/simulations/mim_generation_test.ini
+++ b/quisp/simulations/mim_generation_test.ini
@@ -62,47 +62,47 @@ sim-time-limit = 20s
 network = networks.Testing_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Memory_two]
 network = networks.Testing_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.buffers = 2
 
 [Config Memory_four]
 network = networks.Testing_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.buffers = 4
 
 [Config Memory_eight]
 network = networks.Testing_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.buffers = 8
 
 [Config Memory_sixteen]
 network = networks.Testing_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.buffers = 16
 
 [Config Memory_thirtytwo]
 network = networks.Testing_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.buffers = 32
 
 [Config Memory_sixtyfour]
 network = networks.Testing_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.buffers = 64
 

--- a/quisp/simulations/simulation_test.ini
+++ b/quisp/simulations/simulation_test.ini
@@ -134,25 +134,25 @@ network = networks.Simple_MSM
 network = networks.Simple_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = 3003
+**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
 
 [Config Single_X_Purification_MM_No_Error]
 network = networks.Simple_MM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = 3003
+**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
 
 [Config Single_X_Purification_MSM_No_Error]
 network = networks.Simple_MSM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = 3003
+**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
 
 [Config Single_X_Purification_MIM_Werner_State]
 network = networks.Simple_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = 3003
+**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1
@@ -161,7 +161,7 @@ network = networks.Simple_MIM
 network = networks.Simple_MM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = 3003
+**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1
@@ -170,7 +170,7 @@ network = networks.Simple_MM
 network = networks.Simple_MSM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = 3003
+**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1

--- a/quisp/simulations/simulation_test.ini
+++ b/quisp/simulations/simulation_test.ini
@@ -65,46 +65,46 @@ sim-time-limit = 20s
 network = networks.Simple_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config NoErrorMM]
 network = networks.Simple_MM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config NoErrorMSM]
 network = networks.Simple_MSM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config ChannelXErrorSimpleMIM]
 network = networks.Simple_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.channel_x_error_rate = 0.1
 
 [Config ChannelXErrorSimpleMM]
 network = networks.Simple_MM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.channel_x_error_rate = 0.1
 
 [Config ChannelXErrorSimpleMSM]
 network = networks.Simple_MSM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.channel_x_error_rate = 0.1
 
 [Config Channel_Error_Werner_State_MIM]
 network = networks.Simple_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1
@@ -113,7 +113,7 @@ network = networks.Simple_MIM
 network = networks.Simple_MM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1
@@ -122,7 +122,7 @@ network = networks.Simple_MM
 network = networks.Simple_MSM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1
@@ -191,7 +191,7 @@ seed-set = 0
 **.buffers = 6
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MIM_3_Nodes]
 network = networks.three_node_MIM
@@ -206,7 +206,7 @@ seed-set = 0
 **.buffers = 6
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_3_Nodes]
 network = networks.three_node_MM
@@ -216,7 +216,7 @@ seed-set = 0
 **.buffers = 6
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_4_Nodes]
 network = networks.four_node_MM
@@ -226,7 +226,7 @@ seed-set = 0
 **.buffers = 3
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_5_Nodes]
 network = networks.five_node_MM
@@ -236,7 +236,7 @@ seed-set = 0
 **.buffers = 20
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_6_Nodes]
 network = networks.six_node_MM
@@ -246,7 +246,7 @@ seed-set = 0
 **.buffers = 20
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_7_Nodes]
 network = networks.seven_node_MM
@@ -256,7 +256,7 @@ seed-set = 0
 **.buffers = 20
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_8_Nodes]
 network = networks.eight_node_MM
@@ -266,7 +266,7 @@ seed-set = 0
 **.buffers = 10
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_9_Nodes]
 network = networks.nine_node_MM
@@ -276,7 +276,7 @@ seed-set = 0
 **.buffers = 10
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""
 
 [Config Entanglement_Swapping_MM_10_Nodes]
 network = networks.ten_node_MM
@@ -286,4 +286,4 @@ seed-set = 0
 **.buffers = 20
 **.link_tomography = false
 **.initial_purification = 0
-**.qrsa.hm.purification_type = 0
+**.qrsa.hm.purification_type = ""

--- a/quisp/simulations/simulation_test.ini
+++ b/quisp/simulations/simulation_test.ini
@@ -134,25 +134,25 @@ network = networks.Simple_MSM
 network = networks.Simple_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
+**.qrsa.hm.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Single_X_Purification_MM_No_Error]
 network = networks.Simple_MM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
+**.qrsa.hm.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Single_X_Purification_MSM_No_Error]
 network = networks.Simple_MSM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
+**.qrsa.hm.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 
 [Config Single_X_Purification_MIM_Werner_State]
 network = networks.Simple_MIM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
+**.qrsa.hm.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1
@@ -161,7 +161,7 @@ network = networks.Simple_MIM
 network = networks.Simple_MM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
+**.qrsa.hm.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1
@@ -170,7 +170,7 @@ network = networks.Simple_MM
 network = networks.Simple_MSM
 **.qrsa.hm.link_tomography = true
 **.qrsa.hm.initial_purification = 1
-**.qrsa.hm.purification_type = "R1_Single_X-R2_Single_Z"
+**.qrsa.hm.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 **.channel_x_error_rate = 0.1
 **.channel_y_error_rate = 0.1
 **.channel_z_error_rate = 0.1

--- a/quisp/simulations/test.ini
+++ b/quisp/simulations/test.ini
@@ -67,7 +67,7 @@ sim-time-limit = 20s
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.TrafficPattern = 1
@@ -108,7 +108,7 @@ sim-time-limit = 20s
 # Expected Outcome: High X error rate ~0.5
 **.tomography_output_filename = "Test4"
 **.memory_x_error_rate = 0.5
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 # ====================================================================================
 [Config Test5]
 # Test Name: Memory Y error test
@@ -130,7 +130,7 @@ sim-time-limit = 20s
 # Expected Outcome: High Z error rate ~0.5
 **.tomography_output_filename = "Test7"
 **.memory_energy_excitation_rate = 0.5
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 # ====================================================================================
 [Config Test8]
 # Test Name: Memory energy relaxation error test
@@ -151,21 +151,21 @@ sim-time-limit = 20s
 # Description: Applying photon loss to internal hom
 # Expected Outcome: Currently fidelity goes 1
 **.tomography_output_filename = "Test10"
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 # ====================================================================================
 [Config Test11]
 # Test Name: internal_
 # Description: Applying error to internal hom
 # Expected Outcome: Currently fidelity goes 1
 **.tomography_output_filename = "Test11"
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test12]
 # Test Name: hom loss error test
 # Description: Applying photon loss to external hom
 # Expected Outcome: Currently fidelity goes 1
 **.tomography_output_filename = "Test12"
-**.purification_type = 1031
+**.purification_type = "R1_Double_XZ-R2_Double_ZX"
 # ====================================================================================
 [Config Test13]
 # Test Name: hom error test
@@ -182,7 +182,7 @@ sim-time-limit = 20s
 **.Measurement_x_error_ratio = 1
 **.Measurement_y_error_ratio = 0
 **.Measurement_z_error_ratio = 0
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test15]
 # Test Name: Measurement Y error test
@@ -195,7 +195,7 @@ sim-time-limit = 20s
 **.Measurement_z_error_ratio = 0
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 # ====================================================================================
 [Config Test16]
 # Test Name: Measurement Z error test
@@ -207,7 +207,7 @@ sim-time-limit = 20s
 **.Measurement_x_error_ratio = 0
 **.Measurement_y_error_ratio = 0
 **.Measurement_z_error_ratio = 1
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 # ====================================================================================
 [Config Test17]
 # Test Name: H gate X error test
@@ -218,7 +218,7 @@ sim-time-limit = 20s
 **.h_gate_x_error_ratio = 1
 **.h_gate_y_error_ratio = 0
 **.h_gate_z_error_ratio = 0
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 # ====================================================================================
 [Config Test18]
 # Test Name: H gate Y error test
@@ -229,7 +229,7 @@ sim-time-limit = 20s
 **.h_gate_x_error_ratio = 0
 **.h_gate_y_error_ratio = 1
 **.h_gate_z_error_ratio = 0
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 # ====================================================================================
 [Config Test19]
 # Test Name: H gate Z error test
@@ -240,7 +240,7 @@ sim-time-limit = 20s
 **.h_gate_x_error_ratio = 0
 **.h_gate_y_error_ratio = 0
 **.h_gate_z_error_ratio = 1
-**.purification_type = 1011
+**.purification_type = "R1_Double_X"
 # ====================================================================================
 [Config Test20]
 # Test Name: X gate X error test
@@ -251,7 +251,7 @@ sim-time-limit = 20s
 **.x_gate_x_error_ratio = 1
 **.x_gate_y_error_ratio = 0
 **.x_gate_z_error_ratio = 0
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 # ====================================================================================
 [Config Test21]
 # Test Name: X gate Y error test
@@ -262,7 +262,7 @@ sim-time-limit = 20s
 **.x_gate_x_error_ratio = 0
 **.x_gate_y_error_ratio = 1
 **.x_gate_z_error_ratio = 0
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 # ====================================================================================
 [Config Test22]
 # Test Name: X gate Z error test
@@ -272,7 +272,7 @@ sim-time-limit = 20s
 **.x_gate_x_error_ratio = 0
 **.x_gate_y_error_ratio = 0
 **.x_gate_z_error_ratio = 1
-**.purification_type = 2002
+**.purification_type = "R1_Single_X-R1_Single_Z"
 # ====================================================================================
 [Config Test23]
 # Test Name: Z gate X error test
@@ -283,7 +283,7 @@ sim-time-limit = 20s
 **.z_gate_x_error_ratio = 1
 **.z_gate_y_error_ratio = 0
 **.z_gate_z_error_ratio = 0
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 # ====================================================================================
 [Config Test24]
 # Test Name: Z gate Y error test
@@ -294,7 +294,7 @@ sim-time-limit = 20s
 **.z_gate_x_error_ratio = 0
 **.z_gate_y_error_ratio = 1
 **.z_gate_z_error_ratio = 0
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 # ====================================================================================
 [Config Test25]
 # Test Name: Z gate Z error test
@@ -305,7 +305,7 @@ sim-time-limit = 20s
 **.z_gate_x_error_ratio = 0
 **.z_gate_y_error_ratio = 0
 **.z_gate_z_error_ratio = 1
-**.purification_type = 3003
+**.purification_type = "R1_Single_X-R2_Single_Z"
 # ====================================================================================
 [Config Test26]
 # Test Name: CNOT gate IZ error test
@@ -322,7 +322,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test27]
 # Test Name: CNOT gate ZI error test
@@ -339,7 +339,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test28]
 # Test Name: CNOT gate ZZ error test
@@ -356,7 +356,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test29]
 # Test Name: CNOT gate IX error test
@@ -373,7 +373,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test30]
 # Test Name: CNOT gate XI error test
@@ -390,7 +390,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test31]
 # Test Name: CNOT gate XX error test
@@ -407,7 +407,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test32]
 # Test Name: CNOT gate IY error test
@@ -424,7 +424,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 1 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test33]
 # Test Name: CNOT gate YI error test
@@ -441,7 +441,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 1 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================
 [Config Test34]
 # Test Name: CNOT gate YY error test
@@ -458,5 +458,5 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 1 #checked
-**.purification_type = 1221
+**.purification_type = "R1_Single_XZ-R2_Single_ZX"
 # ====================================================================================

--- a/quisp/simulations/test.ini
+++ b/quisp/simulations/test.ini
@@ -67,7 +67,7 @@ sim-time-limit = 20s
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.TrafficPattern = 1
@@ -108,7 +108,7 @@ sim-time-limit = 20s
 # Expected Outcome: High X error rate ~0.5
 **.tomography_output_filename = "Test4"
 **.memory_x_error_rate = 0.5
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test5]
 # Test Name: Memory Y error test
@@ -130,7 +130,7 @@ sim-time-limit = 20s
 # Expected Outcome: High Z error rate ~0.5
 **.tomography_output_filename = "Test7"
 **.memory_energy_excitation_rate = 0.5
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 # ====================================================================================
 [Config Test8]
 # Test Name: Memory energy relaxation error test
@@ -151,21 +151,21 @@ sim-time-limit = 20s
 # Description: Applying photon loss to internal hom
 # Expected Outcome: Currently fidelity goes 1
 **.tomography_output_filename = "Test10"
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test11]
 # Test Name: internal_
 # Description: Applying error to internal hom
 # Expected Outcome: Currently fidelity goes 1
 **.tomography_output_filename = "Test11"
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test12]
 # Test Name: hom loss error test
 # Description: Applying photon loss to external hom
 # Expected Outcome: Currently fidelity goes 1
 **.tomography_output_filename = "Test12"
-**.purification_type = "R1_Double_XZ-R2_Double_ZX"
+**.purification_type = "N_ALTERNATE_DOUBLE_XZ_WITH_DOUBLE_ZX"
 # ====================================================================================
 [Config Test13]
 # Test Name: hom error test
@@ -182,7 +182,7 @@ sim-time-limit = 20s
 **.Measurement_x_error_ratio = 1
 **.Measurement_y_error_ratio = 0
 **.Measurement_z_error_ratio = 0
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test15]
 # Test Name: Measurement Y error test
@@ -195,7 +195,7 @@ sim-time-limit = 20s
 **.Measurement_z_error_ratio = 0
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test16]
 # Test Name: Measurement Z error test
@@ -207,7 +207,7 @@ sim-time-limit = 20s
 **.Measurement_x_error_ratio = 0
 **.Measurement_y_error_ratio = 0
 **.Measurement_z_error_ratio = 1
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test17]
 # Test Name: H gate X error test
@@ -218,7 +218,7 @@ sim-time-limit = 20s
 **.h_gate_x_error_ratio = 1
 **.h_gate_y_error_ratio = 0
 **.h_gate_z_error_ratio = 0
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 # ====================================================================================
 [Config Test18]
 # Test Name: H gate Y error test
@@ -229,7 +229,7 @@ sim-time-limit = 20s
 **.h_gate_x_error_ratio = 0
 **.h_gate_y_error_ratio = 1
 **.h_gate_z_error_ratio = 0
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 # ====================================================================================
 [Config Test19]
 # Test Name: H gate Z error test
@@ -240,7 +240,7 @@ sim-time-limit = 20s
 **.h_gate_x_error_ratio = 0
 **.h_gate_y_error_ratio = 0
 **.h_gate_z_error_ratio = 1
-**.purification_type = "R1_Double_X"
+**.purification_type = "N_DOUBLE_X"
 # ====================================================================================
 [Config Test20]
 # Test Name: X gate X error test
@@ -251,7 +251,7 @@ sim-time-limit = 20s
 **.x_gate_x_error_ratio = 1
 **.x_gate_y_error_ratio = 0
 **.x_gate_z_error_ratio = 0
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test21]
 # Test Name: X gate Y error test
@@ -262,7 +262,7 @@ sim-time-limit = 20s
 **.x_gate_x_error_ratio = 0
 **.x_gate_y_error_ratio = 1
 **.x_gate_z_error_ratio = 0
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test22]
 # Test Name: X gate Z error test
@@ -272,7 +272,7 @@ sim-time-limit = 20s
 **.x_gate_x_error_ratio = 0
 **.x_gate_y_error_ratio = 0
 **.x_gate_z_error_ratio = 1
-**.purification_type = "R1_Single_X-R1_Single_Z"
+**.purification_type = "2N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test23]
 # Test Name: Z gate X error test
@@ -283,7 +283,7 @@ sim-time-limit = 20s
 **.z_gate_x_error_ratio = 1
 **.z_gate_y_error_ratio = 0
 **.z_gate_z_error_ratio = 0
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test24]
 # Test Name: Z gate Y error test
@@ -294,7 +294,7 @@ sim-time-limit = 20s
 **.z_gate_x_error_ratio = 0
 **.z_gate_y_error_ratio = 1
 **.z_gate_z_error_ratio = 0
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test25]
 # Test Name: Z gate Z error test
@@ -305,7 +305,7 @@ sim-time-limit = 20s
 **.z_gate_x_error_ratio = 0
 **.z_gate_y_error_ratio = 0
 **.z_gate_z_error_ratio = 1
-**.purification_type = "R1_Single_X-R2_Single_Z"
+**.purification_type = "N_ALTERNATE_SINGLE_X_WITH_SINGLE_Z"
 # ====================================================================================
 [Config Test26]
 # Test Name: CNOT gate IZ error test
@@ -322,7 +322,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test27]
 # Test Name: CNOT gate ZI error test
@@ -339,7 +339,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test28]
 # Test Name: CNOT gate ZZ error test
@@ -356,7 +356,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test29]
 # Test Name: CNOT gate IX error test
@@ -373,7 +373,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test30]
 # Test Name: CNOT gate XI error test
@@ -390,7 +390,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test31]
 # Test Name: CNOT gate XX error test
@@ -407,7 +407,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test32]
 # Test Name: CNOT gate IY error test
@@ -424,7 +424,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 1 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test33]
 # Test Name: CNOT gate YI error test
@@ -441,7 +441,7 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 1 #checked
 **.cnot_gate_yy_error_ratio = 0 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================
 [Config Test34]
 # Test Name: CNOT gate YY error test
@@ -458,5 +458,5 @@ sim-time-limit = 20s
 **.cnot_gate_iy_error_ratio = 0 #checked
 **.cnot_gate_yi_error_ratio = 0 #checked
 **.cnot_gate_yy_error_ratio = 1 #checked
-**.purification_type = "R1_Single_XZ-R2_Single_ZX"
+**.purification_type = "N_ALTERNATE_SINGLE_XZ_WITH_SINGLE_ZX"
 # ====================================================================================

--- a/quisp/simulations/three_HOM_star.ini
+++ b/quisp/simulations/three_HOM_star.ini
@@ -5,4 +5,4 @@ network = networks.Three_BSA_star
 **.EndToEndConnection = true
 **.link_tomography = false
 #**.initial_purification = 1
-#**.purification_type = 1001
+#**.purification_type = "R1_Single_XZ"

--- a/quisp/simulations/three_HOM_star.ini
+++ b/quisp/simulations/three_HOM_star.ini
@@ -5,4 +5,4 @@ network = networks.Three_BSA_star
 **.EndToEndConnection = true
 **.link_tomography = false
 #**.initial_purification = 1
-#**.purification_type = "R1_Single_XZ"
+#**.purification_type = "N_SINGLE_XZ"

--- a/quisp/simulations/topology_dumbell_network.ini
+++ b/quisp/simulations/topology_dumbell_network.ini
@@ -61,7 +61,7 @@ seed-set = ${0..24}
 **.channel_y_error_rate = 0.01
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 [Config Dumbell_MIM_Topology]
 network = networks.topology_dumbell_MIM
@@ -77,4 +77,4 @@ seed-set = ${0..24}
 **.channel_y_error_rate = 0.01
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"

--- a/quisp/simulations/topology_dumbell_network.ini
+++ b/quisp/simulations/topology_dumbell_network.ini
@@ -61,7 +61,7 @@ seed-set = ${0..24}
 **.channel_y_error_rate = 0.01
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 [Config Dumbell_MIM_Topology]
 network = networks.topology_dumbell_MIM
@@ -77,4 +77,4 @@ seed-set = ${0..24}
 **.channel_y_error_rate = 0.01
 **.link_tomography = true
 **.initial_purification = 2
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"

--- a/quisp/simulations/two_nodes.ini
+++ b/quisp/simulations/two_nodes.ini
@@ -65,7 +65,7 @@ sim-time-limit = 20s
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.TrafficPattern = 1

--- a/quisp/simulations/two_nodes.ini
+++ b/quisp/simulations/two_nodes.ini
@@ -65,7 +65,7 @@ sim-time-limit = 20s
 
 **.link_tomography = true
 **.initial_purification = 1
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.TrafficPattern = 1

--- a/quisp/simulations/vector_test.ini
+++ b/quisp/simulations/vector_test.ini
@@ -63,7 +63,7 @@ network = networks.Realistic_Layer2_Simple_MIM_MM_5km
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = 1001
+**.purification_type = "R1_Single_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.EndToEndConnection = false

--- a/quisp/simulations/vector_test.ini
+++ b/quisp/simulations/vector_test.ini
@@ -63,7 +63,7 @@ network = networks.Realistic_Layer2_Simple_MIM_MM_5km
 
 **.link_tomography = true
 **.initial_purification = 0
-**.purification_type = "R1_Single_XZ"
+**.purification_type = "N_SINGLE_XZ"
 
 **.initial_notification_timing_buffer = 10 s #when to start the BSA timing notification.
 **.EndToEndConnection = false


### PR DESCRIPTION
The following changes have been made:

**Inside** _**HardwareMonitor.h**_
- `purification_type` declared as string

**Inside** _**HardwareMonitor.cc**_
- `2002`: `"R1_Single_X-R1_Single_Z"`
- `3003`: `"R1_Single_X-R2_Single_Z"`
- `1001`: `"R1_Single_XZ"`
- `1221`: `"R1_Single_XZ-R2_Single_ZX"`
- `1011`: `"R1_Double_X"`
- `1021`: `"R1_Double_X-R2_Double_Z"`
- `1031`: `"R1_Double_XZ-R2_Double_ZX"`
- `1061`: `"R1_Double_X_Single_Z-R2_Double_Z_Single_X"`
- `5555`: `"CR1_Double_X-CR2_Double_ZX--R1_Single_X-R2_Single_Z"`
- `5556`: `"CR1_Double_X-R1_Single_Z-R2_Single_X"`

Here, R1/R2 is for specifying the number of rounds.
_i.e, R1: Round 1, R2: Round 2_

`"CR1_Double_X-CR2_Double_ZX--R1_Single_X-R2_Single_Z"` states that, 
Double_X and Double_ZX purification run in Round1 and Round2 respectively only once.
Then, Single_X and Single_Z purification run during Round1 and Round2 respectively and repeat for more rounds if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/554)
<!-- Reviewable:end -->
