### PR TITLE
Fix build compatibility for OMNeT++ 6.1, 6.2, and 6.3+

### DIFF
--- a/quisp/modules/Logger/JsonLogger.cc
+++ b/quisp/modules/Logger/JsonLogger.cc
@@ -24,14 +24,14 @@ void JsonLogger::setQNodeAddress(int addr) { qnode_address = addr; }
 
 void JsonLogger::logPacket(const std::string& event_type, omnetpp::cMessage const* const msg) {
   auto current_time = omnetpp::simTime();
-  _logger->info("\"simtime\": {}, \"event_type\": \"{}\", \"address\": \"{}\", {}", current_time, event_type, qnode_address, format(msg));
+  _logger->info("\"simtime\": {}, \"event_type\": \"{}\", \"address\": \"{}\", {}", current_time.str(), event_type, qnode_address, format(msg));
 }
 
 void JsonLogger::logQubitState(quisp::modules::QNIC_type qnic_type, int qnic_index, int qubit_index, bool is_busy, bool is_allocated) {
   auto current_time = omnetpp::simTime();
   _logger->info(
       "\"simtime\": {}, \"event_type\": \"QubitStateChange\", \"address\": \"{}\", \"qnic_type\": {}, \"qnic_index\": {}, \"qubit_index\": {}, \"busy\": {}, \"allocated\": {}",
-      current_time, qnode_address, qnic_type, qnic_index, qubit_index, is_busy, is_allocated);
+      current_time.str(), qnode_address, qnic_type, qnic_index, qubit_index, is_busy, is_allocated);
 }
 
 std::string JsonLogger::format(omnetpp::cMessage const* const msg) {
@@ -78,7 +78,7 @@ std::string JsonLogger::format(omnetpp::cMessage const* const msg) {
 void JsonLogger::logBellPairInfo(const std::string& event_type, int partner_addr, quisp::modules::QNIC_type qnic_type, int qnic_index, int qubit_index) {
   auto current_time = omnetpp::simTime();
   _logger->info("\"simtime\": {}, \"event_type\": \"BellPair{}\", \"address\": \"{}\", \"partner_addr\": {}, \"qnic_type\": {}, \"qnic_index\": {}, \"qubit_index\": {}",
-                current_time, event_type, qnode_address, partner_addr, qnic_type, qnic_index, qubit_index);
+                current_time.str(), event_type, qnode_address, partner_addr, qnic_type, qnic_index, qubit_index);
 }
 
 }  // namespace quisp::modules::Logger

--- a/quisp/test_utils/ModuleType.h
+++ b/quisp/test_utils/ModuleType.h
@@ -40,6 +40,10 @@ class TestModuleType : public cModuleType {
   std::string getCxxNamespaceForType(const char *type) const override { return "mock cxx namespace"; };
 #endif
 
+#if OMNETPP_VERSION >= 0x602
+  std::string getDocumentation() const override { return ""; };
+#endif
+
   const char *getSourceFileName() const override { return "no source"; };
   bool isInnerType() const override { return false; };
 

--- a/quisp/test_utils/StaticEnv.h
+++ b/quisp/test_utils/StaticEnv.h
@@ -87,9 +87,17 @@ class StaticEnv : public omnetpp::cEnvir {
   cRNG *getRNG(int k) override;
 
   // output vectors
+#if OMNETPP_VERSION >= 0x601
+  void *registerOutputVector(const char *modulename, const char *vectorname, opp_string_map *attributes = nullptr) override { return nullptr; }
+#else
   void *registerOutputVector(const char *modulename, const char *vectorname) override { return nullptr; }
+#endif
   void deregisterOutputVector(void *vechandle) override {}
+#if OMNETPP_VERSION >= 0x601
+  void setVectorAttribute(void *vechandle, const char *name, const char *value) {}
+#else
   void setVectorAttribute(void *vechandle, const char *name, const char *value) override {}
+#endif
   bool recordInOutputVector(void *vechandle, simtime_t t, double value) override { return false; }
 
   // output scalars
@@ -134,6 +142,10 @@ class StaticEnv : public omnetpp::cEnvir {
   double getAnimationTime() const override { return 0; }
   double getAnimationSpeed() const override { return 0; }
   double getRemainingAnimationHoldTime() const override { return 0; }
+
+#if OMNETPP_VERSION >= 0x601
+  std::ostream& getOutputStream() override { return std::cout; }
+#endif
 
   // lifecycle listeners
   void addLifecycleListener(cISimulationLifecycleListener *listener) override {}


### PR DESCRIPTION
This PR fixes compilation errors caused by API changes in recent OMNeT++ versions.

I have verified that the project builds and runs successfully on **OMNeT++ 6.1.0, 6.2.0, and 6.3.0** with `quisp_tutorial`.

### Key Changes:
1.  **`quisp/modules/Logger/JsonLogger.cc`**: 
    * Explicitly called `.str()` on `simTime()` to fix formatting issues with strict type checking in newer compilers/OMNeT++ versions. This change is backward compatible.
    
2.  **`quisp/test_utils/ModuleType.h`**: 
    * Implemented `getDocumentation()` override. This method became a required pure virtual function starting from **OMNeT++ 6.2**.
    * Guarded with `#if OMNETPP_VERSION >= 0x602`.

3.  **`quisp/test_utils/StaticEnv.h`**: 
    * Updated `registerOutputVector` signature (now requires 3 arguments in v6.1+).
    * Handled `setVectorAttribute` (removed `override` for v6.1+ as the virtual method signature changed/removed).
    * Implemented `getOutputStream` (required pure virtual method in v6.x).
    * All changes are guarded with `#if OMNETPP_VERSION >= 0x601`.

### Test Environment:
* **OS:** Linux Ubuntu 24.04 LTS
* **Compiler:** Clang 18.1.3 (Build verified), GCC 13.3.0
* **OMNeT++ Versions Verified:** 6.1.0, 6.2.0, 6.3.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/577)
<!-- Reviewable:end -->
