### PR TITLE
Fix CNOT error model to include 15 error terms

### DIFF
--- a/quisp/backends/GraphState/test.h
+++ b/quisp/backends/GraphState/test.h
@@ -120,16 +120,24 @@ class Qubit : public GraphStateQubit {
 
     double cnot_gate_error_rate = 0;
     double cnot_gate_ix_error_ratio = 0;
+    double cnot_gate_iy_error_ratio = 0;
+    double cnot_gate_iz_error_ratio = 0;
     double cnot_gate_xi_error_ratio = 0;
     double cnot_gate_xx_error_ratio = 0;
-    double cnot_gate_iz_error_ratio = 0;
-    double cnot_gate_zi_error_ratio = 0;
-    double cnot_gate_zz_error_ratio = 0;
-    double cnot_gate_iy_error_ratio = 0;
+    double cnot_gate_xy_error_ratio = 0;
+    double cnot_gate_xz_error_ratio = 0;
     double cnot_gate_yi_error_ratio = 0;
+    double cnot_gate_yx_error_ratio = 0;
     double cnot_gate_yy_error_ratio = 0;
-    this->gate_err_cnot.setParams(cnot_gate_error_rate, cnot_gate_ix_error_ratio, cnot_gate_xi_error_ratio, cnot_gate_xx_error_ratio, cnot_gate_iz_error_ratio,
-                                  cnot_gate_zi_error_ratio, cnot_gate_zz_error_ratio, cnot_gate_iy_error_ratio, cnot_gate_yi_error_ratio, cnot_gate_yy_error_ratio);
+    double cnot_gate_yz_error_ratio = 0;
+    double cnot_gate_zi_error_ratio = 0;
+    double cnot_gate_zx_error_ratio = 0;
+    double cnot_gate_zy_error_ratio = 0;
+    double cnot_gate_zz_error_ratio = 0;
+    this->gate_err_cnot.setParams(cnot_gate_error_rate, cnot_gate_ix_error_ratio, cnot_gate_iy_error_ratio, cnot_gate_iz_error_ratio, cnot_gate_xi_error_ratio,
+                                  cnot_gate_xx_error_ratio, cnot_gate_xy_error_ratio, cnot_gate_xz_error_ratio, cnot_gate_yi_error_ratio, cnot_gate_yx_error_ratio,
+                                  cnot_gate_yy_error_ratio, cnot_gate_yz_error_ratio, cnot_gate_zi_error_ratio, cnot_gate_zx_error_ratio, cnot_gate_zy_error_ratio,
+                                  cnot_gate_zz_error_ratio);
 
     double x_measurement_error_rate = 0;
     double y_measurement_error_rate = 0;

--- a/quisp/backends/GraphState/types.h
+++ b/quisp/backends/GraphState/types.h
@@ -52,45 +52,64 @@ struct SingleGateErrorModel {
 
 struct TwoQubitGateErrorModel {
   double pauli_error_rate;  // Overall error rate
-  double iz_error_rate;
-  double zi_error_rate;
-  double zz_error_rate;
-  double iy_error_rate;
-  double yi_error_rate;
-  double yy_error_rate;
   double ix_error_rate;
+  double iy_error_rate;
+  double iz_error_rate;
   double xi_error_rate;
   double xx_error_rate;
+  double xy_error_rate;
+  double xz_error_rate;
+  double yi_error_rate;
+  double yx_error_rate;
+  double yy_error_rate;
+  double yz_error_rate;
+  double zi_error_rate;
+  double zx_error_rate;
+  double zy_error_rate;
+  double zz_error_rate;
 
-  void setParams(double error_rate, double ix_ratio, double xi_ratio, double xx_ratio, double iz_ratio, double zi_ratio, double zz_ratio, double iy_ratio, double yi_ratio,
-                 double yy_ratio) {
+  void setParams(double error_rate,
+
+                 double ix_ratio, double iy_ratio, double iz_ratio, double xi_ratio, double xx_ratio, double xy_ratio, double xz_ratio, double yi_ratio, double yx_ratio,
+                 double yy_ratio, double yz_ratio, double zi_ratio, double zx_ratio, double zy_ratio, double zz_ratio) {
     pauli_error_rate = error_rate;
-    double ratio_sum = ix_ratio + xi_ratio + xx_ratio + iz_ratio + zi_ratio + zz_ratio + iy_ratio + yi_ratio + yy_ratio;
+    double ratio_sum =
+        ix_ratio + iy_ratio + iz_ratio + xi_ratio + xx_ratio + xy_ratio + xz_ratio + yi_ratio + yx_ratio + yy_ratio + yz_ratio + zi_ratio + zx_ratio + zy_ratio + zz_ratio;
 
     if (ratio_sum == 0) {
       ix_ratio = 1.;
+      iy_ratio = 1.;
+      iz_ratio = 1.;
       xi_ratio = 1.;
       xx_ratio = 1.;
-      iz_ratio = 1.;
-      zi_ratio = 1.;
-      zz_ratio = 1.;
-      iy_ratio = 1.;
+      xy_ratio = 1.;
+      xz_ratio = 1.;
       yi_ratio = 1.;
+      yx_ratio = 1.;
       yy_ratio = 1.;
-      ratio_sum = 9.;
+      yz_ratio = 1.;
+      zi_ratio = 1.;
+      zx_ratio = 1.;
+      zy_ratio = 1.;
+      zz_ratio = 1.;
+      ratio_sum = 15.;
     }
 
     ix_error_rate = pauli_error_rate * (ix_ratio / ratio_sum);
+    iy_error_rate = pauli_error_rate * (iy_ratio / ratio_sum);
+    iz_error_rate = pauli_error_rate * (iz_ratio / ratio_sum);
     xi_error_rate = pauli_error_rate * (xi_ratio / ratio_sum);
     xx_error_rate = pauli_error_rate * (xx_ratio / ratio_sum);
-
-    iz_error_rate = pauli_error_rate * (iz_ratio / ratio_sum);
-    zi_error_rate = pauli_error_rate * (zi_ratio / ratio_sum);
-    zz_error_rate = pauli_error_rate * (zz_ratio / ratio_sum);
-
-    iy_error_rate = pauli_error_rate * (iy_ratio / ratio_sum);
+    xy_error_rate = pauli_error_rate * (xy_ratio / ratio_sum);
+    xz_error_rate = pauli_error_rate * (xz_ratio / ratio_sum);
     yi_error_rate = pauli_error_rate * (yi_ratio / ratio_sum);
+    yx_error_rate = pauli_error_rate * (yx_ratio / ratio_sum);
     yy_error_rate = pauli_error_rate * (yy_ratio / ratio_sum);
+    yz_error_rate = pauli_error_rate * (yz_ratio / ratio_sum);
+    zi_error_rate = pauli_error_rate * (zi_ratio / ratio_sum);
+    zx_error_rate = pauli_error_rate * (zx_ratio / ratio_sum);
+    zy_error_rate = pauli_error_rate * (zy_ratio / ratio_sum);
+    zz_error_rate = pauli_error_rate * (zz_ratio / ratio_sum);
   }
 };
 

--- a/quisp/backends/QubitConfiguration.h
+++ b/quisp/backends/QubitConfiguration.h
@@ -37,15 +37,22 @@ class StationaryQubitConfiguration : public abstract::IConfiguration {
   double h_gate_z_err_ratio = 0;
   double h_gate_err_rate = 0;
 
-  double cnot_gate_iz_err_ratio = 0;
-  double cnot_gate_zi_err_ratio = 0;
-  double cnot_gate_zz_err_ratio = 0;
   double cnot_gate_ix_err_ratio = 0;
+  double cnot_gate_iy_err_ratio = 0;
+  double cnot_gate_iz_err_ratio = 0;
   double cnot_gate_xi_err_ratio = 0;
   double cnot_gate_xx_err_ratio = 0;
-  double cnot_gate_iy_err_ratio = 0;
+  double cnot_gate_xy_err_ratio = 0;
+  double cnot_gate_xz_err_ratio = 0;
   double cnot_gate_yi_err_ratio = 0;
+  double cnot_gate_yx_err_ratio = 0;
   double cnot_gate_yy_err_ratio = 0;
+  double cnot_gate_yz_err_ratio = 0;
+  double cnot_gate_zi_err_ratio = 0;
+  double cnot_gate_zx_err_ratio = 0;
+  double cnot_gate_zy_err_ratio = 0;
+  double cnot_gate_zz_err_ratio = 0;
+
   double cnot_gate_err_rate = 0;
 
  protected:

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -85,14 +85,14 @@ std::unique_ptr<IConfiguration> StationaryQubit::prepareBackendQubitConfiguratio
     et_conf->z_gate_z_err_ratio = par("z_gate_z_error_ratio").doubleValue();
 
     et_conf->cnot_gate_err_rate = par("cnot_gate_error_rate").doubleValue();
-    et_conf->cnot_gate_iz_err_ratio = par("cnot_gate_ix_error_ratio").doubleValue();
-    et_conf->cnot_gate_ix_err_ratio = par("cnot_gate_iy_error_ratio").doubleValue();
-    et_conf->cnot_gate_iy_err_ratio = par("cnot_gate_iz_error_ratio").doubleValue();
-    et_conf->cnot_gate_zx_err_ratio = par("cnot_gate_xi_error_ratio").doubleValue();
-    et_conf->cnot_gate_zx_err_ratio = par("cnot_gate_xx_error_ratio").doubleValue();
-    et_conf->cnot_gate_zy_err_ratio = par("cnot_gate_xy_error_ratio").doubleValue();
-    et_conf->cnot_gate_zz_err_ratio = par("cnot_gate_xz_error_ratio").doubleValue();
-    et_conf->cnot_gate_yx_err_ratio = par("cnot_gate_yi_error_ratio").doubleValue();
+    et_conf->cnot_gate_ix_err_ratio = par("cnot_gate_ix_error_ratio").doubleValue();
+    et_conf->cnot_gate_iy_err_ratio = par("cnot_gate_iy_error_ratio").doubleValue();
+    et_conf->cnot_gate_iz_err_ratio = par("cnot_gate_iz_error_ratio").doubleValue();
+    et_conf->cnot_gate_xi_err_ratio = par("cnot_gate_xi_error_ratio").doubleValue();
+    et_conf->cnot_gate_xx_err_ratio = par("cnot_gate_xx_error_ratio").doubleValue();
+    et_conf->cnot_gate_xy_err_ratio = par("cnot_gate_xy_error_ratio").doubleValue();
+    et_conf->cnot_gate_xz_err_ratio = par("cnot_gate_xz_error_ratio").doubleValue();
+    et_conf->cnot_gate_yi_err_ratio = par("cnot_gate_yi_error_ratio").doubleValue();
     et_conf->cnot_gate_yx_err_ratio = par("cnot_gate_yx_error_ratio").doubleValue();
     et_conf->cnot_gate_yy_err_ratio = par("cnot_gate_yy_error_ratio").doubleValue();
     et_conf->cnot_gate_yz_err_ratio = par("cnot_gate_yz_error_ratio").doubleValue();

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.cc
@@ -85,15 +85,21 @@ std::unique_ptr<IConfiguration> StationaryQubit::prepareBackendQubitConfiguratio
     et_conf->z_gate_z_err_ratio = par("z_gate_z_error_ratio").doubleValue();
 
     et_conf->cnot_gate_err_rate = par("cnot_gate_error_rate").doubleValue();
-    et_conf->cnot_gate_iz_err_ratio = par("cnot_gate_iz_error_ratio").doubleValue();
-    et_conf->cnot_gate_zi_err_ratio = par("cnot_gate_zi_error_ratio").doubleValue();
-    et_conf->cnot_gate_zz_err_ratio = par("cnot_gate_zz_error_ratio").doubleValue();
-    et_conf->cnot_gate_ix_err_ratio = par("cnot_gate_ix_error_ratio").doubleValue();
-    et_conf->cnot_gate_xi_err_ratio = par("cnot_gate_xi_error_ratio").doubleValue();
-    et_conf->cnot_gate_xx_err_ratio = par("cnot_gate_xx_error_ratio").doubleValue();
-    et_conf->cnot_gate_iy_err_ratio = par("cnot_gate_iy_error_ratio").doubleValue();
-    et_conf->cnot_gate_yi_err_ratio = par("cnot_gate_yi_error_ratio").doubleValue();
+    et_conf->cnot_gate_iz_err_ratio = par("cnot_gate_ix_error_ratio").doubleValue();
+    et_conf->cnot_gate_ix_err_ratio = par("cnot_gate_iy_error_ratio").doubleValue();
+    et_conf->cnot_gate_iy_err_ratio = par("cnot_gate_iz_error_ratio").doubleValue();
+    et_conf->cnot_gate_zx_err_ratio = par("cnot_gate_xi_error_ratio").doubleValue();
+    et_conf->cnot_gate_zx_err_ratio = par("cnot_gate_xx_error_ratio").doubleValue();
+    et_conf->cnot_gate_zy_err_ratio = par("cnot_gate_xy_error_ratio").doubleValue();
+    et_conf->cnot_gate_zz_err_ratio = par("cnot_gate_xz_error_ratio").doubleValue();
+    et_conf->cnot_gate_yx_err_ratio = par("cnot_gate_yi_error_ratio").doubleValue();
+    et_conf->cnot_gate_yx_err_ratio = par("cnot_gate_yx_error_ratio").doubleValue();
     et_conf->cnot_gate_yy_err_ratio = par("cnot_gate_yy_error_ratio").doubleValue();
+    et_conf->cnot_gate_yz_err_ratio = par("cnot_gate_yz_error_ratio").doubleValue();
+    et_conf->cnot_gate_zi_err_ratio = par("cnot_gate_zi_error_ratio").doubleValue();
+    et_conf->cnot_gate_zx_err_ratio = par("cnot_gate_zx_error_ratio").doubleValue();
+    et_conf->cnot_gate_zy_err_ratio = par("cnot_gate_zy_error_ratio").doubleValue();
+    et_conf->cnot_gate_zz_err_ratio = par("cnot_gate_zz_error_ratio").doubleValue();
 
     et_conf->memory_x_err_rate = par("memory_x_error_rate").doubleValue();
     et_conf->memory_y_err_rate = par("memory_y_error_rate").doubleValue();

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit.ned
@@ -55,15 +55,21 @@ simple StationaryQubit
         double z_gate_z_error_ratio = default(1);
 
         double cnot_gate_error_rate = default(0);
-        double cnot_gate_iz_error_ratio = default(1);
-        double cnot_gate_zi_error_ratio = default(1);
-        double cnot_gate_zz_error_ratio = default(1);
         double cnot_gate_ix_error_ratio = default(1);
+        double cnot_gate_iy_error_ratio = default(1);
+        double cnot_gate_iz_error_ratio = default(1);
         double cnot_gate_xi_error_ratio = default(1);
         double cnot_gate_xx_error_ratio = default(1);
-        double cnot_gate_iy_error_ratio = default(1);
+        double cnot_gate_xy_error_ratio = default(1);
+        double cnot_gate_xz_error_ratio = default(1);
         double cnot_gate_yi_error_ratio = default(1);
+        double cnot_gate_yx_error_ratio = default(1);
         double cnot_gate_yy_error_ratio = default(1);
+        double cnot_gate_yz_error_ratio = default(1);
+        double cnot_gate_zi_error_ratio = default(1);
+        double cnot_gate_zx_error_ratio = default(1);
+        double cnot_gate_zy_error_ratio = default(1);
+        double cnot_gate_zz_error_ratio = default(1);
 
         double x_measurement_error_rate = default(0);
         double y_measurement_error_rate = default(0);

--- a/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
+++ b/quisp/modules/QNIC/StationaryQubit/StationaryQubit_test.cc
@@ -79,14 +79,20 @@ class StatQubitTarget : public StationaryQubit {
 
     setParDouble(this, "cnot_gate_error_rate", 1. / 2000);
     setParDouble(this, "cnot_gate_ix_error_ratio", 1);
+    setParDouble(this, "cnot_gate_iy_error_ratio", 1);
+    setParDouble(this, "cnot_gate_iz_error_ratio", 1);
     setParDouble(this, "cnot_gate_xi_error_ratio", 1);
     setParDouble(this, "cnot_gate_xx_error_ratio", 1);
-    setParDouble(this, "cnot_gate_iz_error_ratio", 1);
-    setParDouble(this, "cnot_gate_zi_error_ratio", 1);
-    setParDouble(this, "cnot_gate_zz_error_ratio", 1);
-    setParDouble(this, "cnot_gate_iy_error_ratio", 1);
+    setParDouble(this, "cnot_gate_xy_error_ratio", 1);
+    setParDouble(this, "cnot_gate_xz_error_ratio", 1);
     setParDouble(this, "cnot_gate_yi_error_ratio", 1);
+    setParDouble(this, "cnot_gate_yx_error_ratio", 1);
     setParDouble(this, "cnot_gate_yy_error_ratio", 1);
+    setParDouble(this, "cnot_gate_yz_error_ratio", 1);
+    setParDouble(this, "cnot_gate_zi_error_ratio", 1);
+    setParDouble(this, "cnot_gate_zx_error_ratio", 1);
+    setParDouble(this, "cnot_gate_zy_error_ratio", 1);
+    setParDouble(this, "cnot_gate_zz_error_ratio", 1);
 
     setParDouble(this, "x_measurement_error_rate", 1. / 2000);
     setParDouble(this, "y_measurement_error_rate", 1. / 2000);
@@ -139,14 +145,20 @@ TEST_F(StatQubitTest, StationaryQubitConfigurationOverwrite) {
   auto *config = new StationaryQubitConfiguration();
   setParDouble(qubit, "cnot_gate_error_rate", 0.01);
   setParDouble(qubit, "cnot_gate_ix_error_ratio", 0.02);
-  setParDouble(qubit, "cnot_gate_xi_error_ratio", 0.03);
-  setParDouble(qubit, "cnot_gate_xx_error_ratio", 0.04);
-  setParDouble(qubit, "cnot_gate_iz_error_ratio", 0.05);
-  setParDouble(qubit, "cnot_gate_zi_error_ratio", 0.06);
-  setParDouble(qubit, "cnot_gate_zz_error_ratio", 0.07);
-  setParDouble(qubit, "cnot_gate_iy_error_ratio", 0.08);
+  setParDouble(qubit, "cnot_gate_iy_error_ratio", 0.03);
+  setParDouble(qubit, "cnot_gate_iz_error_ratio", 0.04);
+  setParDouble(qubit, "cnot_gate_xi_error_ratio", 0.05);
+  setParDouble(qubit, "cnot_gate_xx_error_ratio", 0.06);
+  setParDouble(qubit, "cnot_gate_xy_error_ratio", 0.07);
+  setParDouble(qubit, "cnot_gate_xz_error_ratio", 0.08);
   setParDouble(qubit, "cnot_gate_yi_error_ratio", 0.09);
-  setParDouble(qubit, "cnot_gate_yy_error_ratio", 0.10);
+  setParDouble(qubit, "cnot_gate_yx_error_ratio", 0.10);
+  setParDouble(qubit, "cnot_gate_yy_error_ratio", 0.11);
+  setParDouble(qubit, "cnot_gate_yz_error_ratio", 0.12);
+  setParDouble(qubit, "cnot_gate_zi_error_ratio", 0.13);
+  setParDouble(qubit, "cnot_gate_zx_error_ratio", 0.14);
+  setParDouble(qubit, "cnot_gate_zy_error_ratio", 0.15);
+  setParDouble(qubit, "cnot_gate_zz_error_ratio", 0.16);
 
   setParDouble(qubit, "h_gate_error_rate", 0.11);
   setParDouble(qubit, "h_gate_x_error_ratio", 0.12);

--- a/quisp/utils/UtilFunctions.h
+++ b/quisp/utils/UtilFunctions.h
@@ -33,5 +33,6 @@ Label samplingWithWeights(std::map<Label, double> weights, double rand) {
       return l;
     }
   }
+  return (--weights.end())->first;
 }
 }  // namespace quisp::util_functions


### PR DESCRIPTION
The current CNOT error model was incomplete. It can only cover 9 Pauli errors instead of 15, which covers all Pauli channels for 2 qubits.

This closes #563.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/565)
<!-- Reviewable:end -->
