### PR TITLE
Fix Bell pair link generation rate

### DIFF
--- a/quisp/modules/PhysicalConnection/BSA/BSAController.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BSAController.cc
@@ -41,7 +41,7 @@ void BSAController::initialize() {
   time_out_message = new BSMNotificationTimeout("bsm_notification_timeout");
   if (is_active) {
     long long photon_per_second = getParentModule()->getSubmodule("bsa")->par("photon_detection_per_second").intValue();
-    long long time_between_photon_in_atto = ((long long) 1000000000000000000) / photon_per_second;
+    long long time_between_photon_in_atto = ((long long)1000000000000000000) / photon_per_second;
     time_interval_between_photons = SimTime(time_between_photon_in_atto, SIMTIME_AS);
     simtime_t first_notification_timer = SimTime(par("initial_notification_timing_buffer").doubleValue());
     right_qnic = getExternalQNICInfoFromPort(1);

--- a/quisp/modules/PhysicalConnection/BSA/BSAController.cc
+++ b/quisp/modules/PhysicalConnection/BSA/BSAController.cc
@@ -40,7 +40,9 @@ void BSAController::initialize() {
   time_out_count = 0;
   time_out_message = new BSMNotificationTimeout("bsm_notification_timeout");
   if (is_active) {
-    time_interval_between_photons = SimTime(1, SIMTIME_S) / SimTime(getParentModule()->getSubmodule("bsa")->par("photon_detection_per_second").intValue(), SIMTIME_S);
+    long long photon_per_second = getParentModule()->getSubmodule("bsa")->par("photon_detection_per_second").intValue();
+    long long time_between_photon_in_atto = ((long long) 1000000000000000000) / photon_per_second;
+    time_interval_between_photons = SimTime(time_between_photon_in_atto, SIMTIME_AS);
     simtime_t first_notification_timer = SimTime(par("initial_notification_timing_buffer").doubleValue());
     right_qnic = getExternalQNICInfoFromPort(1);
     offset_time_for_first_photon = calculateOffsetTimeFromDistance();


### PR DESCRIPTION
Previously, the link generation rate is set by `photon_detection_per_second`  parameter at BSA. 
It was not converted properly to the `time_interval_between_photons` when scheduling photon arrival specified by BSA_Controller due to the division of integers. 

I fixed this by converting the base unit to attosecond. While it could still result in imprecise actual rate, as long as the division into attosecond (using long long) is close enough, it should not be a problem. 

This fixes #562.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/578)
<!-- Reviewable:end -->
