### PR TITLE
fix: remove unreachable duplicate if-else branch in RuleEngine

### DIFF
--- a/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
+++ b/quisp/modules/QRSA/RuleEngine/RuleEngine.cc
@@ -167,18 +167,6 @@ void RuleEngine::handleMessage(cMessage *msg) {
     RuleSet ruleset(0, 0);
     ruleset.deserialize_json(serialized_ruleset);
     runtimes.acceptRuleSet(ruleset.construct());
-  } else if (auto *pkt = dynamic_cast<InternalRuleSetForwarding *>(msg)) {
-    // add actual process
-    auto serialized_ruleset = pkt->getRuleSet();
-    RuleSet ruleset(0, 0);
-    ruleset.deserialize_json(serialized_ruleset);
-    runtimes.acceptRuleSet(ruleset.construct());
-  } else if (auto *pkt = dynamic_cast<InternalRuleSetForwarding_Application *>(msg)) {
-    if (pkt->getApplication_type() != 0) error("This application is not recognized yet");
-    auto serialized_ruleset = pkt->getRuleSet();
-    RuleSet ruleset(0, 0);
-    ruleset.deserialize_json(serialized_ruleset);
-    runtimes.acceptRuleSet(ruleset.construct());
   } else if (auto *pkt = dynamic_cast<StopEmitting *>(msg)) {
     handleStopEmitting(pkt);
   }


### PR DESCRIPTION
The `handleMessage` if-else chain in RuleEngine had a duplicate pair of `InternalRuleSetForwarding` and `InternalRuleSetForwarding_Application` branches.

No behavior change. Verified: `make exe`, `make run-unit-test`, `make run-sim-test` all pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfc-aqua/quisp/580)
<!-- Reviewable:end -->
